### PR TITLE
[UMASS-167] Show reconciliation note

### DIFF
--- a/app/assets/stylesheets/app/statements.scss
+++ b/app/assets/stylesheets/app/statements.scss
@@ -1,0 +1,8 @@
+.statement {
+  &__nowrap-text {
+    white-space: nowrap;
+    max-width: 150px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -40,6 +40,7 @@ $secondaryColor: #005B8A;
 @import "app/kiosk";
 @import "app/user_accounts";
 @import "app/quick_reservation";
+@import "app/statements";
 
 @import "fine-uploader/fine-uploader-new";
 @import "fine-uploader-override";

--- a/app/controllers/facility_statements_controller.rb
+++ b/app/controllers/facility_statements_controller.rb
@@ -24,10 +24,10 @@ class FacilityStatementsController < ApplicationController
 
   # GET /facilities/:facility_id/statements
   def index
-    search_params = permitted_search_params.merge(current_facility: current_facility)
+    search_params = permitted_search_params.merge(current_facility:)
 
     @search_form = StatementSearchForm.new(search_params)
-    @statements = @search_form.search.order(created_at: :desc)
+    @statements = @search_form.search.order(created_at: :desc).includes(:closed_events, :order_details)
 
     respond_to do |format|
       format.html { @statements = @statements.paginate(page: params[:page]) }
@@ -49,7 +49,7 @@ class FacilityStatementsController < ApplicationController
     @order_detail_action = :create
 
     defaults = SettingsHelper.feature_on?(:set_statement_search_start_date) ? { date_range_start: format_usa_date(1.month.ago.beginning_of_month) } : {}
-    @search_form = TransactionSearch::SearchForm.new(params[:search], defaults: defaults)
+    @search_form = TransactionSearch::SearchForm.new(params[:search], defaults:)
     @search = TransactionSearch::Searcher.billing_search(order_details, @search_form, include_facilities: current_facility.cross_facility?)
     @date_range_field = @search_form.date_params[:field]
     @order_details = @search.order_details.reorder(sort_clause)
@@ -57,7 +57,7 @@ class FacilityStatementsController < ApplicationController
 
   # POST /facilities/:facility_id/statements
   def create
-    @statement_creator = StatementCreator.new(order_detail_ids: params[:order_detail_ids], session_user: session_user, current_facility: current_facility)
+    @statement_creator = StatementCreator.new(order_detail_ids: params[:order_detail_ids], session_user:, current_facility:)
 
     if @statement_creator.order_detail_ids.blank?
       flash[:error] = text("no_selection")

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -32,7 +32,7 @@ class Statement < ApplicationRecord
   scope :unrecoverable, -> { where(canceled_at: nil).where(id: OrderDetail.unrecoverable.where.not(statement_id: nil).select(:statement_id)) }
 
   # Use this for restricting the the current facility
-  scope :for_facility, ->(facility) { where(facility: facility) if facility.single_facility? }
+  scope :for_facility, ->(facility) { where(facility:) if facility.single_facility? }
   # Use this for restricting based on search parameters
   scope :for_facilities, ->(facilities) { where(facility: facilities) if facilities.present? }
 
@@ -46,7 +46,7 @@ class Statement < ApplicationRecord
 
   def self.find_by_statement_id(query)
     return nil unless /\A(?<id>\d+)\z/ =~ query
-    find_by(id: id)
+    find_by(id:)
   end
 
   def self.find_by_invoice_number(query)
@@ -77,13 +77,13 @@ class Statement < ApplicationRecord
 
   def status
     if canceled_at
-      "Canceled"
+      :canceled
     elsif reconciled?
-      "Reconciled"
+      :reconciled
     elsif unrecoverable?
-      "Unrecoverable"
+      :unrecoverable
     else
-      "Unreconciled"
+      :unreconciled
     end
   end
 
@@ -92,7 +92,7 @@ class Statement < ApplicationRecord
   end
 
   def add_order_detail(order_detail)
-    statement_rows << StatementRow.new(order_detail: order_detail)
+    statement_rows << StatementRow.new(order_detail:)
     order_details << order_detail
   end
 
@@ -117,9 +117,9 @@ class Statement < ApplicationRecord
   def send_emails
     account.notify_users.each do |user|
         Notifier.statement(
-          user: user,
-          facility: facility,
-          account: account,
+          user:,
+          facility:,
+          account:,
           statement: self
         ).deliver_later
     end
@@ -131,7 +131,7 @@ class Statement < ApplicationRecord
 
   def cross_core_order_details_from_other_facilities
     cross_core_order_details
-      .where.not(projects: { facility: facility})
+      .where.not(projects: { facility: })
   end
 
   def display_cross_core_messsage?

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -6,6 +6,11 @@ class Statement < ApplicationRecord
   has_many :statement_rows, dependent: :destroy
   has_many :payments, inverse_of: :statement
 
+  has_many :closed_events,
+           -> { where(event_type: "closed") },
+           class_name: "LogEvent",
+           as: :loggable
+
   belongs_to :account
   belongs_to :facility
   belongs_to :created_by_user, class_name: "User", foreign_key: :created_by
@@ -55,7 +60,11 @@ class Statement < ApplicationRecord
 
   def self.where_invoice_number(query)
     return none unless /\A(?<account_id>\d+)-(?<id>\d+)\z/ =~ query
-    where(id: id, account_id: account_id)
+    where(id:, account_id:)
+  end
+
+  def order_details_notes(note_field)
+    order_details.filter_map { |od| od.send(note_field) }.uniq
   end
 
   def invoice_date

--- a/app/presenters/statement_presenter.rb
+++ b/app/presenters/statement_presenter.rb
@@ -28,15 +28,19 @@ class StatementPresenter < SimpleDelegator
   end
 
   def closed_by_user_full_names
-    closed_events.map { |event| event.user.full_name }.join("\n")
+    closed_events.map { |event| event.user.full_name }
   end
 
   def closed_by_times
-    closed_events.map { |event| format_usa_datetime(event.event_time) }.join("\n")
+    closed_events.map { |event| format_usa_datetime(event.event_time) }
   end
 
-  def closed_events
-    @closed_events ||= LogEvent.where(loggable_type: "Statement", loggable_id: id, event_type: "closed")
+  def reconcile_notes
+    @reconcile_notes ||= if status == :reconciled
+                           order_details_notes(:reconciled_note)
+                         elsif status == :unrecoverable
+                           order_details_notes(:unrecoverable_note)
+                         end
   end
 
 end

--- a/app/views/facility_statements/index.html.haml
+++ b/app/views/facility_statements/index.html.haml
@@ -24,4 +24,5 @@
 
 - if @statements.any?
   = link_to t("reports.account_transactions.export"), url_for(format: :csv), class: "js--exportSearchResults pull-right", data: { form: ".search_form" }
-= render partial: "shared/statements_table", locals: { show_cancel_button: true }
+= render partial: "shared/statements_table",
+  locals: { show_cancel_button: true, show_reconcile_notes: SettingsHelper.feature_on?(:show_statement_reconcile_notes)  }

--- a/app/views/shared/_statements_table.html.haml
+++ b/app/views/shared/_statements_table.html.haml
@@ -1,3 +1,4 @@
+- show_reconcile_notes = local_assigns[:show_reconcile_notes]
 - if @statements.empty?
   %p.notice= text("no_statements")
 - else
@@ -18,7 +19,7 @@
         %th= Statement.human_attribute_name(:status)
     %tbody
       - StatementPresenter.wrap(@statements).each do |s|
-        %tr
+        %tr.statement
           %td.centered
             = "##{s.invoice_number}"
             - unless s.canceled_at
@@ -51,8 +52,29 @@
             %td= s.facility.name
           %td.currency= s.order_details.count
           %td.currency= number_to_currency(s.total_cost)
-          %td= s.closed_by_times
-          %td= s.closed_by_user_full_names
-          %td= s.status
+          %td
+            %ul.unstyled
+              - s.closed_by_times.each do |closed_by_time|
+                %li.statement__nowrap-text= closed_by_time
+          %td
+            %ul.unstyled
+              - s.closed_by_user_full_names.each do |closed_by_name|
+                %li.statement__nowrap-text= closed_by_name
+          %td
+            %div
+              %span= Statement.human_attribute_name("status.#{s.status}")
+            - if show_reconcile_notes && s.reconcile_notes.present?
+              %div
+                %small
+                  %strong= "#{t('statements.notes')}:"
+              %small= s.reconcile_notes.shift
+              %ul.unstyled.collapse{ id: "statement-notes-#{s.id}" }
+                - s.reconcile_notes.each do |note|
+                  %li
+                    %small= note
+              - if s.reconcile_notes.length > 0
+                %a{ role: "button", href: "#statement-notes-#{s.id}", data: { toggle: "collapse", target: "#statement-notes-#{s.id}" } }
+                  %small= t("statements.expand")
+
 
   = will_paginate(@statements)

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -427,6 +427,11 @@ en:
         reconcile_note: Reconcile Note
         account_admins: Account Admins
         total_cost: Total
+      statement/status:
+        canceled: Canceled
+        reconciled: Reconciled
+        unrecoverable: Unrecoverable
+        unreconciled: Unreconciled
       account:
         account_number: Account Number
         display_status: Status

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -710,6 +710,8 @@ en:
     cancel: Cancel
     closed_at: Closed At
     closed_by: Closed By
+    notes: Notes
+    expand: Expand
 
   orders:
     add_account:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -167,6 +167,7 @@ feature:
   export_order_disputes: false
   show_unrecoverable_note: false
   show_estimates_option: <%= !Rails.env.production? %>
+  show_statement_reconcile_notes: false
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/spec/system/admin/facility_statements_spec.rb
+++ b/spec/system/admin/facility_statements_spec.rb
@@ -130,7 +130,6 @@ RSpec.describe "Facility Statement Admin" do
 
       order_details.first.update(reconciled_note: "Some note #123")
       order_details.map do |od|
-        # od.touch(:reconciled_at)
         od.update(state: :reconciled)
       end
     end

--- a/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
+++ b/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Account Reconciliation", :js, feature_setting: { show_unrecovera
 
       # ensure the closed by times show up on the statement history page
       click_link "#{I18n.t('Statement')} History"
-      expect(page).to have_content(statement.closed_by_times)
+      expect(page).to have_content(statement.closed_by_times.first)
     end
 
     context "with bulk reconciliation note" do
@@ -232,7 +232,7 @@ RSpec.describe "Account Reconciliation", :js, feature_setting: { show_unrecovera
 
       # ensure the closed by times show up on the statement history page
       click_link "#{I18n.t('Statement')} History"
-      expect(page).to have_content(statement.closed_by_times)
+      expect(page).to have_content(statement.closed_by_times.first)
     end
 
     it "can take a bulk reconciliation note" do


### PR DESCRIPTION
## Notes

- Show reconciled_notes/unrecoverable_notes on statement table

> Note: it depends on changes from #5159 

### Other changes

- Render one log event per line and truncate long user names

## Screenshot

![Captura de pantalla 2025-04-07 a la(s) 13 41 19](https://github.com/user-attachments/assets/8c60a710-b38b-4bc8-ba93-3eb06bf65ea5)
