### PR TITLE
[NUOPEN-5] Add option to move to prev or next month

### DIFF
--- a/app/assets/javascripts/instruments.js
+++ b/app/assets/javascripts/instruments.js
@@ -4,9 +4,13 @@ $(document).ready(function() {
 
   const header = { left: 'title', center: '', right: '' };
 
+  let defaultRightHeader = 'prev,next today';
+
   if (defaultView != 'month') {
-    header.right = 'prev,next today agendaDay,agendaWeek,month';
+    defaultRightHeader = `${defaultRightHeader} agendaDay,agendaWeek,month`;
   }
+
+  header.right = defaultRightHeader;
 
   new FullCalendarConfig(
     calendar, { header }


### PR DESCRIPTION
# Release Notes
* Make previous and next month buttons available in Month calendar view for Daily booking instruments.

# Screenshot
<img width="892" alt="image" src="https://github.com/user-attachments/assets/f27b1f10-8c54-47ff-8c1a-28c9832b8cba" />


