### PR TITLE
[#162477] Add "Order for" in purchase email

### DIFF
--- a/app/mailers/purchase_notifier.rb
+++ b/app/mailers/purchase_notifier.rb
@@ -15,7 +15,7 @@ class PurchaseNotifier < ApplicationMailer
     @order_detail = OrderDetailPresenter.new(order_detail)
     attach_reservation_ical(order_detail.reservation) if order_detail.reservation.present?
     subject = text("views.purchase_notifier.product_order_notification.subject", product: order_detail.product)
-    send_nucore_mail to: recipient, subject: subject, reply_to: @order.created_by_user.email
+    send_nucore_mail to: recipient, subject:, reply_to: @order.created_by_user.email
   end
 
   # Notifies the specified facility staff member if any order is placed within a facility
@@ -23,7 +23,7 @@ class PurchaseNotifier < ApplicationMailer
     @order = order
     attach_all_icals_from_order(@order)
     subject = text("views.purchase_notifier.order_notification.subject")
-    send_nucore_mail to: recipient, subject: subject, reply_to: @order.created_by_user.email, template_name: "order_receipt"
+    send_nucore_mail to: recipient, subject:, reply_to: @order.created_by_user.email, template_name: "order_receipt"
   end
 
   # Custom order forms send out a confirmation email when filled out by a
@@ -39,7 +39,7 @@ class PurchaseNotifier < ApplicationMailer
   private
 
   def attach_all_icals_from_order(order)
-    order.order_details.map(&:reservation).compact.each do |reservation|
+    order.order_details.filter_map(&:reservation).each do |reservation|
       attach_reservation_ical(reservation)
     end
   end
@@ -53,9 +53,9 @@ class PurchaseNotifier < ApplicationMailer
 
   def send_nucore_mail(to:, subject:, reply_to: nil, template_name: nil)
     if reply_to
-      mail(subject: subject, to: to, template_name: template_name, reply_to: reply_to)
+      mail(subject:, to:, template_name:, reply_to:)
     else
-      mail(subject: subject, to: to, template_name: template_name)
+      mail(subject:, to:, template_name:)
     end
   end
 

--- a/app/views/purchase_notifier/order_receipt.html.haml
+++ b/app/views/purchase_notifier/order_receipt.html.haml
@@ -15,6 +15,11 @@
     %td
       %strong= OrderDetail.human_attribute_name(:ordered_by)
     %td= mail_to @order.created_by_user.email, @order.created_by_user.full_name
+  - if @order.user.present? && @order.created_by != @order.user
+    %tr
+      %td
+        %strong= OrderDetail.human_attribute_name(:order_for)
+      %d= mail_to @order.user.full_name
   %tr
     %td
       %strong= Account.model_name.human

--- a/app/views/purchase_notifier/order_receipt.html.haml
+++ b/app/views/purchase_notifier/order_receipt.html.haml
@@ -15,10 +15,10 @@
     %td
       %strong= OrderDetail.human_attribute_name(:ordered_by)
     %td= mail_to @order.created_by_user.email, @order.created_by_user.full_name
-  - if @order.user.present? && @order.created_by != @order.user
+  - if @order.created_by != @order.user_id
     %tr
       %td
-        %strong= OrderDetail.human_attribute_name(:order_for)
+        %strong= text(".order_for")
       %d= mail_to @order.user.full_name
   %tr
     %td

--- a/config/locales/en.purchase_notifier.yml
+++ b/config/locales/en.purchase_notifier.yml
@@ -8,5 +8,6 @@ en:
       order_receipt:
         subject: "!app_name! Order Receipt"
         intro: "Thank you for your order on the !app_name! website."
+        order_for: Order For
         outro: "All prices are estimates. Actual cost is assigned when the order is complete."
         total: Total


### PR DESCRIPTION
## Notes

Add "Order For" in email with information about the user targeting a reservation when it's donde by someone else.

> Also formatted some files