### PR TITLE
[#162525] Improve duration error message

### DIFF
--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -43,10 +43,10 @@ module Reservations::Validations
 
   def starts_before_ends
     if reserve_start_at && reserve_end_at
-      errors.add(:duration_mins, :zero_minutes) if reserve_end_at <= reserve_start_at
+      errors.add(:duration_mins, :zero_duration) if reserve_end_at <= reserve_start_at
     end
     if actual_start_at && actual_end_at
-      errors.add(:actual_duration_mins, :zero_minutes) if actual_end_at <= actual_start_at
+      errors.add(:actual_duration_mins, :zero_duration) if actual_end_at <= actual_start_at
     end
   end
 

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -67,7 +67,7 @@ en:
         bad_payment_source_format: "must be in format %{pattern_format}"
         subsidy_greater_than_cost: "cannot be greater than the Usage cost"
         already_in_queue: Only one file may be in process at a time
-        zero_minutes: must be at least 1 minute
+        zero_duration: must be greater than zero
         start_after_end: must be after Ending Date
         # Append your own errors here or at the model/attributes scope.
       full_messages:

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe OrderManagement::OrderDetailsController do
 
             it "renders an error", :aggregate_failures do
               expect(flash[:error]).to be_present
-              expect(assigns(:order_detail).errors.full_messages).to include("Duration must be at least 1 minute")
+              expect(assigns(:order_detail).errors.full_messages).to include("Duration must be greater than zero")
               expect(response).to render_template(:edit)
               expect(response.code).to eq("406")
             end

--- a/spec/services/problem_reservation_resolver_spec.rb
+++ b/spec/services/problem_reservation_resolver_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe ProblemReservationResolver do
     it "adds an error to the reservation if it is invalid" do
       # Reservations cannot be zero length
       expect(resolver.resolve(actual_end_at: problem_reservation.actual_start_at)).to be_falsy
-      expect(problem_reservation.errors).to be_added(:actual_duration_mins, :zero_minutes)
+      expect(problem_reservation.errors).to be_added(:actual_duration_mins, :zero_duration)
     end
 
   end

--- a/spec/system/admin/manage_order_detail_spec.rb
+++ b/spec/system/admin/manage_order_detail_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe "Managing an order detail" do
       click_link "Update"
       fill_in "Actual Duration", with: "0"
       click_button "Save"
-      expect(page).to have_content("Actual duration must be at least 1 minute")
+      expect(page).to have_content("Actual duration must be greater than zero")
 
       # Confirm the reservation is still listed as a problem
       visit show_problems_facility_reservations_path(facility)

--- a/spec/system/editing_a_reservation_spec.rb
+++ b/spec/system/editing_a_reservation_spec.rb
@@ -298,5 +298,13 @@ RSpec.describe "Editing your own reservation" do
       expect(reservation.reload.reserve_start_at).to eq(new_start_at)
       expect(reservation.reload.duration_days).to eq(new_duration_days)
     end
+
+    it "cannot save a 0 day reservation" do
+      fill_in("Duration Days", with: 0)
+
+      click_button("Save")
+
+      expect(page).to have_content("Duration must be greater than zero")
+    end
   end
 end

--- a/spec/system/fixing_a_problem_reservation_spec.rb
+++ b/spec/system/fixing_a_problem_reservation_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Fixing a problem reservation" do
       visit edit_problem_reservation_path(reservation)
       fill_in "Actual Duration", with: "0"
       click_button "Save"
-      expect(page).to have_content("at least 1 minute")
+      expect(page).to have_content("must be greater than zero")
     end
 
     describe "when the product has available accessories" do

--- a/vendor/engines/secure_rooms/config/locales/en.yml
+++ b/vendor/engines/secure_rooms/config/locales/en.yml
@@ -89,6 +89,8 @@ en:
 
     errors:
       models:
+        secure_rooms/occupancy:
+          zero_minutes: must be at least 1 minute
         secure_rooms/card_reader:
           attributes:
             control_device_number:

--- a/vendor/engines/secure_rooms/spec/models/secure_rooms/occupancy_spec.rb
+++ b/vendor/engines/secure_rooms/spec/models/secure_rooms/occupancy_spec.rb
@@ -46,4 +46,35 @@ RSpec.describe SecureRooms::Occupancy do
       end
     end
   end
+
+  describe "duration validation" do
+    context "when it's positive" do
+      before do
+        occupancy.entry_at = 5.minutes.ago
+        occupancy.exit_at = 1.minute.ago
+      end
+
+      it "is valid" do
+        expect(occupancy.entry_at).to be < occupancy.exit_at
+        expect(occupancy).to be_valid
+      end
+    end
+
+    context "when it's zero" do
+      before do
+        allow(occupancy).to receive(:editing_time_data).and_return(true)
+        now = Time.current
+        occupancy.entry_at = now
+        occupancy.exit_at = now
+        occupancy.valid?
+      end
+
+      it "adds duration error" do
+        expect(occupancy.errors).to be_added(:actual_duration_mins, :zero_minutes)
+        expect(occupancy.errors[:actual_duration_mins]).to(
+          include("must be at least 1 minute")
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Note

- Refactor reservation non positive duration error message to be used for daily and normal booking
- Make secure rooms error not to depend in main app locale