### PR TITLE
[NUOPEN-6][Daily rate] Show message when changing start_time_disable

### DIFF
--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -6,7 +6,7 @@ class InstrumentsController < ProductsCommonController
   admin_tab :create, :new, :edit, :index, :manage, :update, :manage, :schedule
   before_action :store_fullpath_in_session, only: [:index, :show]
   before_action :set_default_lock_window, only: [:create, :update]
-  after_action :update_schedule_rules, only: :update
+  after_action :start_time_disabled_changed_check, only: :update
 
   # public_schedule does not require login
   skip_before_action :authenticate_user!, only: [:public_schedule, :public_list]
@@ -104,10 +104,17 @@ class InstrumentsController < ProductsCommonController
     params
   end
 
-  def update_schedule_rules
-    return unless @product.start_time_disabled? && @product.start_time_disabled_previously_changed?
+  def start_time_disabled_changed_check
+    return unless @product.start_time_disabled_previously_changed?
 
-    @product.schedule_rules.update_all(ScheduleRule.full_day_attributes)
+    if @product.start_time_disabled?
+      @product.schedule_rules.update_all(
+        ScheduleRule.full_day_attributes
+      )
+      flash[:info] = t("controllers.instruments.create.schedule_rules_updated")
+    else
+      flash[:info] = t("controllers.instruments.create.schedule_rules_need_update")
+    end
   end
 
 end

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -83,6 +83,8 @@ en:
     instruments:
       create:
         daily_booking_not_authorized: "Not allowed to create daily booking instruments"
+        schedule_rules_updated: Start time disabled changed, Schedule Rules have been updated
+        schedule_rules_need_update: Start time disabled changed, please update schedule rules
 
     offline_reservations:
       bring_online:

--- a/spec/system/admin/editing_an_instrument_spec.rb
+++ b/spec/system/admin/editing_an_instrument_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe "Editing an instrument" do
       click_button("Save")
 
       expect(page).to have_content("Instrument was successfully updated")
+      expect(page).not_to have_content("Start time disabled changed")
+      expect(page).not_to have_css(".alert-info")
     end
 
     context "switching start_time_disabled on" do
@@ -52,6 +54,24 @@ RSpec.describe "Editing an instrument" do
         )
 
         expect(page).to have_content("Instrument was successfully updated")
+        within(".alert-info") do
+          expect(page).to have_content(I18n.t("controllers.instruments.create.schedule_rules_updated"))
+        end
+      end
+
+      it "shows info when switching off start_time_disabled" do
+        instrument.update(start_time_disabled: true)
+
+        visit edit_facility_instrument_path(facility, instrument)
+
+        uncheck("Start Time Disabled")
+
+        click_button("Save")
+
+        expect(page).to have_content("Instrument was successfully updated")
+        within(".alert-info") do
+          expect(page).to have_content(I18n.t("controllers.instruments.create.schedule_rules_need_update"))
+        end
       end
 
       it "enabling start_time_disabled does not affect old reservations" do


### PR DESCRIPTION
## Note

Add info message when an instrument's `start_time_disabled` is changed because schedule rules are affected.