### PR TITLE
[Chore] Run CI on PRs from forks

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - "**"
+  pull_request_target:
+    types:
+      - opened
 
 jobs:
   run-rspec-engines:


### PR DESCRIPTION
## Notes

- Add event on test workflow so we can run it for PRs created from forks.

Docs: https://docs.github.com/es/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target