### PR TITLE
[NUOPEN- 221][Shared dev] Show Actual duration days as days in Manage order modal

### DIFF
--- a/app/models/time_range.rb
+++ b/app/models/time_range.rb
@@ -30,7 +30,7 @@ class TimeRange
 
     seconds = end_at - start_at
 
-    seconds / 1.day
+    (seconds / 1.day)
   end
 
   private

--- a/app/support/reservations/date_support.rb
+++ b/app/support/reservations/date_support.rb
@@ -95,7 +95,7 @@ module Reservations::DateSupport
     if @actual_duration_days
       @actual_duration_days.to_i
     elsif actual_start_at
-      TimeRange.new(actual_start_at, actual_end_at || actual_end_fallback).duration_days
+      TimeRange.new(actual_start_at, actual_end_at || actual_end_fallback).duration_days.ceil
     else
       0
     end

--- a/app/views/order_management/order_details/_reservation.html.haml
+++ b/app/views/order_management/order_details/_reservation.html.haml
@@ -23,9 +23,14 @@
         .controls
           %label &nbsp;
           = time_select r, :actual_start, :minute_step => 1
-      - options = { class: "timeinput", data: { allow_init_blank: true }  }
-      - options[:value] = "" if r.object.actual_duration_mins == 0
-      = r.input :actual_duration_mins, input_html: options, error: false
+      - options = { data: { allow_init_blank: true }  }
+      - if reservation.product.daily_booking?
+        - options[:value] = "" if r.object.actual_duration_days == 0
+        = r.input :actual_duration_days, input_html: options, error: false
+      - else
+        - options[:value] = "" if r.object.actual_duration_mins == 0
+        - options[:class] = "timeinput"
+        = r.input :actual_duration_mins, input_html: options, error: false
       = render "copy_actuals_from_reservation", reservation: reservation
 
     - else

--- a/spec/system/admin/order_show_spec.rb
+++ b/spec/system/admin/order_show_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe "Order show" do
   let(:facility) { create(:setup_facility) }
-  let(:account) { create(:setup_account) }
+  let(:account) { create(:setup_account, facility:) }
   let!(:instrument) { create(:setup_instrument, :always_available, :daily_booking, facility:) }
   let(:reservation_order) { create(:setup_order, product: instrument, account:) }
   let!(:reservation) do
@@ -12,13 +12,17 @@ RSpec.describe "Order show" do
       :purchased_reservation,
       product: instrument,
       order_detail: reservation_order.order_details.first,
-      reserve_start_at: 1.day.from_now,
-      reserve_end_at: 4.days.from_now
+      reserve_start_at: 4.days.ago,
+      reserve_end_at: 1.day.ago,
+      actual_start_at: 4.days.ago,
+      actual_end_at: 1.day.ago
     )
   end
   let(:facility_administrator) { create(:user, :facility_administrator, facility:) }
 
   before do
+    order_detail = reservation_order.order_details.first
+    order_detail.complete!
     login_as facility_administrator
     visit facility_order_path(facility, reservation_order)
   end
@@ -33,7 +37,7 @@ RSpec.describe "Order show" do
   describe "reservation actual" do
     it "is correctly displayed in days" do
       # Actual is the fourth column
-      expect(all("tbody tr").first.all("td")[3]).to have_text("0", exact: true)
+      expect(all("tbody tr").first.all("td")[3]).to have_text("3", exact: true)
     end
   end
 
@@ -45,6 +49,7 @@ RSpec.describe "Order show" do
 
     it "shows the duration days field" do
       expect(page).to have_field("Duration Days", with: "3")
+      expect(page).to have_field("Actual duration days", with: "3")
     end
   end
 end


### PR DESCRIPTION
# Release Notes
* Show Actual duration days as days in Manage order modal

# Screenshot
<img width="1013" alt="image" src="https://github.com/user-attachments/assets/3470b8a0-48bb-4b3e-85eb-9560046bf57e" />
