### PR TITLE
[#162474][Daily Rate] Handle reservations that end at beginning of day

### DIFF
--- a/app/models/schedule_rule.rb
+++ b/app/models/schedule_rule.rb
@@ -119,8 +119,8 @@ class ScheduleRule < ApplicationRecord
   end
 
   def cover?(dt)
-    # we check the previous minute in case dt is exactly the
-    # beginning of a day in case it's the end of a reservation
+    # check the previous minute in case dt is exactly the
+    # beginning of a day and it's the end of a reservation
     # (if it's not then the next minuted checked will be uncovered).
     dt_int = dt.hour * 100 + dt.min
     dt_day = if dt_int.zero?

--- a/app/models/schedule_rule.rb
+++ b/app/models/schedule_rule.rb
@@ -119,9 +119,18 @@ class ScheduleRule < ApplicationRecord
   end
 
   def cover?(dt)
-    return false unless on_day?(dt)
-
+    # we check the previous minute in case dt is exactly the
+    # beginning of a day in case it's the end of a reservation
+    # (if it's not then the next minuted checked will be uncovered).
     dt_int = dt.hour * 100 + dt.min
+    dt_day = if dt_int.zero?
+               dt - 1.minute
+             else
+               dt
+             end
+
+    return false unless on_day?(dt_day)
+
     dt_int >= start_time_int && dt_int <= end_time_int
   end
 

--- a/app/models/schedule_rule.rb
+++ b/app/models/schedule_rule.rb
@@ -121,15 +121,15 @@ class ScheduleRule < ApplicationRecord
   def cover?(dt)
     # check the previous minute in case dt is exactly the
     # beginning of a day and it's the end of a reservation
-    # (if it's not then the next minuted checked will be uncovered).
+    # (if it's not then the next minute checked will be uncovered).
     dt_int = dt.hour * 100 + dt.min
-    dt_day = if dt_int.zero?
+    dt = if dt_int.zero?
                dt - 1.minute
              else
                dt
              end
 
-    return false unless on_day?(dt_day)
+    return false unless on_day?(dt)
 
     dt_int >= start_time_int && dt_int <= end_time_int
   end

--- a/app/support/reservations/moving_up.rb
+++ b/app/support/reservations/moving_up.rb
@@ -4,18 +4,19 @@
 # up to that next time slot
 module Reservations::MovingUp
 
-  #
   # Returns a new reservation with the reserve_*_at times updated
   # to the next accommodating time slot on the calendar from NOW. Returns nil
   # if there is no such time slot. For read-only purposes.
   def earliest_possible
-    after = 1.minute.from_now
-    next_res = product.next_available_reservation(after: after,
-                                                  duration: duration_mins.minutes,
-                                                  options:
-                                                    { exclude: self,
-                                                      user: user,
-                                                      until: reserve_start_at })
+    next_res = product.next_available_reservation(
+      after: 1.minute.from_now,
+      duration: duration_mins.minutes,
+      options: {
+        exclude: self, user:,
+        until: reserve_start_at
+      }
+    )
+
     return nil if next_res.nil? || next_res.reserve_start_at >= reserve_start_at
     next_res
   end


### PR DESCRIPTION
# Notes

- Fix reservation checks on schedule rules when a reservation ends exactly at midnight (12:00 AM)
- Add tests to move a reservation next to unavailable day and next to another reservation when the availability ends at midnight
