### PR TITLE
[NUOPEN-212] Project show flaky specs

### DIFF
--- a/spec/system/admin/projects_show_spec.rb
+++ b/spec/system/admin/projects_show_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Projects show" do
 
       it "navigates to order" do
         within("table.js--transactions-table") do
-          click_link active_project_order.id.to_s
+          find_link(href: facility_order_path(facility, active_project_order.id)).click
         end
 
         expect(page).to have_content(active_project_order.id.to_s)
@@ -91,7 +91,9 @@ RSpec.describe "Projects show" do
 
         it "navigates to original order" do
           within("table.js--transactions-table") do
-            click_link originating_order_facility1.id.to_s
+            find_link(
+              href: facility_order_path(facility, originating_order_facility1.id)
+            ).click
           end
 
           within("table#order-management") do
@@ -137,7 +139,7 @@ RSpec.describe "Projects show" do
 
         it "navigates to facility order" do
           within("table.js--transactions-table") do
-            click_link cross_core_orders[2].id.to_s
+            find_link(href: facility_order_path(facility, cross_core_orders[2].id)).click
           end
 
           within("table#order-management") do

--- a/spec/system/admin/projects_show_spec.rb
+++ b/spec/system/admin/projects_show_spec.rb
@@ -93,9 +93,10 @@ RSpec.describe "Projects show" do
           within("table.js--transactions-table") do
             click_link originating_order_facility1.id.to_s
           end
-        
 
-          expect(page).to have_content(originating_order_facility1.id.to_s)
+          within("table#order-management") do
+            expect(page).to have_content(originating_order_facility1.id.to_s)
+          end
           expect(page).to have_content(facility2.name)
           expect(page).to have_content(facility3.name)
         end
@@ -124,12 +125,14 @@ RSpec.describe "Projects show" do
           expect(page).not_to have_content(active_project_order.account.to_s)
         end
 
-        it "shows other facility's orders as text" do
-          expect(page).not_to have_link(originating_order_facility2.id.to_s)
-          expect(page).not_to have_link(cross_core_orders[3].id.to_s)
+        it "shows other facility's orders as text", :js do
+          within("table.js--transactions-table") do
+            expect(page).not_to have_link(originating_order_facility2.id.to_s)
+            expect(page).not_to have_link(cross_core_orders[3].id.to_s)
 
-          expect(page).to have_content(originating_order_facility2.id.to_s)
-          expect(page).to have_content(cross_core_orders[3].id.to_s)
+            expect(page).to have_content(originating_order_facility2.id.to_s)
+            expect(page).to have_content(cross_core_orders[3].id.to_s)
+          end
         end
 
         it "navigates to facility order" do
@@ -137,7 +140,10 @@ RSpec.describe "Projects show" do
             click_link cross_core_orders[2].id.to_s
           end
 
-          expect(page).to have_content(cross_core_orders[2].id.to_s)
+          within("table#order-management") do
+            expect(page).to have_content(cross_core_orders[2].id.to_s)
+          end
+
           expect(page).to have_content(facility2.name)
           expect(page).to have_content(facility3.name)
         end


### PR DESCRIPTION
## Note

- Fix some `project_show_spec` flaky tests that use record ids to match page content