### PR TITLE
Tech task: [#162459] Use wyeworkshub image instead of nucoretxi

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -21,9 +21,6 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
     container:
       image: wyeworkshub/ruby-node-chrome-pack:3.3.0
-      credentials:
-        username: wyeworks
-        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     env:
       RAILS_ENV: test
       MYSQL_HOST: mysql
@@ -62,9 +59,6 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
     container:
       image: wyeworkshub/ruby-node-chrome-pack:3.3.0
-      credentials:
-        username: wyeworks
-        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     env:
       RAILS_ENV: test
       MYSQL_HOST: mysql
@@ -99,9 +93,6 @@ jobs:
         options: --shm-size="2g"
     container:
       image: wyeworkshub/ruby-node-chrome-pack:3.3.0
-      credentials:
-        username: wyeworks
-        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     env:
       TEASPOON_RAILS_ENV: test
       RAILS_ENV: test

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -20,9 +20,9 @@ jobs:
           MYSQL_ROOT_HOST: "%"
         options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
     container:
-      image: nucoretxi/ruby-node-chrome-pack:3.3.0
+      image: wyeworkshub/ruby-node-chrome-pack:3.3.0
       credentials:
-        username: nucoretxi
+        username: wyeworks
         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     env:
       RAILS_ENV: test
@@ -61,9 +61,9 @@ jobs:
           MYSQL_ROOT_HOST: "%"
         options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
     container:
-      image: nucoretxi/ruby-node-chrome-pack:3.3.0
+      image: wyeworkshub/ruby-node-chrome-pack:3.3.0
       credentials:
-        username: nucoretxi
+        username: wyeworks
         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     env:
       RAILS_ENV: test
@@ -98,9 +98,9 @@ jobs:
           - 4444:4444
         options: --shm-size="2g"
     container:
-      image: nucoretxi/ruby-node-chrome-pack:3.3.0
+      image: wyeworkshub/ruby-node-chrome-pack:3.3.0
       credentials:
-        username: nucoretxi
+        username: wyeworks
         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     env:
       TEASPOON_RAILS_ENV: test

--- a/Dockerfile.github-actions
+++ b/Dockerfile.github-actions
@@ -1,4 +1,4 @@
-# More info: https://hub.docker.com/repository/docker/nucoretxi/ruby-node-chrome-pack/general
+# More info: https://hub.docker.com/repository/docker/wyeworkshub/ruby-node-chrome-pack/general
 #
 # To build with specific versions of bundler or node, pass in a build arg.
 # You can set these explicitly:

--- a/README.md
+++ b/README.md
@@ -245,14 +245,14 @@ docker build . -f Dockerfile.github-actions --build-arg NODE_VERSION=$NODE_VERSI
 docker image ls
 
 # Tag the image with the appropriate ruby version
-docker tag {IMAGE ID} nucoretxi/ruby-node-chrome-pack:3.3.0
+docker tag {IMAGE ID} wyeworkshub/ruby-node-chrome-pack:3.3.0
 
 # Check the image was tagged correctly
 docker image ls
 
 # login and push the new tag
-docker login -u nucoretxi
-docker push nucoretxi/ruby-node-chrome-pack:3.3.0
+docker login
+docker push wyeworkshub/ruby-node-chrome-pack:3.3.0
 ```
 
 #### Parallel Tests


### PR DESCRIPTION
# Release Notes
* Transition: use WyeWorks' Dockerhub instead of TXI's.

# Additional context
Removed usage of `DOCKER_HUB_ACCESS_TOKEN` as the images are public.
