### PR TITLE
[#161265] Skip credit card reconcile test if not reconcilable

### DIFF
--- a/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
+++ b/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Account Reconciliation", js: true do
     let(:other_order_number) { "##{orders.last.id} - #{orders.last.order_details.first.id}" }
 
     it "can search and then reconcile a credit card order" do
-      break skip("credit card account disabled") unless credit_card_account_enabled?
+      skip("credit card account disabled") unless credit_card_account_enabled?
 
       visit facility_notifications_path(facility)
       click_link "Reconcile Credit Cards"
@@ -80,7 +80,7 @@ RSpec.describe "Account Reconciliation", js: true do
 
     context "with bulk reconciliation note" do
       it "sets the note when checkbox is checked" do
-        break skip("credit card account disabled") unless credit_card_account_enabled?
+        skip("credit card account disabled") unless credit_card_account_enabled?
 
         visit credit_cards_facility_accounts_path(facility)
         click_link "Reconcile Credit Cards"
@@ -101,7 +101,7 @@ RSpec.describe "Account Reconciliation", js: true do
       end
 
       it "does NOT set the note when checkbox is NOT checked" do
-        break skip("credit card account disabled") unless credit_card_account_enabled?
+        skip("credit card account disabled") unless credit_card_account_enabled?
 
         visit credit_cards_facility_accounts_path(facility)
         click_link "Reconcile Credit Cards"

--- a/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
+++ b/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe "Account Reconciliation", js: true do
   let(:director) { create(:user, :facility_director, facility: facility) }
   let(:statement) { StatementPresenter.new order_detail.statement }
 
+  def credit_card_account_enabled?
+    Account.config.reconcilable_account_types.include?("CreditCardAccount")
+  end
+
   before do
     orders.zip(statements).each do |order, statement|
       order.order_details.each do |od|
@@ -34,6 +38,8 @@ RSpec.describe "Account Reconciliation", js: true do
     let(:other_order_number) { "##{orders.last.id} - #{orders.last.order_details.first.id}" }
 
     it "can search and then reconcile a credit card order" do
+      break skip("credit card account disabled") unless credit_card_account_enabled?
+
       visit facility_notifications_path(facility)
       click_link "Reconcile Credit Cards"
 
@@ -74,6 +80,8 @@ RSpec.describe "Account Reconciliation", js: true do
 
     context "with bulk reconciliation note" do
       it "sets the note when checkbox is checked" do
+        break skip("credit card account disabled") unless credit_card_account_enabled?
+
         visit credit_cards_facility_accounts_path(facility)
         click_link "Reconcile Credit Cards"
 
@@ -93,6 +101,8 @@ RSpec.describe "Account Reconciliation", js: true do
       end
 
       it "does NOT set the note when checkbox is NOT checked" do
+        break skip("credit card account disabled") unless credit_card_account_enabled?
+
         visit credit_cards_facility_accounts_path(facility)
         click_link "Reconcile Credit Cards"
 


### PR DESCRIPTION
## Notes

Reconcile credit card tests fail on the c2po engine if credit card is not reconcilable because the route is not generated.
The simplest solution is to skip those on setups where they are not used.