### PR TITLE
[#162393] Avoid creation of service and item price policies with usage_rate

### DIFF
--- a/app/services/price_policy_builder.rb
+++ b/app/services/price_policy_builder.rb
@@ -125,15 +125,13 @@ class PricePolicyBuilder
   end
 
   def self.create_price_policy_for(product, price_group)
-    usage_rate = ["Service", "Item"].include?(product.type) ? nil : 0
-
     PricePolicy.create(
       type: "#{product.type}PricePolicy",
-      product: product,
+      product:,
       start_date: 1.month.ago,
       expire_date: 75.years.from_now,
-      price_group: price_group,
-      usage_rate: usage_rate,
+      price_group:,
+      usage_rate: usage_rate_for(product),
       minimum_cost: 0,
       cancellation_cost: 0,
       usage_subsidy: 0,
@@ -143,6 +141,10 @@ class PricePolicyBuilder
       charge_for: "reservation",
       note: "Price rule automatically created because of billing mode"
     )
+  end
+
+  def self.usage_rate_for(product)
+    ["Service", "Item"].include?(product.type) ? nil : 0
   end
 
 end

--- a/app/services/price_policy_builder.rb
+++ b/app/services/price_policy_builder.rb
@@ -26,42 +26,12 @@ class PricePolicyBuilder
   def self.create_skip_review_for(product, price_groups = nil)
     groups = price_groups || PriceGroup.globals
     groups.each do |price_group|
-      PricePolicy.create(
-        type: "#{product.type}PricePolicy",
-        product:,
-        start_date: 1.month.ago,
-        expire_date: 75.years.from_now,
-        price_group:,
-        usage_rate: 0,
-        minimum_cost: 0,
-        cancellation_cost: 0,
-        usage_subsidy: 0,
-        unit_cost: 0,
-        unit_subsidy: 0,
-        can_purchase: true,
-        charge_for: "reservation",
-        note: "Price rule automatically created because of billing mode"
-      )
+      create_price_policy_for(product, price_group)
     end
   end
-
+  
   def self.create_nonbillable_for(product)
-    PricePolicy.create(
-      type: "#{product.type}PricePolicy",
-      product:,
-      start_date: 1.month.ago,
-      expire_date: 75.years.from_now,
-      price_group: PriceGroup.nonbillable,
-      usage_rate: 0,
-      minimum_cost: 0,
-      cancellation_cost: 0,
-      usage_subsidy: 0,
-      unit_cost: 0,
-      unit_subsidy: 0,
-      can_purchase: true,
-      charge_for: "reservation",
-      note: "Price rule automatically created because of billing mode"
-    )
+    create_price_policy_for(product, PriceGroup.nonbillable)
   end
 
   def initialize(product, start_date)
@@ -152,6 +122,27 @@ class PricePolicyBuilder
   def price_policies_for_start_date
     return [] if start_date.blank?
     product.price_policies.for_date(start_date)
+  end
+
+  def self.create_price_policy_for(product, price_group)
+    usage_rate = ["Service", "Item"].include?(product.type) ? nil : 0
+
+    PricePolicy.create(
+      type: "#{product.type}PricePolicy",
+      product: product,
+      start_date: 1.month.ago,
+      expire_date: 75.years.from_now,
+      price_group: price_group,
+      usage_rate: usage_rate,
+      minimum_cost: 0,
+      cancellation_cost: 0,
+      usage_subsidy: 0,
+      unit_cost: 0,
+      unit_subsidy: 0,
+      can_purchase: true,
+      charge_for: "reservation",
+      note: "Price rule automatically created because of billing mode"
+    )
   end
 
 end

--- a/spec/services/price_policy_builder_spec.rb
+++ b/spec/services/price_policy_builder_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PricePolicyBuilder do
+  let(:price_group) { create(:price_group) }
+  let!(:facility) { create(:setup_facility) }
+
+  shared_examples "a correctly created PricePolicy" do
+    before do
+      subject
+    end
+
+    it "creates a PricePolicy with the correct attributes" do
+      price_policy = PricePolicy.last
+      expect(price_policy).to be_present
+      expect(price_policy.type).to eq("#{product.type}PricePolicy")
+      expect(price_policy.start_date).to be_within(1.day).of(1.month.ago)
+      expect(price_policy.expire_date).to be_within(1.day).of(75.years.from_now)
+      expect(price_policy.usage_rate).to eq(usage_rate)
+      expect(price_policy.minimum_cost).to eq(0)
+      expect(price_policy.cancellation_cost).to eq(0)
+      expect(price_policy.usage_subsidy).to eq(0)
+      expect(price_policy.unit_cost).to eq(0)
+      expect(price_policy.unit_subsidy).to eq(0)
+      expect(price_policy.can_purchase).to be(true)
+      expect(price_policy.note).to eq("Price rule automatically created because of billing mode")
+    end
+  end
+
+  describe ".create_skip_review_for" do
+    subject(:subject) { PricePolicyBuilder.create_skip_review_for(product, price_groups) }
+
+    context "when product is a Service or Item" do
+      let(:usage_rate) { nil }
+
+      %w[service item].each do |product_type|
+        context "when product is a #{product_type}" do
+          let(:product) { create(product_type.to_sym, facility: facility, billing_mode: "Skip Review") }
+          let!(:price_groups) { create_list(:price_group, 2) }
+
+          it_behaves_like "a correctly created PricePolicy"
+        end
+      end
+    end
+
+    context "when product is not a Service or Item" do
+      let(:product) { create(:instrument, facility: facility, billing_mode: "Skip Review") }
+      let!(:price_groups) { create_list(:price_group, 2) }
+      let(:usage_rate) { 0 }
+
+      it_behaves_like "a correctly created PricePolicy"
+    end
+  end
+
+  describe ".create_nonbillable_for" do
+    subject(:subject) { PricePolicyBuilder.create_nonbillable_for(product) }
+    let!(:price_groups) { [PriceGroup.nonbillable] }
+
+    context "when product is a Service or Item" do
+      let(:usage_rate) { nil }
+
+      %w[service item].each do |product_type|
+        context "when product is a #{product_type}" do
+          let(:product) { create(product_type.to_sym, facility: facility, billing_mode: "Nonbillable") }
+
+          it_behaves_like "a correctly created PricePolicy"
+        end
+      end
+    end
+
+    context "when product is not a Service or Item" do
+      let(:product) { create(:instrument, facility: facility, billing_mode: "Nonbillable") }
+      let(:usage_rate) { 0 }
+
+      it_behaves_like "a correctly created PricePolicy"
+    end
+  end
+end

--- a/spec/support/shared_examples/create_product_with_price_rule_shared_examples.rb
+++ b/spec/support/shared_examples/create_product_with_price_rule_shared_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples "creates a product with billing mode" do |product_type, billing_mode|
   let(:logged_in_user) { administrator }
 
@@ -8,12 +10,13 @@ RSpec.shared_examples "creates a product with billing mode" do |product_type, bi
 
     fill_in "Name", with: "My new Product", match: :first
     fill_in "URL Name", with: "new-service"
-    select "Required", from: "#{product_type}[user_notes_field_mode]"
-    select billing_mode, from: "#{product_type}[billing_mode]"
+    select "Required", from: "Users may submit a note when purchasing?"
+    select billing_mode, from: "Billing mode"
 
     click_button "Create"
-    click_on "Pricing"
+    expect(Product.last.name).to eq("My new Product")
 
+    click_on "Pricing"
     expect(page).to have_content "#{PriceGroup.nonbillable} (#{PriceGroup.nonbillable.type_string}) $0"
     expect(PricePolicy.last.product.name).to eq("My new Product")
     expect(PricePolicy.last.usage_rate).to eq(nil)

--- a/spec/support/shared_examples/create_service_with_price_rule_shared_examples.rb
+++ b/spec/support/shared_examples/create_service_with_price_rule_shared_examples.rb
@@ -1,0 +1,21 @@
+RSpec.shared_examples "creates a product with billing mode" do |product_type, billing_mode|
+  let(:logged_in_user) { administrator }
+
+  it "can create a #{product_type}, which automatically creates a price rule" do
+    visit facility_products_path(facility)
+    all("a", text: product_type.capitalize)[0].click
+    click_link "Add #{product_type.capitalize}"
+
+    fill_in "Name", with: "My new Product", match: :first
+    fill_in "URL Name", with: "new-service"
+    select "Required", from: "#{product_type}[user_notes_field_mode]"
+    select billing_mode, from: "#{product_type}[billing_mode]"
+
+    click_button "Create"
+    click_on "Pricing"
+
+    expect(page).to have_content "#{PriceGroup.nonbillable} (#{PriceGroup.nonbillable.type_string}) $0"
+    expect(PricePolicy.last.product.name).to eq("My new Product")
+    expect(PricePolicy.last.usage_rate).to eq(nil)
+  end
+end

--- a/spec/system/admin/creating_a_service_spec.rb
+++ b/spec/system/admin/creating_a_service_spec.rb
@@ -54,4 +54,12 @@ RSpec.describe "Creating a service" do
     expect(page).to have_content("Date Uploaded")
     expect(page).not_to have_content("No Downloadable Order Forms have been uploaded")
   end
+
+  context "when billing mode is Nonbillable" do
+    include_examples "creates a product with billing mode", "service", "Nonbillable"
+  end
+
+  context "when billing mode is Skip Review" do
+    include_examples "creates a product with billing mode", "service", "Skip Review"
+  end
 end

--- a/spec/system/admin/creating_an_item_spec.rb
+++ b/spec/system/admin/creating_an_item_spec.rb
@@ -34,43 +34,11 @@ RSpec.describe "Creating an item" do
     expect(page).to have_content("#{I18n.t('views.admin.products.product_fields.hints.cross_core_ordering_available')}\nNo")
   end
 
-  context "when billing mode is Skip Review" do
-    let(:logged_in_user) { administrator }
-
-    it "can create an item, which automatically creates a price rule" do
-      visit facility_products_path(facility)
-      click_link "Items"
-      click_link "Add Item"
-
-      fill_in "Name", with: "My New Item", match: :first
-      fill_in "URL Name", with: "new-item"
-      select "Required", from: "item[user_notes_field_mode]"
-      select "Skip Review", from: "item[billing_mode]"
-
-      click_button "Create"
-      click_on "Pricing"
-
-      expect(page).to have_content "#{PriceGroup.nonbillable} (#{PriceGroup.nonbillable.type_string}) $0"
-    end
+  context "when billing mode is Nonbillable" do
+    include_examples "creates a product with billing mode", "service", "Nonbillable"
   end
 
-  context "when billing mode is Nonbillable" do
-    let(:logged_in_user) { administrator }
-
-    it "can create an item, which automatically creates a price rule" do
-      visit facility_products_path(facility)
-      click_link "Items"
-      click_link "Add Item"
-
-      fill_in "Name", with: "My New Item", match: :first
-      fill_in "URL Name", with: "new-item"
-      select "Required", from: "item[user_notes_field_mode]"
-      select "Nonbillable", from: "item[billing_mode]"
-
-      click_button "Create"
-      click_on "Pricing"
-
-      expect(page).to have_content "#{PriceGroup.nonbillable} (#{PriceGroup.nonbillable.type_string}) $0"
-    end
+  context "when billing mode is Skip Review" do
+    include_examples "creates a product with billing mode", "service", "Skip Review"
   end
 end


### PR DESCRIPTION
# Release Notes

There's a service that automatically creates price_policies with a usage_rate value of 0. This is not totally real as some price_policies aren't meant to have usage_rate at all which may result in future bugs.

Change the code to reflect reality, add tests, and refactor a little to reuse some code.