### PR TITLE
[FIX] Replace uglifier by terser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,6 @@ gem "paranoia"
 ## views
 gem "sass-rails"
 gem "coffee-rails"
-gem "uglifier"
 gem "bootstrap-sass", "~> 2.3.2" # will not upgrade
 gem "haml"
 gem "will_paginate"
@@ -156,3 +155,5 @@ group :stage, :production do
   gem "unicorn", require: false
   gem "whenever", require: false
 end
+
+gem "terser", "~> 1.2"

--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem "paranoia"
 ## views
 gem "sass-rails"
 gem "coffee-rails"
-gem "uglifier", "= 4.1.18" # 4.1.19 has an issue https://github.com/mishoo/UglifyJS2/issues/3245
+gem "uglifier"
 gem "bootstrap-sass", "~> 2.3.2" # will not upgrade
 gem "haml"
 gem "will_paginate"

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem "paranoia"
 gem "sass-rails"
 gem "coffee-rails"
 gem "bootstrap-sass", "~> 2.3.2" # will not upgrade
+gem "terser", "~> 1.2"
 gem "haml"
 gem "will_paginate"
 # TODO: Remove dynamic_form and use Rails to display errors
@@ -155,5 +156,3 @@ group :stage, :production do
   gem "unicorn", require: false
   gem "whenever", require: false
 end
-
-gem "terser", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -673,7 +673,7 @@ GEM
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2025.2)
       tzinfo (>= 1.0.0)
-    uglifier (4.1.18)
+    uglifier (4.2.1)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
@@ -817,7 +817,7 @@ DEPENDENCIES
   teaspoon-jasmine
   text_helpers
   tzinfo-data
-  uglifier (= 4.1.18)
+  uglifier
   unicorn
   vuejs-rails (~> 1.0.26)
   web-console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -658,6 +658,8 @@ GEM
     temple (0.10.3)
     terrapin (1.1.0)
       climate_control
+    terser (1.2.5)
+      execjs (>= 0.3.0, < 3)
     text_helpers (1.2.0)
       activesupport
       i18n (>= 0.6.8)
@@ -673,8 +675,6 @@ GEM
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2025.2)
       tzinfo (>= 1.0.0)
-    uglifier (4.2.1)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -815,9 +815,9 @@ DEPENDENCIES
   sprockets-rails
   synaccess_connect
   teaspoon-jasmine
+  terser (~> 1.2)
   text_helpers
   tzinfo-data
-  uglifier
   unicorn
   vuejs-rails (~> 1.0.26)
   web-console

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(harmony: true)
+  config.assets.js_compressor = :terser
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/config/initializers/uglifier_restriction.rb
+++ b/config/initializers/uglifier_restriction.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-unless Uglifier::VERSION == "4.1.18"
-  raise "Uglifier 4.1.19 has a bug (https://github.com/mishoo/UglifyJS2/issues/3245).
-  Please ensure it's fixed before advancing"
-end


### PR DESCRIPTION
## Note

- Uglifier, which is configured on staging and production, was failing to compress javascript code with ES6 syntax.