### PR TITLE
[Chore] Pin concurrent-ruby < 1.3.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,10 @@ gem "net-pop"
 gem "tzinfo-data"
 gem "webrick"
 
+# Remove once we upgrade to 7.2.X or greater
+# See: github.com/rails/rails/pull/54264
+gem "concurrent-ruby", "< 1.3.5"
+
 ## database
 gem "mysql2"
 # To use Oracle, remove the mysql2 gem above and uncomment these lines

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "net-pop"
 gem "tzinfo-data"
 gem "webrick"
 
-# Remove once we upgrade to 7.2.X or greater
+# Remove once we upgrade to rails 7.2.X or greater
 # See: github.com/rails/rails/pull/54264
 gem "concurrent-ruby", "< 1.3.5"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -724,6 +724,7 @@ DEPENDENCIES
   clockpunch
   coffee-rails
   coffeelint
+  concurrent-ruby (< 1.3.5)
   config
   daemons
   dataprobe!


### PR DESCRIPTION
## Notes

After concurrent-ruby update to 1.3.5 the "logger" module is not required and rails is raising an error. https://github.com/rails/rails/pull/54264.

Since dependabot is updating `concurrent-ruby` along other libraries we should pin it until we upgrade rails to the version that fixes this issue (which is not 7.0.X).