### PR TITLE
[NUOPEN-5][Daily rate] Render calendar monthly events with offsets

### DIFF
--- a/app/assets/javascripts/app/calendar.js
+++ b/app/assets/javascripts/app/calendar.js
@@ -182,19 +182,20 @@ window.FullCalendarConfig = class FullCalendarConfig {
       endOfDay.add(1, 'day')
     }
 
-    let startOffset = event.start.diff(startOfDay, 'minutes');
+    let startOffsetMins = event.start.diff(startOfDay, 'minutes');
     if (!seg.isStart) {
       // Event started some row above
-      startOffset = 0;
+      startOffsetMins = 0;
     }
-    let endOffset = endOfDay.diff(event.end, 'minutes');
+    let endOffsetMins = endOfDay.diff(event.end, 'minutes');
     if (!seg.isEnd) {
       // Event ends some row below
-      endOffset = 0;
+      endOffsetMins = 0;
     }
 
-    let marginLeft = startOffset / 14.40; // 1440 minutes per day in percentage
-    let marginRight = endOffset / 14.40;
+    const minutesPerDay = 24 * 60;
+    let marginLeft = startOffsetMins / minutesPerDay * 100; // in percentage
+    let marginRight = endOffsetMins / minutesPerDay * 100;
 
     // Normalize margins relative to the amount of slots
     // in the segment

--- a/app/assets/javascripts/app/calendar.js
+++ b/app/assets/javascripts/app/calendar.js
@@ -37,16 +37,21 @@ window.FullCalendarConfig = class FullCalendarConfig {
   }
 
   baseOptions() {
+    var self = this;
+
     return {
       editable: false,
       defaultView: "agendaWeek",
       allDaySlot: false,
+      nextDayThreshold: '00:00:00',
       events: events_path,
-      loading: (isLoading, view) => {
+      loading: (isLoading, _view) => {
         return this.toggleOverlay(isLoading);
       },
-
-      eventAfterRender: this.buildTooltip,
+      eventAfterRender: function(event, element, view) {
+        self.buildTooltip(event, element, view);
+        self.adjustEvent(event, element, view);
+      },
       eventAfterAllRender: view => {
         this.$element.trigger("calendar:rendered");
         return this.toggleNextPrev(view);
@@ -140,5 +145,56 @@ window.FullCalendarConfig = class FullCalendarConfig {
 
   linkToEditOrder(event) {
     if ((event.orderId != null) && (typeof orders_path_base !== 'undefined' && orders_path_base !== null)) { return `<a href='${orders_path_base}/${event.orderId}'>Edit</a>`; }
+  }
+
+  /*
+   * Render monthly view events with margins
+   * depending on the start and end offset
+   * from midnight.
+   */
+  adjustEvent(event, element, view) {
+    // Don't apply changes unless monthly view
+    if (view.name != 'month') { return; }
+    // exclude allDay and background events
+    if (event['rendering'] == 'background' || event['allDay']) { return; }
+
+    let seg = $(element).data('fc-seg');
+    // if there's no info about the drawn event segment
+    // there's nothing to do
+    if (!seg) { return; }
+
+    // Don't add margins if event last less than a day
+    if (event.end.diff(event.start, 'days', true) < 1.0) { return; }
+
+    let startOfDay = event.start.clone();
+    startOfDay.startOf('day');
+    let endOfDay = event.end.clone();
+    endOfDay.endOf('day');
+
+    let startOffsetDiff = event.start.diff(startOfDay, 'minutes');
+    let startOffset = startOffsetDiff;
+    if (!seg.isStart) {
+      // Event started some row above
+      startOffset = 0;
+    }
+    let endOffset = endOfDay.diff(event.end, 'minutes');
+    // If startOffsetDiff is zero then reservation starts
+    // at begging of thay and it does not have end offset
+    if (!seg.isEnd || startOffsetDiff === 0) {
+      // Event ends some row below
+      endOffset = 0;
+    }
+
+    let marginLeft = startOffset / 14.40; // 1440 minutes per day in percentage
+    let marginRight = endOffset / 14.40;
+
+    let eventSegmentSlots = seg.rightCol - seg.leftCol + 1;
+
+    // A maximum of 7 days (calendar slots) in each row
+    marginLeft /= eventSegmentSlots;
+    marginRight /= eventSegmentSlots;
+
+    $(element).css('margin-left', marginLeft + "%");
+    $(element).css('margin-right', marginRight + "%");
   }
 };

--- a/app/assets/javascripts/app/calendar.js
+++ b/app/assets/javascripts/app/calendar.js
@@ -153,6 +153,10 @@ window.FullCalendarConfig = class FullCalendarConfig {
    * Render monthly view events with margins
    * depending on the start and end offset
    * from midnight.
+   *
+   * It's called once for each event segment:
+   * - Callback ref: https://fullcalendar.io/docs/v3/eventAfterRender
+   * - Segment object: https://fullcalendar.io/docs/v3/eventLimitClick#event-segment-object
    */
   adjustEvent(event, element, view) {
     // Do nothing if not daily booking

--- a/app/presenters/calendar_events_presenter.rb
+++ b/app/presenters/calendar_events_presenter.rb
@@ -22,7 +22,7 @@ class CalendarEventsPresenter
   end
 
   def events
-    events ||= reservation_events + unavailable_events
+    @events ||= reservation_events + unavailable_events
   end
 
   private

--- a/app/views/instruments/schedule.html.haml
+++ b/app/views/instruments/schedule.html.haml
@@ -14,6 +14,7 @@
 :javascript
   var events_path = "#{calendar_events_path(current_facility, @product, with_details: true)}";
   var orders_path_base = "#{facility_orders_path(current_facility)}";
+  var dailyBooking = #{@product.daily_booking?};
 
 %h2= @product
 

--- a/app/views/reservations/_js_variables.html.haml
+++ b/app/views/reservations/_js_variables.html.haml
@@ -14,3 +14,4 @@
   var instrumentOnline = #{@instrument.online?};
   var initialDate = "#{@reservation&.reserve_start_at&.iso8601}";
   var reserveInterval = #{@instrument.reserve_interval || 1};
+  var dailyBooking = #{@instrument.daily_booking?};


### PR DESCRIPTION
## Notes

Add event calendar render logic to make it more clear when daily booking reservations start and end during a day.
These changes are only applied if daily booking is set for the instrument.

- Add calendar render event logic to keep event block offsets depending on proportion of the day occupied.
- Used the `eventAfterRender` hook instead of `eventRender` because the former includes segment information which is useful when an event spans over multiple calendar lines.
- Render events whose duration is less than a day as small blocks (like the admin hold in the screenshot)
- Show dates on event tooltips

## Screenshot

<img width="878" alt="Captura de pantalla 2024-12-26 a la(s) 10 20 03" src="https://github.com/user-attachments/assets/2a9154ac-0bbe-42da-93d9-041e9a837494" />


