### PR TITLE
[#162414] Show admin holds as unavailable

### DIFF
--- a/app/presenters/reservations/calendar_presenter.rb
+++ b/app/presenters/reservations/calendar_presenter.rb
@@ -3,42 +3,7 @@
 module Reservations
 
   class CalendarPresenter < DelegateClass(Reservation)
-
-    def as_calendar_object(options = {})
-      calendar_object_default.merge(reservation_options(options))
-    end
-
-    private
-
-    def reservation_options(options)
-      if order.present?
-        if options[:with_details].present?
-          {
-            title: order.user.full_name,
-            email: order.user.email,
-            orderId: order.id,
-            orderNote: order_detail.facility.show_order_note? ? order_detail.note : nil,
-          }
-        else
-          {}
-        end
-      elsif offline?
-        {
-          title: "Instrument Offline",
-          email: created_by.try(:full_name),
-        }
-      else
-        hash = {
-          title: model_name.human,
-          email: created_by.try(:full_name),
-        }
-        hash[:expiration] = "Expires #{MinutesToTimeFormatter.new(expires_mins_before)} prior" if expires_mins_before.present?
-        hash[:userNote] = user_note
-        hash
-      end
-    end
-
-    def calendar_object_default
+    def as_calendar_object(_options = {})
       {
         start: display_start_at.iso8601,
         end: display_end_at.iso8601,
@@ -49,6 +14,53 @@ module Reservations
       }
     end
 
+    def self.build(reservation)
+      if reservation.order.present?
+        OrderCalendarPresenter.new(reservation)
+      elsif reservation.offline?
+        OfflineCalendarPresenter.new(reservation)
+      else
+        FallbackCalendarPresenter.new(reservation)
+      end
+    end
   end
 
+  class OfflineCalendarPresenter < CalendarPresenter
+    def as_calendar_object(_options = {})
+      super.merge(
+        title: "Instrument Offline",
+        email: created_by.try(:full_name),
+      )
+    end
+  end
+
+  class OrderCalendarPresenter < CalendarPresenter
+    def as_calendar_object(options = {})
+      ret = super
+
+      return (ret = super) if options[:with_details].blank?
+
+      ret.merge(
+        title: order.user.full_name,
+        email: order.user.email,
+        orderId: order.id,
+        orderNote: order_detail.facility.show_order_note? ? order_detail.note : nil,
+      )
+    end
+  end
+
+  class FallbackCalendarPresenter < CalendarPresenter
+    def as_calendar_object(_options = {})
+      super.merge(
+        title: model_name.human,
+        email: created_by.try(:full_name),
+        userNote: user_note,
+      ).tap do |hash|
+        if expires_mins_before.present?
+          hash[:expiration] = "Expires #{MinutesToTimeFormatter.new(expires_mins_before)} prior"
+        end
+        hash[:className] = 'unavailable' if __getobj__.is_a?(AdminReservation)
+      end
+    end
+  end
 end

--- a/app/presenters/reservations/calendar_presenter.rb
+++ b/app/presenters/reservations/calendar_presenter.rb
@@ -30,6 +30,7 @@ module Reservations
       super.merge(
         title: "Instrument Offline",
         email: created_by.try(:full_name),
+        className: "unavailable"
       )
     end
   end
@@ -59,7 +60,7 @@ module Reservations
         if expires_mins_before.present?
           hash[:expiration] = "Expires #{MinutesToTimeFormatter.new(expires_mins_before)} prior"
         end
-        hash[:className] = 'unavailable' if __getobj__.is_a?(AdminReservation)
+        hash[:className] = "unavailable" if __getobj__.is_a?(AdminReservation)
       end
     end
   end

--- a/app/presenters/schedule_rules/calendar_presenter.rb
+++ b/app/presenters/schedule_rules/calendar_presenter.rb
@@ -26,7 +26,7 @@ module ScheduleRules
 
     def events
       date_range.filter_map do |date|
-        hash_for_date(date.beginning_of_day) if rule_occurs_on_date?(date)
+        as_calendar_object(date.beginning_of_day) if rule_occurs_on_date?(date)
       end
     end
 
@@ -36,7 +36,7 @@ module ScheduleRules
       start_at.to_date..end_at.to_date
     end
 
-    def hash_for_date(date)
+    def as_calendar_object(date)
       start_at = date.change(hour: start_hour, min: start_min)
       end_at = date.change(hour: end_hour, min: end_min)
 

--- a/app/support/reservations/rendering.rb
+++ b/app/support/reservations/rendering.rb
@@ -31,7 +31,7 @@ module Reservations::Rendering
   end
 
   def calendar_presenter
-    Reservations::CalendarPresenter.new(self)
+    Reservations::CalendarPresenter.build(self)
   end
 
 end

--- a/spec/app_support/reservations/rendering_spec.rb
+++ b/spec/app_support/reservations/rendering_spec.rb
@@ -103,16 +103,20 @@ RSpec.describe Reservations::Rendering do
       subject(:reservation) do
         build_stubbed(
           :admin_reservation,
-          reserve_start_at: reserve_start_at,
-          reserve_end_at: reserve_end_at,
-          actual_start_at: actual_start_at,
-          actual_end_at: actual_end_at,
+          reserve_start_at:,
+          reserve_end_at:,
+          actual_start_at:,
+          actual_end_at:,
           created_by: user,
           user_note: "this is a note",
         )
       end
 
       let(:user) { FactoryBot.build(:user) }
+
+      before do
+        base_hash.merge!(className: "unavailable")
+      end
 
       context "with details requested" do
         it "returns a hash without extra details about the order" do

--- a/spec/presenters/reservations/calendar_presenter_spec.rb
+++ b/spec/presenters/reservations/calendar_presenter_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Reservations::CalendarPresenter do
+  let(:product) { build(:product) }
+  let(:presenter) { described_class.build(reservation) }
+  let(:subject) { presenter.as_calendar_object }
+
+  context "with an normal reservation with order" do
+    let(:reservation) { build(:setup_reservation) }
+    let(:order) { reservation.order }
+
+    it { is_expected.to include(:id, :product, :title, :start, :end) }
+    it { expect(presenter).to be_a(Reservations::OrderCalendarPresenter) }
+
+    it "include order details if with_details" do
+      expect(presenter.as_calendar_object(with_details: true)).to include(
+        :orderId,
+        :orderNote,
+        title: order.user.full_name,
+        email: order.user.email
+      )
+    end
+  end
+
+  context "with an offline reservation" do
+    let(:reservation) { build(:offline_reservation, product:) }
+
+    it { is_expected.to include(:id, :product, :title, :start, :end) }
+    it { is_expected.to include(className: "unavailable") }
+    it { expect(presenter).to be_a(Reservations::OfflineCalendarPresenter) }
+  end
+
+  context "with an admin hold reservation" do
+    let(:reservation) { build(:admin_reservation, product:) }
+
+    it { is_expected.to include(:id, :product, :title, :start, :end) }
+    it { is_expected.to include(className: "unavailable") }
+    it { expect(presenter).to be_a(Reservations::FallbackCalendarPresenter) }
+
+    context "when expires_mins_before is present" do
+      before do
+        reservation.expires_mins_before = 30
+      end
+
+      it { is_expected.to include(expiration: String) }
+    end
+  end
+end


### PR DESCRIPTION
## Note

Show admin reservations and offline reservations as unavailable in the calendar (with the unavailable css class). I've also refactored the reservation's calendar presenter and added some tests.

> Even though the ticket is related to daily booking, the change applies to all admin holds.

## Screenshots

![Captura desde 2024-11-20 11-06-30](https://github.com/user-attachments/assets/01cd089d-6189-4cd6-91de-81db7d5dfb36)
