### PR TITLE
Fix scanning-in-and-out-spec failing test

### DIFF
--- a/app/services/price_policies/time_based_price_calculator.rb
+++ b/app/services/price_policies/time_based_price_calculator.rb
@@ -13,7 +13,7 @@ module PricePolicies
     end
 
     def calculate(start_at, end_at)
-      return unless start_at < end_at
+      return if start_at > end_at
 
       strategy_class.new(price_policy, start_at, end_at).calculate
     end


### PR DESCRIPTION
# Release Notes

A small operator change in the time_based_price_calculator resulted in failing tests on some repos as it was skipping the calculation when the start date and the end date where the same.
