### PR TITLE
[#162473][Daily Rate]: Find next available reservation time

### DIFF
--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -102,7 +102,7 @@ module DateHelper
   private
 
   def minute_options(step = nil)
-    step ||= 1
+    step ||= 5
     (0..59).step(step).map { |d| ["%02d" % d, d] }
   end
 

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -102,7 +102,7 @@ module DateHelper
   private
 
   def minute_options(step = nil)
-    step ||= 5
+    step ||= 1
     (0..59).step(step).map { |d| ["%02d" % d, d] }
   end
 

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -16,6 +16,7 @@ class Instrument < Product
   include EmailListAttribute
 
   RESERVE_INTERVALS = [1, 5, 10, 15, 30, 60].freeze
+  RESERVE_INTERVAL_DAILY = 1
 
   PRICING_MODES = [Pricing::SCHEDULE_RULE, Pricing::DURATION].tap do |pricing_modes|
     if SettingsHelper.feature_on?(:show_daily_rate_option)
@@ -152,7 +153,7 @@ class Instrument < Product
     if daily_booking?
       self.min_reserve_mins = nil
       self.max_reserve_mins = nil
-      self.reserve_interval = nil
+      self.reserve_interval = RESERVE_INTERVAL_DAILY
     else
       self.min_reserve_days = nil
       self.max_reserve_days = nil

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -3,9 +3,11 @@
 class Instrument < Product
 
   module Pricing
+
     SCHEDULE_RULE = "Schedule Rule"
     SCHEDULE_DAILY = "Schedule Rule (Daily Booking only)"
     DURATION = "Duration"
+
   end
 
   include Products::RelaySupport
@@ -14,6 +16,7 @@ class Instrument < Product
   include EmailListAttribute
 
   RESERVE_INTERVALS = [1, 5, 10, 15, 30, 60].freeze
+  RESERVE_INTERVAL_DAILY = 5
   PRICING_MODES = [Pricing::SCHEDULE_RULE, Pricing::DURATION].tap do |pricing_modes|
     if SettingsHelper.feature_on?(:show_daily_rate_option)
       pricing_modes.insert(1, Pricing::SCHEDULE_DAILY)
@@ -86,7 +89,7 @@ class Instrument < Product
   def create_default_price_group_products
     PriceGroup.globals.find_each do |price_group|
       price_group_products.create!(
-        price_group: price_group,
+        price_group:,
         reservation_window: PriceGroupProduct::DEFAULT_RESERVATION_WINDOW
       )
     end
@@ -135,7 +138,7 @@ class Instrument < Product
     return unless reserve_interval.to_i > 0 && field_value > 0
 
     if field_value % reserve_interval != 0
-      errors.add attribute, :not_interval, reserve_interval: reserve_interval
+      errors.add attribute, :not_interval, reserve_interval:
     end
   end
 
@@ -149,7 +152,7 @@ class Instrument < Product
     if daily_booking?
       self.min_reserve_mins = nil
       self.max_reserve_mins = nil
-      self.reserve_interval = nil
+      self.reserve_interval = RESERVE_INTERVAL_DAILY
     else
       self.min_reserve_days = nil
       self.max_reserve_days = nil

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -16,7 +16,7 @@ class Instrument < Product
   include EmailListAttribute
 
   RESERVE_INTERVALS = [1, 5, 10, 15, 30, 60].freeze
-  RESERVE_INTERVAL_DAILY = 5
+
   PRICING_MODES = [Pricing::SCHEDULE_RULE, Pricing::DURATION].tap do |pricing_modes|
     if SettingsHelper.feature_on?(:show_daily_rate_option)
       pricing_modes.insert(1, Pricing::SCHEDULE_DAILY)
@@ -152,7 +152,7 @@ class Instrument < Product
     if daily_booking?
       self.min_reserve_mins = nil
       self.max_reserve_mins = nil
-      self.reserve_interval = RESERVE_INTERVAL_DAILY
+      self.reserve_interval = nil
     else
       self.min_reserve_days = nil
       self.max_reserve_days = nil

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -197,6 +197,8 @@ class Reservation < ApplicationRecord
   end
 
   def round_reservation_times
+    return self unless product.reserve_interval.present?
+
     interval = product.reserve_interval.minutes # Round to the nearest reservation interval
     self.reserve_start_at = time_ceil(reserve_start_at, interval) if reserve_start_at
     self.reserve_end_at   = time_ceil(reserve_end_at, interval) if reserve_end_at

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -177,6 +177,10 @@ FactoryBot.define do
           )
       end
     end
+
+    trait :daily_booking do
+      pricing_mode { Instrument::Pricing::SCHEDULE_DAILY }
+    end
   end
 
   factory :instrument_requiring_approval, parent: :setup_instrument do

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -443,7 +443,7 @@ RSpec.describe Instrument do
     before(:each) do
       # create instrument, min reserve time is 60 minutes, max is 60 minutes
       @instrument = create(:instrument,
-                           facility: facility,
+                           facility:,
                            min_reserve_mins: 60,
                            reserve_interval: 60,
                            max_reserve_mins: 60)
@@ -521,8 +521,47 @@ RSpec.describe Instrument do
       assert @reservation1.valid?
       # find next reservation after 12 am tomorrow at 10 am tomorrow
       @next_reservation = @instrument.next_available_reservation(after: Time.zone.tomorrow.beginning_of_day)
-      assert_equal (Time.zone.now + 1.day).day, @next_reservation.reserve_start_at.day
+      assert_equal 1.day.from_now.day, @next_reservation.reserve_start_at.day
       assert_equal 10, @next_reservation.reserve_start_at.hour
+    end
+  end
+
+  context "next available reservation with daily booking" do
+    let!(:instrument) do
+      create(
+        :instrument,
+        facility:,
+        pricing_mode: Instrument::Pricing::SCHEDULE_DAILY,
+        min_reserve_days: 2
+      )
+    end
+    before do
+      instrument.schedule_rules.create(
+        attributes_for(
+          :schedule_rule,
+          start_hour: 0, start_min: 0,
+          end_hour: 23, end_min: 59
+        )
+      )
+    end
+
+    it "correctly find reservations for n * 24 hour blocks" do
+      after = 1.minute.from_now
+      duration =  instrument.min_reserve_days.days
+
+      reservation = instrument.next_available_reservation(
+        after:, duration:
+      )
+
+      expect(reservation).to be_present
+      expect(reservation.save).to be true
+
+      second_reservation = instrument.next_available_reservation(
+        after:, duration:
+      )
+
+      expect(second_reservation).to be_present
+      expect(second_reservation.reserve_start_at).to_not be_before(reservation.reserve_end_at)
     end
   end
 
@@ -530,7 +569,7 @@ RSpec.describe Instrument do
     before(:each) do
       # create instrument, min reserve time is 60 minutes, max is 60 minutes
       @instrument = FactoryBot.create(:instrument,
-                                      facility: facility,
+                                      facility:,
                                       min_reserve_mins: 60,
                                       max_reserve_mins: 60)
       assert @instrument.valid?
@@ -936,6 +975,37 @@ RSpec.describe Instrument do
         expect(instrument.quick_reservation_intervals).to eq [15, 30, 60]
         expect(instrument.quick_reservation_intervals.count).to eq 3
       end
+    end
+  end
+
+  describe "with daily booking pricing mode" do
+    subject(:instrument) do
+      build(
+        :instrument,
+        facility:,
+        pricing_mode: Instrument::Pricing::SCHEDULE_DAILY
+      )
+    end
+
+    it "sets the reserve_interval to default interval for daily booking" do
+      instrument.save!
+
+      expect(instrument.reserve_interval).to eq(Instrument::RESERVE_INTERVAL_DAILY)
+    end
+
+    it "unsets min_reserve_mins and max_reserve_mins" do
+      instrument.assign_attributes(
+        min_reserve_mins: 10,
+        max_reserve_mins: 10,
+        min_reserve_days: 1,
+        max_reserve_days: 20
+      )
+      instrument.save!
+
+      expect(instrument.min_reserve_mins).to be_nil
+      expect(instrument.max_reserve_mins).to be_nil
+      expect(instrument.min_reserve_days).to_not be_nil
+      expect(instrument.max_reserve_days).to_not be_nil
     end
   end
 end

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -979,10 +979,10 @@ RSpec.describe Instrument do
       )
     end
 
-    it "sets the reserve_interval to nil for daily booking" do
+    it "sets the reserve_interval to daily reserve interval" do
       instrument.save!
 
-      expect(instrument.reserve_interval).to eq(nil)
+      expect(instrument.reserve_interval).to eq(Instrument::RESERVE_INTERVAL_DAILY)
     end
 
     it "unsets min_reserve_mins and max_reserve_mins" do

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -529,9 +529,9 @@ RSpec.describe Instrument do
   context "next available reservation with daily booking" do
     let!(:instrument) do
       create(
-        :instrument,
+        :setup_instrument,
+        :daily_booking,
         facility:,
-        pricing_mode: Instrument::Pricing::SCHEDULE_DAILY,
         min_reserve_days: 2
       )
     end
@@ -981,9 +981,9 @@ RSpec.describe Instrument do
   describe "with daily booking pricing mode" do
     subject(:instrument) do
       build(
-        :instrument,
+        :setup_instrument,
+        :daily_booking,
         facility:,
-        pricing_mode: Instrument::Pricing::SCHEDULE_DAILY
       )
     end
 

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -531,21 +531,13 @@ RSpec.describe Instrument do
       create(
         :setup_instrument,
         :daily_booking,
+        :always_available,
         facility:,
         min_reserve_days: 2
       )
     end
-    before do
-      instrument.schedule_rules.create(
-        attributes_for(
-          :schedule_rule,
-          start_hour: 0, start_min: 0,
-          end_hour: 23, end_min: 59
-        )
-      )
-    end
 
-    it "correctly find reservations for n * 24 hour blocks" do
+    it "correctly finds reservations for n * 24 hour blocks" do
       after = 1.minute.from_now
       duration =  instrument.min_reserve_days.days
 
@@ -987,10 +979,10 @@ RSpec.describe Instrument do
       )
     end
 
-    it "sets the reserve_interval to default interval for daily booking" do
+    it "sets the reserve_interval to nil for daily booking" do
       instrument.save!
 
-      expect(instrument.reserve_interval).to eq(Instrument::RESERVE_INTERVAL_DAILY)
+      expect(instrument.reserve_interval).to eq(nil)
     end
 
     it "unsets min_reserve_mins and max_reserve_mins" do

--- a/spec/services/next_available_reservation_finder_spec.rb
+++ b/spec/services/next_available_reservation_finder_spec.rb
@@ -46,11 +46,11 @@ RSpec.describe NextAvailableReservationFinder do
       describe "reservation duration" do
         before { instrument.update(min_reserve_days: 4) }
 
-        it "has a correctly duration in minutes" do
+        it "has a correct duration in minutes" do
           expect(reservation.duration_mins.minutes).to eq instrument.min_reserve_days.days
         end
 
-        it "has a correctly duration in minutes" do
+        it "has a correct duration in days" do
           expect(reservation.duration_days).to eq instrument.min_reserve_days
         end
       end

--- a/spec/services/next_available_reservation_finder_spec.rb
+++ b/spec/services/next_available_reservation_finder_spec.rb
@@ -56,10 +56,7 @@ RSpec.describe NextAvailableReservationFinder do
       end
 
       it "returns a schedule as soon as possible" do
-        next_available_time = 1.minute.from_now.then do |time|
-          delta = time.min % instrument.reserve_interval
-          time - delta.minutes + instrument.reserve_interval.minutes
-        end
+        next_available_time = 1.minute.from_now
 
         expect(reservation.reserve_start_at).to eq next_available_time
       end

--- a/spec/services/next_available_reservation_finder_spec.rb
+++ b/spec/services/next_available_reservation_finder_spec.rb
@@ -1,12 +1,15 @@
-require "spec_helper"
+# frozen_string_literal: true
+
+require "rails_helper"
 
 RSpec.describe NextAvailableReservationFinder do
-  let(:instrument) { FactoryBot.build(:instrument, min_reserve_mins: 0) }
-  let(:user) { FactoryBot.build(:user) }
+  let(:user) { build(:user) }
+  subject(:reservation) { described_class.new(instrument).next_available_for(user, user) }
 
-  describe "#next_available_for" do
+  describe "time scheduled instrument" do
+    let(:instrument) { build(:instrument, min_reserve_mins: 0) }
+
     describe "without a next available reservation" do
-      subject(:reservation) { described_class.new(instrument).next_available_for(user, user) }
 
       before do
         expect(instrument).to receive(:next_available_reservation).and_return(nil)
@@ -22,6 +25,47 @@ RSpec.describe NextAvailableReservationFinder do
 
       it "is on the right product" do
         expect(reservation.product).to eq(instrument)
+      end
+    end
+  end
+
+  describe "daily booking instrument" do
+    let(:instrument) do
+      create(
+        :setup_instrument,
+        :always_available,
+        :daily_booking
+      )
+    end
+
+    describe "with an empty schedule" do
+      it "has a duration of 1 day when no minimum" do
+        expect(reservation.duration_mins.minutes).to eq 1.day
+      end
+
+      describe "reservation duration" do
+        before { instrument.update(min_reserve_days: 4) }
+
+        it "has a correctly duration in minutes" do
+          expect(reservation.duration_mins.minutes).to eq instrument.min_reserve_days.days
+        end
+
+        it "has a correctly duration in minutes" do
+          expect(reservation.duration_days).to eq instrument.min_reserve_days
+        end
+      end
+
+      it "returns a schedule as soon as possible" do
+        next_available_time = 1.minute.from_now.then do |time|
+          delta = time.min % instrument.reserve_interval
+          time - delta.minutes + instrument.reserve_interval.minutes
+        end
+
+        expect(reservation.reserve_start_at).to eq next_available_time
+      end
+
+      it "sets reserve_end_at correctly" do
+        expect(reservation.reserve_end_at).to eq(reservation.reserve_start_at + 1.day)
       end
     end
   end


### PR DESCRIPTION
# Notes

Make product's next available reservation logic to work for daily rate instruments.

> To be discussed
> What should be the reserve interval for daily rate instruments?

## Testing Notes

This does not include schedule rules changes required by daily rate instruments.
When loading the reservation page, the initial date should be an empty slot where the instrument can be reserved using the default duration.