### PR TITLE
[Fix] Spec depending on synaccess rev a relay selection

### DIFF
--- a/spec/system/admin/instrument_relay_tab_spec.rb
+++ b/spec/system/admin/instrument_relay_tab_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Instrument Relay Tab" do
+RSpec.describe "Instrument Relay Tab", feature_setting: { disable_relay_synaccess_rev_a: false } do
   let(:facility) { FactoryBot.create(:setup_facility) }
   let(:user) { FactoryBot.create(:user, :administrator) }
 


### PR DESCRIPTION
## Notes

Fix spec depending on relay of type Synaccess Rev A which can be disabled by a FF.