### PR TITLE
[Chore] Ignore rollbar errors handled by rails

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -17,7 +17,9 @@ if defined?(Rollbar)
       "AbstractController::ActionNotFound" => "ignore",
       "ActionController::UnknownFormat"    => "ignore",
       "ActionController::UnknownHttpMethod" => "ignore",
-      "ActionDispatch::Http::MimeNegotiation::InvalidType" => "ignore"
+      "ActionDispatch::Http::MimeNegotiation::InvalidType" => "ignore",
+      "CanCan::AccessDenied" => "ignore",
+      "NUCore::PermissionDenied" => "ignore"
     )
 
     # By default, Rollbar will try to call the `current_user` controller method


### PR DESCRIPTION
## Notes

These are handled by rollbar after we refactored error handling (they used to be catched before rollbar by application controller's rescue from)