### PR TITLE
[NUOPEN-225] List and show estimates

### DIFF
--- a/app/controllers/facility_estimates_controller.rb
+++ b/app/controllers/facility_estimates_controller.rb
@@ -13,6 +13,9 @@ class FacilityEstimatesController < ApplicationController
   before_action :set_users, only: [:search]
 
   def index
+    @estimates = current_facility.estimates
+                                 .includes(:user)
+                                 .order(created_at: :desc)
   end
 
   def show

--- a/app/views/facility_estimates/index.html.haml
+++ b/app/views/facility_estimates/index.html.haml
@@ -4,3 +4,21 @@
 
 - if current_ability.can?(:create, Estimate)
   %p= link_to t(".add"), new_facility_estimate_path, class: "btn-add"
+
+- if @estimates.present?
+  %table.table.table-striped.table-hover
+    %thead
+      %tr
+        %th= Estimate.human_attribute_name(:id)
+        %th= Estimate.human_attribute_name(:name)
+        %th= Estimate.human_attribute_name(:user)
+        %th= Estimate.human_attribute_name(:expires_at)
+    %tbody
+      - @estimates.each do |estimate|
+        %tr
+          %td= link_to estimate.id, facility_estimate_path(current_facility, estimate)
+          %td= estimate.name
+          %td= estimate.user.full_name
+          %td= format_usa_date(estimate.expires_at)
+- else
+  %p.notice= t(".no_estimates")

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -249,7 +249,7 @@ en:
         name: Name
         user: User
         created_by_user: Created By
-        expires_at: Expiration Date
+        expires_at: Expires at
         note: Notes
       schedule_rule:
         start_time: Start Time

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -245,6 +245,12 @@ en:
         user_role: Role
       affiliate:
         subaffiliates_enabled: Allows subaffiliates
+      estimate:
+        name: Name
+        user: User
+        created_by_user: Created By
+        expires_at: Expiration Date
+        note: Notes
       schedule_rule:
         start_time: Start Time
         end_time: End Time

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -518,6 +518,7 @@ en:
   facility_estimates:
     index:
       add: Add Estimate
+      no_estimates: No estimates found
     create:
       success: Estimate successfully created
       error: There was an error creating the estimate

--- a/spec/factories/estimates.rb
+++ b/spec/factories/estimates.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :estimate do
+    facility
+    user
+    association :created_by_user, factory: :user
+    name { "Test Estimate" }
+    note { "This is a test estimate" }
+    expires_at { 30.days.from_now }
+  end
+end

--- a/spec/system/admin/viewing_estimates_spec.rb
+++ b/spec/system/admin/viewing_estimates_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Viewing estimates", :disable_requests_local do
+  let(:facility) { create(:setup_facility) }
+  let(:director) { create(:user, :facility_director, facility:) }
+  let(:admin) { create(:user, :facility_administrator, facility:) }
+  let(:billing_admin) { create(:user, :global_billing_administrator) }
+  let(:senior_staff) { create(:user, :senior_staff, facility:) }
+  let(:staff) { create(:user, :staff, facility:) }
+  let(:regular_user) { create(:user) }
+  
+  let!(:estimate1) { create(:estimate, facility:, name: "First Estimate", created_at: 2.days.ago) }
+  let!(:estimate2) { create(:estimate, facility:, name: "Second Estimate", created_at: 1.day.ago) }
+
+  context "viewing index page" do
+    context "as authorized roles" do
+      shared_examples "can view the estimates index and details" do
+        it "displays the list of estimates in order" do
+          visit facility_estimates_path(facility)
+          
+          expect(page).to have_selector("#admin_estimates_tab")
+          expect(page).to have_content "Second Estimate"
+          expect(page).to have_content "First Estimate"
+          
+          # Newest first
+          expect(page.body.index("Second Estimate")).to be < page.body.index("First Estimate")
+
+          click_link estimate1.id
+          
+          expect(page).to have_content "Estimate ##{estimate1.id}"
+          expect(page).to have_content estimate1.name
+          expect(page).to have_content estimate1.user.full_name
+          expect(page).to have_content estimate1.created_by_user.full_name
+          expect(page).to have_content estimate1.note
+          expect(page).to have_content I18n.l(estimate1.expires_at.to_date, format: :usa)
+        end
+      end
+
+      context "as facility director" do
+        before { login_as director }
+        include_examples "can view the estimates index and details"
+      end
+
+      context "as facility administrator" do
+        before { login_as admin }
+        include_examples "can view the estimates index and details"
+      end
+
+      context "as global billing admin" do
+        before { login_as billing_admin }
+        include_examples "can view the estimates index and details"
+      end
+    end
+
+    context "as unauthorized roles" do
+      shared_examples "cannot view the estimates index" do
+        it "denies access to the estimates page" do
+          visit facility_estimates_path(facility)
+          expect(page).to have_content "403 – Permission Denied"
+          expect(page).to have_content "Sorry, you don't have permission to access this page."
+        end
+      end
+
+      context "as facility senior staff" do
+        before { login_as senior_staff }
+        include_examples "cannot view the estimates index"
+      end
+
+      context "as facility staff" do
+        before { login_as staff }
+        include_examples "cannot view the estimates index"
+      end
+
+      context "as regular user" do
+        before { login_as regular_user }
+        include_examples "cannot view the estimates index"
+      end
+    end
+  end
+
+  context "viewing show page" do
+    context "as unauthorized roles" do
+      shared_examples "cannot view the estimate details" do
+        it "denies access to the estimate details" do
+          visit facility_estimate_path(facility, estimate1)
+          expect(page).to have_content "403 – Permission Denied"
+          expect(page).to have_content "Sorry, you don't have permission to access this page."
+        end
+      end
+
+      context "as facility senior staff" do
+        before { login_as senior_staff }
+        include_examples "cannot view the estimate details"
+      end
+
+      context "as facility staff" do
+        before { login_as staff }
+        include_examples "cannot view the estimate details"
+      end
+
+      context "as regular user" do
+        before { login_as regular_user }
+        include_examples "cannot view the estimate details"
+      end
+    end
+  end
+end

--- a/spec/system/admin/viewing_estimates_spec.rb
+++ b/spec/system/admin/viewing_estimates_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Viewing estimates", :disable_requests_local do
   let(:senior_staff) { create(:user, :senior_staff, facility:) }
   let(:staff) { create(:user, :staff, facility:) }
   let(:regular_user) { create(:user) }
-  
+
   let!(:estimate1) { create(:estimate, facility:, name: "First Estimate", created_at: 2.days.ago) }
   let!(:estimate2) { create(:estimate, facility:, name: "Second Estimate", created_at: 1.day.ago) }
 
@@ -19,16 +19,16 @@ RSpec.describe "Viewing estimates", :disable_requests_local do
       shared_examples "can view the estimates index and details" do
         it "displays the list of estimates in order" do
           visit facility_estimates_path(facility)
-          
+
           expect(page).to have_selector("#admin_estimates_tab")
           expect(page).to have_content "Second Estimate"
           expect(page).to have_content "First Estimate"
-          
+
           # Newest first
           expect(page.body.index("Second Estimate")).to be < page.body.index("First Estimate")
 
           click_link estimate1.id
-          
+
           expect(page).to have_content "Estimate ##{estimate1.id}"
           expect(page).to have_content estimate1.name
           expect(page).to have_content estimate1.user.full_name


### PR DESCRIPTION
# Release Notes

Add a page that lists the user's estimates and shows the estimate details when clicking on one of them.

# Screenshot

![Screenshot 2025-04-14 at 11 15 42 AM](https://github.com/user-attachments/assets/51943f49-2e9c-4d46-9e82-8c7f42d4a39c)
