### PR TITLE
[NUOPEN-219][Tech task] Fix links matching on project show spec

### DIFF
--- a/spec/system/admin/projects_show_spec.rb
+++ b/spec/system/admin/projects_show_spec.rb
@@ -74,11 +74,13 @@ RSpec.describe "Projects show" do
         end
 
         it "shows other facility's orders as text" do
-          expect(page).not_to have_link(cross_core_orders[0].id.to_s)
-          expect(page).not_to have_link(cross_core_orders[1].id.to_s)
+          expect(page).not_to have_link(facility_order_path(facility, cross_core_orders[0]))
+          expect(page).not_to have_link(facility_order_path(facility, cross_core_orders[1]))
 
-          expect(page).to have_content(cross_core_orders[0].id.to_s)
-          expect(page).to have_content(cross_core_orders[1].id.to_s)
+          within("table.js--transactions-table") do
+            expect(page).to have_content(cross_core_orders[0].id.to_s)
+            expect(page).to have_content(cross_core_orders[1].id.to_s)
+          end
         end
 
         it "shows Edit button" do
@@ -128,10 +130,10 @@ RSpec.describe "Projects show" do
         end
 
         it "shows other facility's orders as text", :js do
-          within("table.js--transactions-table") do
-            expect(page).not_to have_link(originating_order_facility2.id.to_s)
-            expect(page).not_to have_link(cross_core_orders[3].id.to_s)
+          expect(page).not_to have_link(facility_order_path(facility2, originating_order_facility2))
+          expect(page).not_to have_link(facility_order_path(facility, cross_core_orders[3]))
 
+          within("table.js--transactions-table") do
             expect(page).to have_content(originating_order_facility2.id.to_s)
             expect(page).to have_content(cross_core_orders[3].id.to_s)
           end


### PR DESCRIPTION
## Notes

More flaky spec fixes.
Match full path on links instead of just the link text.