### PR TITLE
[161578] Fix bulk note checkbox dynamic behavior

### DIFF
--- a/app/assets/javascripts/app/checkbox_form.js
+++ b/app/assets/javascripts/app/checkbox_form.js
@@ -1,6 +1,6 @@
 $(document).ready(function() {
   let submitButton = $(".js--requireValueForSubmit");
-  let checkboxes = submitButton.parents("form").find(":checkbox");
+  let checkboxes = submitButton.parents("form").find(":checkbox").not('[name="bulk_note_checkbox"]');
   let confirmationMessageEle = document.querySelector(".js--confirmationMessage");
   let reconcileAll = document.querySelector("#js--reconcileAll");
 

--- a/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
+++ b/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
@@ -78,8 +78,12 @@ RSpec.describe "Account Reconciliation", js: true do
         click_link "Reconcile Credit Cards"
 
         check "Use Bulk Note"
+        expect(page).to have_button("Update Orders", disabled: true)
+
         fill_in "Bulk Reconciliation Note", with: "this is the bulk note"
         check "order_detail_#{order_detail.id}_reconciled"
+        expect(page).to have_button("Update Orders", disabled: false)
+
         check "order_detail_#{orders.last.order_details.first.id}_reconciled"
         fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
         click_button "Update Orders", match: :first


### PR DESCRIPTION
# Release Notes

On the Credit Card Orders Reconciliation page the "Update order" button should only be available if an order is selected. 
The button wasn't behaving as expected because it was turning into active once the "Use bulk note" checkbox was checked despite no orders being selected.

Before:
![Screenshot 2024-11-05 at 8 46 43 PM](https://github.com/user-attachments/assets/3f7ce8ba-d306-464b-bf22-357ab27673fb)

After:
![Screenshot 2024-11-05 at 8 45 35 PM](https://github.com/user-attachments/assets/d0693ab1-4811-4661-8e0d-4f334ad32713)


# Additional Context

The check box form logic was looking for any checkbox in the submit button's parent component to be checked to activate the button. I exclude the bulk note checkbox from this check

