### PR TITLE
[UMASS-133] Allow multiple recipients on product order notification

### DIFF
--- a/app/controllers/product_notifications_controller.rb
+++ b/app/controllers/product_notifications_controller.rb
@@ -35,7 +35,7 @@ class ProductNotificationsController < ApplicationController
   def notification_params
     params.require(:product).permit(
       :training_request_contacts,
-      :order_notification_recipient,
+      :order_notification_recipients,
       :cancellation_email_recipients,
       :issue_report_recipients,
     )

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -39,6 +39,7 @@ class Product < ApplicationRecord
   after_create :create_nonbillable_price_policy, if: :nonbillable_mode?
 
   email_list_attribute :training_request_contacts
+  email_list_attribute :order_notification_recipients
 
   # Allow us to use `product.hidden?`
   alias_attribute :hidden, :is_hidden
@@ -48,10 +49,6 @@ class Product < ApplicationRecord
   validate_url_name :url_name, :facility_id
   validates :user_notes_field_mode, presence: true, inclusion: Products::UserNoteMode.all
   validates :user_notes_label, length: { maximum: 255 }
-
-  validates :order_notification_recipient,
-            email_format: true,
-            allow_blank: true
 
   validates(
     :account,

--- a/app/views/product_notifications/edit.html.haml
+++ b/app/views/product_notifications/edit.html.haml
@@ -13,7 +13,7 @@
     - if SettingsHelper.feature_on?(:training_requests)
       = f.input :training_request_contacts, as: :string, hint: text("hints.training_request_contacts")
     - key = current_facility.order_notification_recipient.present? ? "hints.order_notification_with_facility" : "hints.order_notification"
-    = f.input :order_notification_recipient, as: :email, hint: text(key, email: current_facility.order_notification_recipient)
+    = f.input :order_notification_recipients, as: :string, hint: text(key, email: current_facility.order_notification_recipient)
     = f.input :cancellation_email_recipients, as: :string, hint: text("hints.cancellation_email_recipients") if @product.is_a?(Instrument)
     = f.input :issue_report_recipients, as: :string, hint: text("hints.issue_report_recipients") if @product.is_a?(Instrument)
 

--- a/app/views/product_notifications/show.html.haml
+++ b/app/views/product_notifications/show.html.haml
@@ -11,7 +11,7 @@
     - if SettingsHelper.feature_on?(:training_requests)
       = f.input :training_request_contacts, as: :string
     - hint = current_facility.order_notification_recipient.present? ? text("hints.already_configured", email: current_facility.order_notification_recipient) : nil
-    = f.input :order_notification_recipient, as: :email, hint: hint
+    = f.input :order_notification_recipients, as: :string, hint: hint
     - if @product.is_a?(Instrument)
       = f.input :cancellation_email_recipients, as: :string
 

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -289,7 +289,7 @@ en:
         email_purchasers_on_order_status_changes: Email purchasers when the status of an order changes?
         user_notes_label: Label for Notes Field
         training_request_contacts: Training Request Recipients
-        order_notification_recipient: Order Notification Recipient
+        order_notification_recipients: Order Notification Recipients
         cancellation_email_recipients: Cancellation Notification Recipients
         issue_report_recipients: Alternate Issue Report Recipients
       product_access_group:

--- a/config/locales/views/admin/en.product_notifications.yml
+++ b/config/locales/views/admin/en.product_notifications.yml
@@ -10,7 +10,7 @@ en:
         instructions: Leave blank to skip notifications for the event.
         hints:
           order_notification: |
-              This email address will be notified when an order is placed by a user.
+              Comma separated list of email addresses to be notified when an order is placed by a user.
           order_notification_with_facility: |
             !views.product_notifications.edit.hints.order_notification!
             !views.product_notifications.show.hints.already_configured!

--- a/db/migrate/20250326131059_change_product_order_notification_recipient.rb
+++ b/db/migrate/20250326131059_change_product_order_notification_recipient.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ChangeProductOrderNotificationRecipient < ActiveRecord::Migration[7.0]
+  def up
+    change_column :products, :order_notification_recipient, :string, limit: 1000
+    rename_column :products, :order_notification_recipient, :order_notification_recipients
+  end
+
+  def down
+    rename_column :products, :order_notification_recipients, :order_notification_recipient
+    change_column :products, :order_notification_recipient, :string, limit: 255
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_27_211156) do
+ActiveRecord::Schema[7.0].define(version: 2025_03_26_131059) do
   create_table "account_facility_joins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "facility_id", null: false
     t.integer "account_id", null: false
@@ -644,7 +644,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_27_211156) do
     t.string "dashboard_token"
     t.string "user_notes_field_mode", default: "hidden", null: false
     t.string "user_notes_label"
-    t.string "order_notification_recipient"
+    t.string "order_notification_recipients", limit: 1000
     t.text "cancellation_email_recipients"
     t.text "issue_report_recipients"
     t.boolean "email_purchasers_on_order_status_changes", default: false, null: false

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -454,16 +454,27 @@ RSpec.describe OrdersController do
         end
 
         context "when product has order_notification_recipients" do
-          let(:order_detail) { order.order_details.last }
-          let(:recipients) { ["u1@example.com", "u2@exmaple.com"] }
-
           before do
             @instrument.update(order_notification_recipients: recipients.join(", "))
           end
 
-          it "sends notification to recipients" do
-            # Send one mail to purchaser and two to the product order notification recipients
-            expect { do_request }.to change(ActionMailer::Base.deliveries, :count).by(3)
+          shared_examples "send notifications to recipients" do
+            it "sends notifications to all recipients" do
+              # Send one mail to purchaser and recipients.length to the product order notification recipients
+              expect { do_request }.to change(ActionMailer::Base.deliveries, :count).by(recipients.length + 1)
+            end
+          end
+
+          context "when there's a single recipient" do
+            let(:recipients) { ["u1@example.com"] }
+
+            include_examples "send notifications to recipients"
+          end
+
+          context "when there're multiple" do
+            let(:recipients) { ["u1@example.com", "u2@exmaple.com"] }
+
+            include_examples "send notifications to recipients"
           end
         end
 

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -453,6 +453,20 @@ RSpec.describe OrdersController do
           end
         end
 
+        context "when product has order_notification_recipients" do
+          let(:order_detail) { order.order_details.last }
+          let(:recipients) { ["u1@example.com", "u2@exmaple.com"] }
+
+          before do
+            @instrument.update(order_notification_recipients: recipients.join(", "))
+          end
+
+          it "sends notification to recipients" do
+            # Send one mail to purchaser and two to the product order notification recipients
+            expect { do_request }.to change(ActionMailer::Base.deliveries, :count).by(3)
+          end
+        end
+
         context "when ordering on behalf of (acting as)" do
           before { switch_to @staff }
 

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -778,5 +778,17 @@ RSpec.describe Product do
 
       expect(product.order_notification_recipients.to_a).to eq(emails)
     end
+
+    it "validates a single email" do
+      product.order_notification_recipients = "user"
+      expect(product).to_not be_valid
+      expect(product.errors).to include("order_notification_recipients")
+    end
+
+    it "detects if any email is invalid" do
+      product.order_notification_recipients = "user1@example.com, user2@, user3@example.com"
+      expect(product).to_not be_valid
+      expect(product.errors).to include("order_notification_recipients")
+    end
   end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -761,4 +761,22 @@ RSpec.describe Product do
       expect(product.start_time_disabled).to be true
     end
   end
+
+  describe "order_notification_recipients" do
+    let(:product) { create(:setup_instrument) }
+
+    it "can provide a single email" do
+      email = "u1@example.com"
+      product.update(order_notification_recipients: email)
+
+      expect(product.order_notification_recipients.to_a).to eq([email])
+    end
+
+    it "can provide multiple emails" do
+      emails = ["u1@example.com", "u2@example.com"]
+      product.update(order_notification_recipients: emails.join(", "))
+
+      expect(product.order_notification_recipients.to_a).to eq(emails)
+    end
+  end
 end

--- a/spec/system/admin/product_notifications_controller_spec.rb
+++ b/spec/system/admin/product_notifications_controller_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe ProductNotificationsController, feature_setting: { training_reque
       click_link "Notifications"
       click_link "Edit"
 
-      fill_in "Order Notification Recipient", with: "user1@example.com"
+      fill_in "Order Notification Recipients", with: "user1@example.com"
       fill_in "Cancellation Notification Recipients", with: "user2@example.com, user3@example.com"
       fill_in "Training Request Recipients", with: "user4@example.com, user5@example.com"
       click_button "Save"
 
-      expect(page).to have_content("Order Notification Recipient\nuser1@example.com")
+      expect(page).to have_content("Order Notification Recipients\nuser1@example.com")
       expect(page).to have_content("Cancellation Notification Recipients\nuser2@example.com, user3@example.com")
       expect(page).to have_content("Training Request Recipients\nuser4@example.com, user5@example.com")
     end

--- a/spec/system/admin/product_notifications_controller_spec.rb
+++ b/spec/system/admin/product_notifications_controller_spec.rb
@@ -4,10 +4,10 @@ require "rails_helper"
 
 RSpec.describe ProductNotificationsController, feature_setting: { training_requests: true, reload_routes: true } do
   let(:facility) { create(:setup_facility) }
-  let!(:instrument) { create(:instrument, facility: facility) }
+  let!(:instrument) { create(:instrument, facility:) }
 
   describe "as a facility director" do
-    before { login_as create(:user, :facility_director, facility: facility) }
+    before { login_as create(:user, :facility_director, facility:) }
 
     it "can update the fields" do
       visit facility_instruments_path(facility)
@@ -15,7 +15,7 @@ RSpec.describe ProductNotificationsController, feature_setting: { training_reque
       click_link "Notifications"
       click_link "Edit"
 
-      fill_in "Order Notification Recipients", with: "user1@example.com"
+      fill_in "Order Notification Recipients", with: "user1@example.com, user@example.com"
       fill_in "Cancellation Notification Recipients", with: "user2@example.com, user3@example.com"
       fill_in "Training Request Recipients", with: "user4@example.com, user5@example.com"
       click_button "Save"
@@ -27,7 +27,7 @@ RSpec.describe ProductNotificationsController, feature_setting: { training_reque
   end
 
   describe "as facility senior staff" do
-    before { login_as create(:user, :senior_staff, facility: facility) }
+    before { login_as create(:user, :senior_staff, facility:) }
 
     it "does not see the edit button" do
       visit facility_instruments_path(facility)


### PR DESCRIPTION
## Notes

- Allow to specify a list of recipients on product order notification
- Rename `order_product_recipient` field to plural and extend its limit

