### PR TITLE
[NU-2] Change admin hold calendar color

### DIFF
--- a/app/assets/stylesheets/calendar/fullcalendar.extensions.scss
+++ b/app/assets/stylesheets/calendar/fullcalendar.extensions.scss
@@ -1,7 +1,7 @@
 .unavailable,
 .fc-agenda .unavailable .fc-event-time,
 .unavailable a {
-  background-color: #DBDBDB;
+  background-color: #aaaaaa;
   border-color: #DBDBDB;
   color: #fff;
 }


### PR DESCRIPTION
# Release Notes

The color of the admin hold blocks in the calendar was quite light. Made it a little bit darker.

# Screenshot

Before:
![Screenshot 2024-12-30 at 1 34 36 PM](https://github.com/user-attachments/assets/61f677cf-3736-4f38-9add-7f7b6d006d10)

After:
![Screenshot 2024-12-30 at 1 35 18 PM](https://github.com/user-attachments/assets/cfa04890-7ba6-4fa3-9076-9ebf5893831f)
