### PR TITLE
[Fix] Change test-suite workflow trigger events

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -4,8 +4,8 @@ name: Run test suite
 on:
   push:
     branches:
-      - "**"
-  pull_request_target:
+      - "master"
+  pull_request:
 
 jobs:
   run-rspec-engines:


### PR DESCRIPTION
## Notes

- Change test-suite workflow events because it was triggering two workflow runs for pushes to existing pull requests.
- Remove event `pull_request_target` because it runs in the context of the main branch, which seems to imply that nothing from the pull request branch gets tested
- In order to be able to run a single workflow for the repo collaborators and fork pull request I changed test-suite to only run for the `pull_request` event and for pushes to `master` so the staging deployment works.