### PR TITLE
[NUOPEN-212] Update merge_describer

### DIFF
--- a/bin/merge_describer
+++ b/bin/merge_describer
@@ -9,20 +9,48 @@
 #
 # Compare your current branch to a tag:
 # bin/merge_describer v2024-06-18
+
+repo_url=https://github.com/wyeworks/nucore-open
+jira_base_url=https://universe-of-universities.atlassian.net/browse
 target_branch=${1:-master}
-git log $target_branch.. | egrep '\(#\d+\)$' | while read LINE; do
-  # $LINE looks like this:
-  # 4369    Move render to right td
-  # The PR number is the first part (4369)...
-  pr=$(echo $LINE | sed -E 's/^.+\(#//' | sed -E 's/\)$//' | cut -d' ' -f1)
-  # ... and the description is the rest (Move render to right td)
-  desc=$(echo "$LINE" | sed -E 's/ *\(#[0-9]+\)$//' | sed -E 's/[*]//' | cut -d' ' -f1-)
-  # Add a bullet point (*) and link to the PR, either in nucore-open or the current repo:
-  # * Move render to right td (https://github.com/wyeworks/nucore-open/pull/4369)
-  # If the PR number is greater than 4000, it's a nucore-open PR.
-  if [[ $pr -gt 4000 ]]; then
-    echo "* $desc (https://github.com/wyeworks/nucore-open/pull/$pr)"
-  else
-    echo "* $desc (#$pr)"
+
+pr_num() {
+  echo "$1" | grep -oE "\(#[0-9]+\)$" | tr -d "(#)"
+}
+
+jira_num() {
+  echo "$1" | grep -oE "\[[a-zA-Z]+-[0-9]+\]" | tr -d "[]"
+}
+
+commit_msg() {
+
+  echo "$1" | sed -E 's/ *\(#[0-9]+\)$//' | sed -E 's#^\[.*\]##' | sed 's/^ //'
+}
+
+git_log() {
+  # Only log the commit title
+  git log --pretty=format:"%s" $1..
+}
+
+git_log $target_branch | while read line; do
+  pr=$(pr_num "$line")
+
+  # If there's no matching PR number we skip the commit
+  if [ -z $pr ]; then
+    continue
   fi
-done | sort -n
+
+  ticket=$(jira_num "$line")
+
+  message=$(commit_msg "$line")
+
+  if [ ! -z $ticket ]; then
+    output="[[$ticket]]($jira_base_url/$ticket)"
+  else
+    output="*"
+  fi
+
+  output="$output $message [#$pr]($repo_url/pull/$pr)"
+
+  echo "$output"
+done | sort -r

--- a/bin/merge_describer
+++ b/bin/merge_describer
@@ -45,7 +45,7 @@ git_log $target_branch | while read line; do
   message=$(commit_msg "$line")
 
   if [ ! -z $ticket ]; then
-    output="[[$ticket]]($jira_base_url/$ticket)"
+    output="* [[$ticket]]($jira_base_url/$ticket)"
   else
     output="*"
   fi

--- a/bin/merge_describer
+++ b/bin/merge_describer
@@ -10,8 +10,7 @@
 # Compare your current branch to a tag:
 # bin/merge_describer v2024-06-18
 
-repo_url=https://github.com/wyeworks/nucore-open
-jira_base_url=https://universe-of-universities.atlassian.net/browse
+open_repo_url=https://github.com/wyeworks/nucore-open
 target_branch=${1:-master}
 
 pr_num() {
@@ -23,7 +22,6 @@ jira_num() {
 }
 
 commit_msg() {
-
   echo "$1" | sed -E 's/ *\(#[0-9]+\)$//' | sed -E 's#^\[.*\]##' | sed 's/^ //'
 }
 
@@ -45,12 +43,20 @@ git_log $target_branch | while read line; do
   message=$(commit_msg "$line")
 
   if [ ! -z $ticket ]; then
-    output="* [[$ticket]]($jira_base_url/$ticket)"
+    prefix="* [$ticket]"
   else
-    output="*"
+    prefix="*"
   fi
 
-  output="$output $message [#$pr]($repo_url/pull/$pr)"
+  # Add a a link to the PR, either in nucore-open or the current repo:
+  # If the PR number is greater than 4000, it's a nucore-open PR.
+  if [[ $pr -gt 4000 ]]; then
+    pr_ref="$open_repo_url/pull/$pr)"
+  else
+    pr_ref="(#$pr)"
+  fi
+
+  output="$prefix $message $pr_ref"
 
   echo "$output"
-done | sort -r
+done | sort


### PR DESCRIPTION
# Notes

- Update merge describer script to parse jira tickets and include jira links in the output

## Example from last upstream merge

* [[UMASS-175]](https://universe-of-universities.atlassian.net/browse/UMASS-175) Fix condition when ff on [#5071](https://github.com/wyeworks/nucore-open/pull/5071)
* [[UMASS-175]](https://universe-of-universities.atlassian.net/browse/UMASS-175) Allow Global Billing admins to update actual cost [#5062](https://github.com/wyeworks/nucore-open/pull/5062)
* [[NUOPEN-214]](https://universe-of-universities.atlassian.net/browse/NUOPEN-214) Remove `cross_core_projects` and `cross_core_order_view` [#5056](https://github.com/wyeworks/nucore-open/pull/5056)
* [[NU-19]](https://universe-of-universities.atlassian.net/browse/NU-19) Add flag to remove synaccess rev a relay option [#5060](https://github.com/wyeworks/nucore-open/pull/5060)
* Update sanger sequencing csv for alternative machine [#5034](https://github.com/wyeworks/nucore-open/pull/5034)
* Show Actual duration days as days in Manage order modal [#5044](https://github.com/wyeworks/nucore-open/pull/5044)
* Fix spec depending on synaccess rev a relay selection [#5070](https://github.com/wyeworks/nucore-open/pull/5070)
* Bump zeitwerk from 2.7.1 to 2.7.2 [#5037](https://github.com/wyeworks/nucore-open/pull/5037)
* Bump uri from 1.0.2 to 1.0.3 [#5058](https://github.com/wyeworks/nucore-open/pull/5058)
* Bump selenium-webdriver from 4.29.0 to 4.29.1 [#5052](https://github.com/wyeworks/nucore-open/pull/5052)
* Bump selenium-webdriver from 4.28.0 to 4.29.0 [#5042](https://github.com/wyeworks/nucore-open/pull/5042)
* Bump rubocop-rails from 2.30.1 to 2.30.2 [#5051](https://github.com/wyeworks/nucore-open/pull/5051)
* Bump rubocop-ast from 1.38.0 to 1.38.1 [#5053](https://github.com/wyeworks/nucore-open/pull/5053)
* Bump rubocop from 1.72.2 to 1.73.0 [#5059](https://github.com/wyeworks/nucore-open/pull/5059)
* Bump oj from 3.16.9 to 3.16.10 [#5049](https://github.com/wyeworks/nucore-open/pull/5049)
* Bump nokogiri from 1.18.2 to 1.18.3 [#5032](https://github.com/wyeworks/nucore-open/pull/5032)
* Bump mini_magick from 5.1.2 to 5.2.0 [#5048](https://github.com/wyeworks/nucore-open/pull/5048)
* Bump mime-types-data from 3.2025.0204 to 3.2025.0220 [#5039](https://github.com/wyeworks/nucore-open/pull/5039)
* Bump launchy from 3.1.0 to 3.1.1 [#5045](https://github.com/wyeworks/nucore-open/pull/5045)
* Bump haml_lint from 0.60.0 to 0.61.0 [#5050](https://github.com/wyeworks/nucore-open/pull/5050)
* Bump aws-sdk-s3 from 1.181.0 to 1.182.0 [#5038](https://github.com/wyeworks/nucore-open/pull/5038)
* Bump aws-sdk-kms from 1.98.0 to 1.99.0 [#5035](https://github.com/wyeworks/nucore-open/pull/5035)
* Bump aws-sdk-core from 3.218.1 to 3.219.0 [#5040](https://github.com/wyeworks/nucore-open/pull/5040)
* Bump aws-partitions from 1.1055.0 to 1.1056.0 [#5057](https://github.com/wyeworks/nucore-open/pull/5057)
* Bump aws-partitions from 1.1054.0 to 1.1055.0 [#5055](https://github.com/wyeworks/nucore-open/pull/5055)
* Bump aws-partitions from 1.1051.0 to 1.1053.0 [#5043](https://github.com/wyeworks/nucore-open/pull/5043)
* Bump akhileshns/heroku-deploy from 3.13.15 to 3.14.15 [#5047](https://github.com/wyeworks/nucore-open/pull/5047)