### PR TITLE
[#162417] Fix order details unrecoverable status flow

### DIFF
--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -101,7 +101,7 @@ class OrderManagement::OrderDetailsController < ApplicationController
     return if @order_detail.reconciled?
 
     if @order_detail.complete?
-      @order_statuses = [OrderStatus.complete, OrderStatus.canceled]
+      @order_statuses = [OrderStatus.complete, OrderStatus.canceled, OrderStatus.unrecoverable]
       @order_statuses << OrderStatus.reconciled if @order_detail.can_reconcile?
     elsif @order_detail.order_status.root == OrderStatus.canceled
       @order_statuses = OrderStatus.canceled_statuses_for_facility(current_facility)

--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -101,8 +101,8 @@ class OrderManagement::OrderDetailsController < ApplicationController
     return if @order_detail.reconciled?
 
     if @order_detail.complete?
-      @order_statuses = [OrderStatus.complete, OrderStatus.canceled, OrderStatus.unrecoverable]
-      @order_statuses << OrderStatus.reconciled if @order_detail.can_reconcile?
+      @order_statuses = OrderStatus.where(name: %w[complete canceled unrecoverable reconciled]).to_a
+      @order_statuses.reject! { |status| status.name == 'reconciled' } unless @order_detail.can_reconcile?
     elsif @order_detail.order_status.root == OrderStatus.canceled
       @order_statuses = OrderStatus.canceled_statuses_for_facility(current_facility)
     else

--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -101,8 +101,14 @@ class OrderManagement::OrderDetailsController < ApplicationController
     return if @order_detail.reconciled?
 
     if @order_detail.complete?
-      @order_statuses = OrderStatus.where(name: %w[complete canceled unrecoverable reconciled]).to_a
-      @order_statuses.reject! { |status| status.name == 'reconciled' } unless @order_detail.can_reconcile?
+      @order_statuses = OrderStatus.by_names([
+        OrderStatus::COMPLETE,
+        OrderStatus::CANCELED,
+        OrderStatus::UNRECOVERABLE,
+        OrderStatus::RECONCILED
+      ]).to_a
+    
+      @order_statuses.reject! { |status| status.name == OrderStatus::RECONCILED } unless @order_detail.can_reconcile?
     elsif @order_detail.order_status.root == OrderStatus.canceled
       @order_statuses = OrderStatus.canceled_statuses_for_facility(current_facility)
     else

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -369,6 +369,7 @@ class OrderDetail < ApplicationRecord
   include AASM
 
   CANCELABLE_STATES = [:new, :inprocess, :complete, :unrecoverable].freeze
+  COMPLETABLE_STATES = [:new, :inprocess, :unrecoverable].freeze
   aasm column: :state do
     state :new, initial: true
     state :inprocess
@@ -386,7 +387,7 @@ class OrderDetail < ApplicationRecord
     end
 
     event :to_complete do
-      transitions to: :complete, from: [:new, :inprocess], guard: :time_data_completeable?
+      transitions to: :complete, from: COMPLETABLE_STATES, guard: :time_data_completeable?
     end
 
     event :to_reconciled do

--- a/app/models/order_status.rb
+++ b/app/models/order_status.rb
@@ -17,36 +17,45 @@ class OrderStatus < ApplicationRecord
     end
   end
 
-  scope :for_facility, ->(facility) { where(facility_id: [nil, facility&.id]) }
-
-  ROOT_STATUS_ORDER = ["New", "In Process", "Canceled", "Complete", "Reconciled", "Unrecoverable"].freeze
+  NEW = "New".freeze
+  IN_PROCESS = "In Process".freeze
+  CANCELED = "Canceled".freeze
+  COMPLETE = "Complete".freeze
+  RECONCILED = "Reconciled".freeze
+  UNRECOVERABLE = "Unrecoverable".freeze
+  
+  ROOT_STATUS_ORDER = [NEW, IN_PROCESS, CANCELED, COMPLETE, RECONCILED, UNRECOVERABLE].freeze
 
   # Needs to be overridable by engines
   cattr_accessor(:ordered_root_statuses) { ROOT_STATUS_ORDER.dup }
 
+  scope :for_facility, ->(facility) { where(facility_id: [nil, facility&.id]) }
+  scope :by_name, ->(name) { find_by(name: name) }
+  scope :by_names, ->(names) { where(name: names) }
+
   # This one is different because `new` is a reserved keyword
   def self.new_status
-    find_by(name: "New")
+    by_name(NEW)
   end
 
   def self.in_process
-    find_by(name: "In Process")
+    by_name(IN_PROCESS)
   end
 
   def self.canceled
-    find_by(name: "Canceled")
+    by_name(CANCELED)
   end
 
   def self.complete
-    find_by(name: "Complete")
+    by_name(COMPLETE)
   end
 
   def self.reconciled
-    find_by(name: "Reconciled")
+    by_name(RECONCILED)
   end
 
   def self.unrecoverable
-    find_by(name: "Unrecoverable")
+    by_name(UNRECOVERABLE)
   end
 
   def self.add_to_order_statuses(facility)

--- a/app/models/order_status.rb
+++ b/app/models/order_status.rb
@@ -122,6 +122,7 @@ class OrderStatus < ApplicationRecord
       new_status.self_and_descendants
         .or(in_process.self_and_descendants)
         .or(canceled.self_and_descendants)
+        .or(unrecoverable.self_and_descendants)
         .or(complete.self_and_descendants)
         .for_facility(facility).sorted
     end

--- a/spec/models/order_status_spec.rb
+++ b/spec/models/order_status_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe OrderStatus do
         described_class.canceled,
         facility_status,
         described_class.complete,
+        described_class.unrecoverable,
       ]
 
       expect(described_class.non_protected_statuses(facility)).to eq(expected_statuses)
@@ -98,6 +99,7 @@ RSpec.describe OrderStatus do
         described_class.in_process,
         described_class.canceled,
         described_class.complete,
+        described_class.unrecoverable,
       ]
 
       expect(described_class.non_protected_statuses(nil)).to eq(expected_statuses)


### PR DESCRIPTION
# Release Notes

Ticket: [#162417 | Status in Order Detail page does not show Unrecoverable
](https://pm.tablexi.com/issues/162417?issue_count=45&issue_position=23&next_issue_id=162414&prev_issue_id=162472)

After changing the status of an order to Unrecoverable, then going back to the Order Detail page, the Order Status is displayed as "New".

Added the Unrecoverable status to the order details view dropdown and added permissions to set the status of completed orders to unrecoverable. 

# Screenshot

![Screenshot 2024-11-28 at 3 39 25 PM](https://github.com/user-attachments/assets/30e70063-e3a1-40f3-8f2c-73e9554a6862)

