### PR TITLE
[OSU-114] Handle nil and default as the same sanger group

### DIFF
--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/sanger_product.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/sanger_product.rb
@@ -10,10 +10,11 @@ module SangerSequencing
     # sanger_sequencing_product_groups is too long of a table name for Oracle
     self.table_name = "sanger_seq_product_groups"
     GROUPS = WellPlateConfiguration::CONFIGS.keys
+    DEFAULT_GROUP = 'default'
 
     belongs_to :product
 
-    attribute :group, default: 'default'
+    attribute :group, default: DEFAULT_GROUP
 
     validates :group, presence: true, inclusion: { in: GROUPS }
     validates :product, presence: true, uniqueness: { case_sensitive: false }

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/sanger_product.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/sanger_product.rb
@@ -19,6 +19,13 @@ module SangerSequencing
     validates :group, presence: true, inclusion: { in: GROUPS }
     validates :product, presence: true, uniqueness: { case_sensitive: false }
 
+    def self.by_group(group)
+      where(group:)
+    end
+
+    def self.excluding_group(group)
+      where.not(group:)
+    end
   end
 
 end

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
@@ -35,7 +35,15 @@ module SangerSequencing
       if product_group.present?
         where(order_details: { product_id: SangerProduct.where(group: product_group).pluck(:product_id) })
       else
-        where.not(order_details: { product_id: SangerProduct.pluck(:product_id) })
+        # Absence of product_group is conceptually the same
+        # as having default group
+        where.not(
+          order_details: {
+            product_id: SangerProduct.where.not(
+              group: SangerProduct::DEFAULT_GROUP
+            ).pluck(:product_id),
+          }
+        )
       end
     end
 

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
@@ -32,15 +32,21 @@ module SangerSequencing
     }
 
     def self.for_product_group(product_group)
-      if product_group.present?
-        where(order_details: { product_id: SangerProduct.where(group: product_group).pluck(:product_id) })
-      else
+      if product_group.nil? || product_group == SangerProduct::DEFAULT_GROUP
         # Absence of product_group is conceptually the same
         # as having default group
         where.not(
           order_details: {
             product_id: SangerProduct.where.not(
               group: SangerProduct::DEFAULT_GROUP
+            ).pluck(:product_id),
+          }
+        )
+      else
+        where(
+          order_details: {
+            product_id: SangerProduct.where(
+              group: product_group
             ).pluck(:product_id),
           }
         )

--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
@@ -32,24 +32,16 @@ module SangerSequencing
     }
 
     def self.for_product_group(product_group)
-      if product_group.nil? || product_group == SangerProduct::DEFAULT_GROUP
-        # Absence of product_group is conceptually the same
+      product_group ||= SangerProduct::DEFAULT_GROUP
+
+      if product_group == SangerProduct::DEFAULT_GROUP
+        # Absence of SangerProduct is conceptually the same
         # as having default group
-        where.not(
-          order_details: {
-            product_id: SangerProduct.where.not(
-              group: SangerProduct::DEFAULT_GROUP
-            ).pluck(:product_id),
-          }
-        )
+        skip_products = SangerProduct.excluding_group(product_group).pluck(:product_id)
+        where.not(order_details: { product_id: skip_products })
       else
-        where(
-          order_details: {
-            product_id: SangerProduct.where(
-              group: product_group
-            ).pluck(:product_id),
-          }
-        )
+        include_products = SangerProduct.by_group(product_group).pluck(:product_id)
+        where(order_details: { product_id: include_products })
       end
     end
 

--- a/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/submission_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/submission_spec.rb
@@ -3,21 +3,71 @@
 require "rails_helper"
 
 RSpec.describe SangerSequencing::Submission do
-  let(:order_detail) { FactoryBot.build(:order_detail) }
-  let(:subject) { described_class.create!(order_detail: order_detail) }
+  context do
+    let(:order_detail) { build(:order_detail) }
+    let(:subject) { described_class.create!(order_detail:) }
 
-  it "can be created" do
-    expect(subject.order_detail).to eq(order_detail)
-  end
-
-  describe "#create_prefilled_sample" do
-    it "returns a sample" do
-      expect(subject.create_prefilled_sample).to be_kind_of(SangerSequencing::Sample)
+    it "can be created" do
+      expect(subject.order_detail).to eq(order_detail)
     end
 
-    it "sets customer_sample_id to the id of the sample padded and limitedto 4 places" do
-      sample = subject.create_prefilled_sample
-      expect(sample.customer_sample_id).to eq(("%04d" % sample.id).last(4))
+    describe "#create_prefilled_sample" do
+      it "returns a sample" do
+        expect(subject.create_prefilled_sample).to be_kind_of(SangerSequencing::Sample)
+      end
+
+      it "sets customer_sample_id to the id of the sample padded and limitedto 4 places" do
+        sample = subject.create_prefilled_sample
+        expect(sample.customer_sample_id).to eq(("%04d" % sample.id).last(4))
+      end
+    end
+  end
+
+  describe "#for_product_group" do
+    let(:facility) { create(:setup_facility) }
+    let(:user) { create(:user) }
+    let(:order) { create(:order, created_by: user.id, user:, state: :purchased) }
+
+    def has_group(group)
+      proc do |submission|
+        submission.order_detail.product.sanger_product&.group == group
+      end
+    end
+
+    before do
+      [nil, "default", "fragment"].each do |group|
+        product = create(:service, facility:)
+        product.create_sanger_product(group:) if group.present?
+        order_detail = create(:order_detail, product:, order:)
+        described_class.create(order_detail:)
+      end
+    end
+
+    context "when it's nil" do
+      it "returns submissions for nil and default groups" do
+        submissions = described_class.purchased.for_product_group(nil)
+
+        expect(submissions.count(&has_group(nil))).to eq 1
+        expect(submissions.count(&has_group("default"))).to eq 1
+      end
+    end
+
+    context "when default" do
+      it "returns submissions for nil and default groups" do
+        submissions_nil = described_class.purchased.for_product_group(nil)
+        submissions_default = described_class.purchased.for_product_group("default")
+
+        expect(submissions_nil.to_a).to eq(submissions_default.to_a)
+      end
+    end
+
+    context "when fragment" do
+      it "returns submissions for products in fragment group" do
+        submissions = described_class.purchased.for_product_group("fragment")
+
+        expect(submissions.count).to eq 1
+        expect(submissions.count(&has_group("fragment"))).to eq 1
+      end
     end
   end
 end

--- a/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/submission_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/submission_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe SangerSequencing::Submission do
-  context do
+  describe "create" do
     let(:order_detail) { build(:order_detail) }
     let(:subject) { described_class.create!(order_detail:) }
 


### PR DESCRIPTION
## Notes

The `SangerProduct` model does not exist for every sanger service, so for those the group will be nil which we should treat it as `default`.

This impacts which submissions are shown on the batch creation page.