### PR TITLE
[OSU-123] Fix batch group filtering

### DIFF
--- a/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
+++ b/vendor/engines/sanger_sequencing/app/models/sanger_sequencing/submission.rb
@@ -32,7 +32,7 @@ module SangerSequencing
     }
 
     def self.for_product_group(product_group)
-      product_group ||= SangerProduct::DEFAULT_GROUP
+      product_group = product_group.presence || SangerProduct::DEFAULT_GROUP
 
       if product_group == SangerProduct::DEFAULT_GROUP
         # Absence of SangerProduct is conceptually the same

--- a/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/shared/_sidenav.html.haml
+++ b/vendor/engines/sanger_sequencing/app/views/sanger_sequencing/admin/shared/_sidenav.html.haml
@@ -2,5 +2,5 @@
   - if SettingsHelper.feature_on?(:sanger_enabled_service)
     = tab text("sanger_sequencing.tabnav_manage_primers"), facility_sanger_sequencing_admin_primers_path(current_facility), sidenav_tab == "manage_primers"
   = tab SangerSequencing::Submission.model_name.human(count: 2), facility_sanger_sequencing_admin_submissions_path(current_facility), sidenav_tab == "submissions"
-  = tab text("sanger_sequencing.product_groups.default"), facility_sanger_sequencing_admin_batches_path(current_facility), sidenav_tab == "batches"
-  = tab text("sanger_sequencing.product_groups.fragment"), facility_sanger_sequencing_admin_batches_path(current_facility, group: "fragment"), sidenav_tab == "fragment_batches"
+  - SangerSequencing::SangerProduct::GROUPS.each do |product_group|
+    = tab text("sanger_sequencing.product_groups.#{product_group}"), facility_sanger_sequencing_admin_batches_path(current_facility, group: product_group), sidenav_tab == "#{product_group}_batches"

--- a/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/batch_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/batch_spec.rb
@@ -6,24 +6,26 @@ RSpec.describe SangerSequencing::Batch do
   describe ".for_product_group" do
     subject { described_class.for_product_group(group) }
 
-    before { FactoryBot.create(:product_group, :fragment) }
-    let!(:blank_batch) { FactoryBot.create(:sanger_sequencing_batch, group: "") }
-    let!(:nil_batch) { FactoryBot.create(:sanger_sequencing_batch, group: nil) }
-    let!(:grouped_batch) { FactoryBot.create(:sanger_sequencing_batch, group: "fragment") }
+    let!(:blank_batch) { create(:sanger_sequencing_batch, group: "") }
+    let!(:nil_batch) { create(:sanger_sequencing_batch, group: nil) }
+    let!(:default_group_batch) { create(:sanger_sequencing_batch, group: "default") }
+    let!(:fragment_group_batch) { create(:sanger_sequencing_batch, group: "fragment") }
+
+    before { create(:product_group, :fragment) }
 
     context "with group given as nil" do
       let(:group) { nil }
-      it { is_expected.to match_array [blank_batch, nil_batch] }
+      it { is_expected.to match_array [blank_batch, nil_batch, default_group_batch] }
     end
 
     context "with group given as empty string" do
       let(:group) { "" }
-      it { is_expected.to match_array [blank_batch, nil_batch] }
+      it { is_expected.to match_array [blank_batch, nil_batch, default_group_batch] }
     end
 
     context "with a group provided" do
       let(:group) { "fragment" }
-      it { is_expected.to match_array [grouped_batch] }
+      it { is_expected.to match_array [fragment_group_batch] }
     end
   end
 end

--- a/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/submission_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/models/sanger_sequencing/submission_spec.rb
@@ -52,6 +52,15 @@ RSpec.describe SangerSequencing::Submission do
       end
     end
 
+    context "when it's blank" do
+      it "returns submissions for nil and default groups" do
+        submissions = described_class.purchased.for_product_group('')
+
+        expect(submissions.count(&has_group(nil))).to eq 1
+        expect(submissions.count(&has_group("default"))).to eq 1
+      end
+    end
+
     context "when default" do
       it "returns submissions for nil and default groups" do
         submissions_nil = described_class.purchased.for_product_group(nil)


### PR DESCRIPTION
## Notes

- Use the same semantics as submissions group filtering, that is, nil or empty treated the same as default group
- In the Sanger navtab partial, render batch link for each group instead of hardcoding default and fragment groups links