### PR TITLE
Fix daily reservation on unavailable day test

### DIFF
--- a/spec/system/purchasing_a_reservation_spec.rb
+++ b/spec/system/purchasing_a_reservation_spec.rb
@@ -289,7 +289,9 @@ RSpec.describe "Purchasing a reservation" do
 
         click_button("Create")
 
-        expect(page).to have_content("Unable to place order")
+        expect(page).to have_content(
+          I18n.t("activerecord.errors.models.reservation.attributes.base.no_schedule_rule")
+        )
       end
 
       it "can create before unavailable day and span over it" do


### PR DESCRIPTION
Fix test that changed due to merging this PR: https://github.com/wyeworks/nucore-open/pull/4782 not up to date with master.

The fixed test currently asserts the correct message. It use to fail due to other reason with a generic message which was fixed (by chance) in the aformentioned PR.