### PR TITLE
[Fix] Label click not toggling checkbox

### DIFF
--- a/app/views/reservations/new.html.haml
+++ b/app/views/reservations/new.html.haml
@@ -38,7 +38,6 @@
       - if @order.order_details.size == 1
         .span6.send-notification
           = label_tag :send_notification, class: "checkbox" do
-            = hidden_field_tag :send_notification, 0
             = check_box_tag :send_notification, 1, params[:send_notification] == "1"
             = t(".notify")
 


### PR DESCRIPTION
## Note

Fix checkbox label clicking not toggling checkbox change because there was a hidden input under the same label, with the same name which I found to be useless

## Screenshot

<img width="934" alt="Captura de pantalla 2024-12-13 a la(s) 11 09 32" src="https://github.com/user-attachments/assets/31480b49-0a01-4f63-b287-b8bf77f8578f" />

