### PR TITLE
[Fix] Acting as error handling

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -179,7 +179,7 @@ class ApplicationController < ActionController::Base
   end
 
   def render_acting_error
-    render "error/acting_error", status: 403, layout: "application", formats: formats_with_html_fallback
+    render "errors/acting_error", status: 403, layout: "application", formats: formats_with_html_fallback
   end
 
 end

--- a/spec/requests/error_pages_spec.rb
+++ b/spec/requests/error_pages_spec.rb
@@ -14,4 +14,17 @@ RSpec.describe "error pages", :disable_requests_local do
 
     expect(response).to have_http_status(:not_acceptable)
   end
+
+  it "handles acting as error" do
+    allow_any_instance_of(FacilitiesController).to receive(:index).and_raise(
+      NUCore::NotPermittedWhileActingAs
+    )
+
+    get facilities_path
+
+    expect(response).to have_http_status(:forbidden)
+    expect(response.body).to include(
+      "This function is unavailable while you are acting as another user"
+    )
+  end
 end


### PR DESCRIPTION
## Notes

Acting as error handling is raising template not found error.