### PR TITLE
Fix migration for Oracle

### DIFF
--- a/db/migrate/20241014161738_add_is_hidden_to_price_groups.rb
+++ b/db/migrate/20241014161738_add_is_hidden_to_price_groups.rb
@@ -4,7 +4,11 @@ class AddIsHiddenToPriceGroups < ActiveRecord::Migration[7.0]
   def up
     add_column :price_groups, :is_hidden, :boolean, default: false
 
-    execute("UPDATE price_groups SET is_hidden = false")
+    if Nucore::Database.oracle?
+      execute("UPDATE price_groups SET price_groups.is_hidden = 0")
+    else
+      execute("UPDATE price_groups SET price_groups.is_hidden = false")
+    end
 
     change_column_null :price_groups, :is_hidden, false
   end


### PR DESCRIPTION
# Release Notes
Oracle prefers 0 and ` for booleans: https://stackoverflow.com/questions/19435160/how-to-update-a-boolean-field-in-oracle-table
