### PR TITLE
[Fix] Include SangerProduct into Product

### DIFF
--- a/vendor/engines/sanger_sequencing/lib/sanger_sequencing/engine.rb
+++ b/vendor/engines/sanger_sequencing/lib/sanger_sequencing/engine.rb
@@ -15,7 +15,7 @@ module SangerSequencing
         "sanger_sequencing/admin/shared/tabnav_product/sanger"
       )
 
-      Service.include SangerSequencing::SangerEnabledProduct
+      Product.include SangerSequencing::SangerEnabledProduct
     end
 
     config.generators do |g|


### PR DESCRIPTION
## Note

Change which class include the module because it causes an error if there's other engine doing the same for Product. It's likely some loading issue related to STI. This solves OSU upstream merge failing specs.
