### PR TITLE
[#162480][Daily rate] Only allow global admins to create instruments

### DIFF
--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -35,6 +35,16 @@ class InstrumentsController < ProductsCommonController
     end
   end
 
+  def create
+    if resource_params[:pricing_mode] == Instrument::Pricing::SCHEDULE_DAILY && cannot?(:create_daily_booking, Instrument)
+      flash.now[:error] = t("controllers.instruments.create.daily_booking_not_authorized")
+
+      render :new
+    else
+      super
+    end
+  end
+
   # GET /facilities/:facility_id/instruments/:instrument_id/schedule
   def schedule
     @admin_reservations =
@@ -79,6 +89,16 @@ class InstrumentsController < ProductsCommonController
       # raise ActiveRecord::RecordNotFound
     end
     render json: @status
+  end
+
+  private
+
+  def permitted_params
+    params = super
+
+    (params += %i[min_reserve_days max_reserve_days]) if can?(:create_daily_booking, Instrument)
+
+    params
   end
 
 end

--- a/app/controllers/products_common_controller.rb
+++ b/app/controllers/products_common_controller.rb
@@ -54,6 +54,10 @@ class ProductsCommonController < ApplicationController
     @product = current_facility_products.new(account: Settings.accounts.product_default)
   end
 
+  # GET /facilities/alpha/(items|services|instruments)/1/edit
+  def edit
+  end
+
   # POST /services
   def create
     @product = current_facility_products.new(resource_params)
@@ -65,10 +69,6 @@ class ProductsCommonController < ApplicationController
     else
       render action: "new"
     end
-  end
-
-  # GET /facilities/alpha/(items|services|instruments)/1/edit
-  def edit
   end
 
   # PUT /services/1
@@ -119,8 +119,7 @@ class ProductsCommonController < ApplicationController
       :min_reserve_mins, :max_reserve_mins, :min_cancel_hours,
       :auto_cancel_mins, :lock_window, :cutoff_hours,
       :problems_resolvable_by_user, :restrict_holiday_access, :billing_mode,
-      :pricing_mode, :cross_core_ordering_available,
-      :min_reserve_days, :max_reserve_days
+      :pricing_mode, :cross_core_ordering_available
     ]
   end
 

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -27,6 +27,14 @@ module ProductsHelper
     }
   end
 
+  def instrument_pricing_modes
+    return Instrument::PRICING_MODES if can?(:create_daily_booking, Instrument)
+
+    Instrument::PRICING_MODES.reject do |pricing_mode|
+      pricing_mode == Instrument::Pricing::SCHEDULE_DAILY
+    end
+  end
+
   def public_calendar_link(product)
     return unless product.respond_to? :reservations
 

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -393,6 +393,7 @@ class Ability
       ProductDisplayGroup,
     ]
 
+    cannot :create_daily_booking, Product
     can :manage, User if controller.is_a?(FacilityUsersController)
 
     # ideally we don't use `cannot` as it adds a dependency on the order of assigning abilities for multiple roles

--- a/app/views/instruments/_instrument_fields.html.haml
+++ b/app/views/instruments/_instrument_fields.html.haml
@@ -13,7 +13,7 @@
   = f.input :schedule, as: :readonly, value_method: :display_name, hint: false
 
 - if f.object.new_record?
-  = f.input :pricing_mode, as: :radio_buttons, collection: Instrument::PRICING_MODES, label: text("instruments.instrument_fields.schedule.pricing_mode"),
+  = f.input :pricing_mode, as: :radio_buttons, collection: instrument_pricing_modes, label: text("instruments.instrument_fields.schedule.pricing_mode"),
     item_wrapper_class: :radio, item_wrapper_tag: :div, wrapper_html: { class: "js--pricing-mode" }
 
 - daily_booking = f.object.daily_booking?

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -80,6 +80,10 @@ en:
         success: The reservation has been canceled successfully.
         error: An error was encountered while canceling the order.
 
+    instruments:
+      create:
+        daily_booking_not_authorized: "Not allowed to create daily booking instruments"
+
     offline_reservations:
       bring_online:
         success: The instrument is back online

--- a/spec/controllers/instruments_controller_spec.rb
+++ b/spec/controllers/instruments_controller_spec.rb
@@ -3,11 +3,11 @@
 require "rails_helper"
 require "controller_spec_helper"
 
-RSpec.describe InstrumentsController do
+RSpec.describe InstrumentsController, type: :controller do
   render_views
 
   let(:facility) { FactoryBot.create(:setup_facility) }
-  let(:instrument) { FactoryBot.create(:instrument, facility: facility, no_relay: true) }
+  let(:instrument) { FactoryBot.create(:instrument, facility:, no_relay: true) }
 
   before(:all) { create_users }
 
@@ -261,12 +261,18 @@ RSpec.describe InstrumentsController do
     end
 
     it_should_allow_managers_only :redirect do
-      assert_successful_creation { expect(assigns(:product).relay).to be_nil }
+      expect(assigns(:product)).to be_kind_of Instrument
+      expect(assigns(:product).initial_order_status_id).to eq(OrderStatus.default_order_status.id)
+
+      expect(assigns(:product).relay).to be_nil
+
+      is_expected.to set_flash
+      assert_redirected_to manage_facility_instrument_url(facility, assigns(:product))
     end
 
     describe "shared schedule" do
       before :each do
-        @schedule = FactoryBot.create(:schedule, facility: facility)
+        @schedule = FactoryBot.create(:schedule, facility:)
         sign_in @admin
       end
 
@@ -298,7 +304,6 @@ RSpec.describe InstrumentsController do
     end
 
     context "fail" do
-
       before :each do
         @params[:instrument].delete(:name)
       end
@@ -308,15 +313,49 @@ RSpec.describe InstrumentsController do
         expect(assigns(:product).initial_order_status_id).to eq(OrderStatus.default_order_status.id)
         is_expected.to render_template "new"
       end
-
     end
 
-    def assert_successful_creation
-      expect(assigns(:product)).to be_kind_of Instrument
-      expect(assigns(:product).initial_order_status_id).to eq(OrderStatus.default_order_status.id)
-      yield
-      is_expected.to set_flash
-      assert_redirected_to manage_facility_instrument_url(facility, assigns(:product))
+    describe "daily booking permissions" do
+      before do
+        @params[:instrument] = attributes_for(
+          :instrument,
+          pricing_mode: Instrument::Pricing::SCHEDULE_DAILY,
+          facility_account_id: facility.facility_accounts.first.id,
+        )
+      end
+
+      shared_examples "daily booking creation dissallowed" do
+        it "does not allow user to create daily booking instrument" do
+          sign_in(user)
+
+          expect { do_request }.to_not change { Instrument.count }
+          expect(@response.body).to(
+            include(I18n.t("controllers.instruments.create.daily_booking_not_authorized"))
+          )
+        end
+      end
+
+      context "as facility admin" do
+        let(:user) { create(:user, :facility_administrator, facility:) }
+
+        include_examples "daily booking creation dissallowed"
+      end
+
+      context "as facility director" do
+        let(:user) { create(:user, :facility_director, facility:) }
+
+        include_examples "daily booking creation dissallowed"
+      end
+
+      context "as administrator" do
+        let(:user) { create(:user, :administrator) }
+
+        it "allows to create a daily booking instrument" do
+          sign_in user
+
+          expect { do_request }.to change { Instrument.count }.by(1)
+        end
+      end
     end
   end
 
@@ -362,7 +401,6 @@ RSpec.describe InstrumentsController do
     end
 
     context "schedule" do
-
       before :each do
         @method = :get
         @action = :schedule
@@ -396,7 +434,6 @@ RSpec.describe InstrumentsController do
           is_expected.to render_template "schedule"
         end
       end
-
     end
 
     context "instrument_statuses" do
@@ -404,7 +441,7 @@ RSpec.describe InstrumentsController do
         @method = :get
         @action = :instrument_statuses
         @instrument_with_relay = FactoryBot.create(:instrument,
-                                                   facility: facility,
+                                                   facility:,
                                                    no_relay: true)
         FactoryBot.create(:relay_syna, instrument: @instrument_with_relay)
       end
@@ -427,11 +464,9 @@ RSpec.describe InstrumentsController do
           )
         end
       end
-
     end
 
     context "switch" do
-
       before :each do
         @method = :get
         @action = :switch
@@ -439,7 +474,6 @@ RSpec.describe InstrumentsController do
       end
 
       it_should_allow_operators_only
-
     end
   end
 end

--- a/spec/controllers/instruments_controller_spec.rb
+++ b/spec/controllers/instruments_controller_spec.rb
@@ -324,7 +324,7 @@ RSpec.describe InstrumentsController, type: :controller do
         )
       end
 
-      shared_examples "daily booking creation dissallowed" do
+      shared_examples "daily booking creation disallowed" do
         it "does not allow user to create daily booking instrument" do
           sign_in(user)
 
@@ -338,13 +338,13 @@ RSpec.describe InstrumentsController, type: :controller do
       context "as facility admin" do
         let(:user) { create(:user, :facility_administrator, facility:) }
 
-        include_examples "daily booking creation dissallowed"
+        include_examples "daily booking creation disallowed"
       end
 
       context "as facility director" do
         let(:user) { create(:user, :facility_director, facility:) }
 
-        include_examples "daily booking creation dissallowed"
+        include_examples "daily booking creation disallowed"
       end
 
       context "as administrator" do

--- a/spec/system/admin/creating_an_instrument_spec.rb
+++ b/spec/system/admin/creating_an_instrument_spec.rb
@@ -4,53 +4,67 @@ require "rails_helper"
 
 RSpec.describe "Creating an instrument", :js do
   let(:facility) { create(:setup_facility) }
-  let(:director) { create(:user, :facility_director, facility:) }
-
-  before do
-    login_as director
-  end
 
   describe "Daily Booking instrument" do
-    it "is accessible" do
-      visit new_facility_instrument_path(facility)
-      expect(page).to be_axe_clean
+    context "as disallowed user" do
+      let(:user) { create(:user, :facility_director, facility:) }
+
+      it "cannot select daily booking pricing mode" do
+        visit new_facility_instrument_path(facility)
+
+        expect(page).to_not have_element(Instrument::Pricing::SCHEDULE_DAILY)
+      end
     end
+    context "as administrator" do
+      let(:user) { create(:user, :administrator) }
 
-    it "can create and see a daily booking instrument" do
-      visit facility_products_path(facility)
-      click_link "Instruments (0)", exact: true
-      click_link "Add Instrument"
+      before do
+        login_as user
+      end
 
-      fill_in "Name", with: "Daily Booking Instrument", match: :first
-      fill_in "URL Name", with: "daily-booking-instrument"
+      it "is accessible" do
+        visit new_facility_instrument_path(facility)
+        expect(page).to be_axe_clean
+      end
 
-      expect(page).to have_field("Interval (minutes)")
-      expect(page).to have_field("Minimum (minutes)")
-      expect(page).to have_field("Maximum (minutes)")
-      expect(page).not_to have_field("Minimum (days)")
-      expect(page).not_to have_field("Maximum (days)")
+      it "can create and see a daily booking instrument" do
+        visit facility_products_path(facility)
+        click_link "Instruments (0)", exact: true
+        click_link "Add Instrument"
 
-      choose "Schedule Rule (Daily Booking only)"
+        fill_in "Name", with: "Daily Booking Instrument", match: :first
+        fill_in "URL Name", with: "daily-booking-instrument"
 
-      expect(page).not_to have_field("Interval Minutes")
-      expect(page).not_to have_field("Minimum (minutes)")
-      expect(page).not_to have_field("Maximum (minutes)")
-      expect(page).to have_field("Maximum (days)")
-      expect(page).to have_field("Minimum (days)")
+        expect(page).to have_field("Interval (minutes)")
+        expect(page).to have_field("Minimum (minutes)")
+        expect(page).to have_field("Maximum (minutes)")
+        expect(page).not_to have_field("Minimum (days)")
+        expect(page).not_to have_field("Maximum (days)")
 
-      fill_in "Minimum (days)", with: "5"
-      fill_in "Maximum (days)", with: "10"
+        expect(page).to have_content(Instrument::Pricing::SCHEDULE_DAILY)
 
-      click_button "Create"
+        choose Instrument::Pricing::SCHEDULE_DAILY
 
-      expect(current_path).to eq(manage_facility_instrument_path(facility, Instrument.last))
-      expect(page).to have_content("Daily Booking Instrument")
-      expect(page).to have_content("Schedule Rule (Daily Booking only)")
-      expect(page).to have_content("Min reserve days")
-      expect(page).to have_content("Max reserve days")
-      expect(page).not_to have_content("Interval minutes")
-      expect(page).not_to have_content("Min reserve minutes")
-      expect(page).not_to have_content("Max reserve minutes")
+        expect(page).not_to have_field("Interval Minutes")
+        expect(page).not_to have_field("Minimum (minutes)")
+        expect(page).not_to have_field("Maximum (minutes)")
+        expect(page).to have_field("Maximum (days)")
+        expect(page).to have_field("Minimum (days)")
+
+        fill_in "Minimum (days)", with: "5"
+        fill_in "Maximum (days)", with: "10"
+
+        click_button "Create"
+
+        expect(current_path).to eq(manage_facility_instrument_path(facility, Instrument.last))
+        expect(page).to have_content("Daily Booking Instrument")
+        expect(page).to have_content("Schedule Rule (Daily Booking only)")
+        expect(page).to have_content("Min reserve days")
+        expect(page).to have_content("Max reserve days")
+        expect(page).not_to have_content("Interval minutes")
+        expect(page).not_to have_content("Min reserve minutes")
+        expect(page).not_to have_content("Max reserve minutes")
+      end
     end
   end
 end


### PR DESCRIPTION
## Notes

Only allow global admins to create daily rate instruments and only show the option to them.