### PR TITLE
[NUOPEN-58] Clear trailing whitespaces

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -531,12 +531,6 @@ Layout/TrailingEmptyLines:
     - 'app/models/research_safety_certificate.rb'
     - 'spec/models/concerns/downloadable_file_spec.rb'
 
-# Offense count: 26
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowInHeredoc.
-Layout/TrailingWhitespace:
-  Enabled: false
-
 # Offense count: 39
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/app/controllers/facility_account_users_controller.rb
+++ b/app/controllers/facility_account_users_controller.rb
@@ -34,7 +34,7 @@ class FacilityAccountUsersController < ApplicationController
   # POST /facilities/:facility_id/accounts/:account_id/account_users
   def create
     @user = User.find(params[:user_id])
-    
+
     if existing_member_becoming_owner?
       flash[:error] = text("create.existing_member_error", user: @user.full_name)
       redirect_to facility_account_members_path(current_facility, @account)

--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -107,10 +107,10 @@ class OrderManagement::OrderDetailsController < ApplicationController
         OrderStatus::UNRECOVERABLE,
         OrderStatus::RECONCILED
       ]).to_a
-    
+
       # Add potentially missing custom status
       @order_statuses |= [@order_detail.order_status]
-      
+
       @order_statuses.reject! { |status| status.name == OrderStatus::RECONCILED } unless @order_detail.can_reconcile?
     elsif @order_detail.order_status.root == OrderStatus.canceled
       @order_statuses = OrderStatus.canceled_statuses_for_facility(current_facility)

--- a/app/helpers/account_price_group_members_helper.rb
+++ b/app/helpers/account_price_group_members_helper.rb
@@ -8,7 +8,7 @@ module AccountPriceGroupMembersHelper
   #
   # +limit+ The maximum number of accounts that will be displayed
   def additional_results_notice(count:, limit:)
-    # This ensures that count and limit exist before attemtping to use 
+    # This ensures that count and limit exist before attemtping to use
     # them, and will silently exit if they don't.
     #
     # This should never happen, so this method is mainly here to handle

--- a/app/mailers/problem_order_mailer.rb
+++ b/app/mailers/problem_order_mailer.rb
@@ -21,5 +21,5 @@ class ProblemOrderMailer < ApplicationMailer
   def translation_scope
     "views.problem_order_mailer"
   end
-  
+
 end

--- a/app/models/concerns/downloadable_files/image.rb
+++ b/app/models/concerns/downloadable_files/image.rb
@@ -4,7 +4,7 @@ module DownloadableFiles
 
     extend ActiveSupport::Concern
 
-    if SettingsHelper.feature_on?(:active_storage_for_images_only) 
+    if SettingsHelper.feature_on?(:active_storage_for_images_only)
       include ActiveStorageFile
     else
       include PaperclipFile

--- a/app/models/order_status.rb
+++ b/app/models/order_status.rb
@@ -23,7 +23,7 @@ class OrderStatus < ApplicationRecord
   COMPLETE = "Complete".freeze
   RECONCILED = "Reconciled".freeze
   UNRECOVERABLE = "Unrecoverable".freeze
-  
+
   ROOT_STATUS_ORDER = [NEW, IN_PROCESS, CANCELED, COMPLETE, RECONCILED, UNRECOVERABLE].freeze
 
   # Needs to be overridable by engines

--- a/app/models/reports/account_transactions_report.rb
+++ b/app/models/reports/account_transactions_report.rb
@@ -84,7 +84,7 @@ class Reports::AccountTransactionsReport
     else
       headers
     end
- 
+
   end
 
   def build_row(order_detail)

--- a/app/services/price_policy_builder.rb
+++ b/app/services/price_policy_builder.rb
@@ -29,7 +29,7 @@ class PricePolicyBuilder
       create_price_policy_for(product, price_group)
     end
   end
-  
+
   def self.create_nonbillable_for(product)
     create_price_policy_for(product, PriceGroup.nonbillable)
   end

--- a/app/support/orders/item_adder.rb
+++ b/app/support/orders/item_adder.rb
@@ -41,7 +41,7 @@ class Orders::ItemAdder
 
   def nonbillable_account?
     @order.account == NonbillableAccount.singleton_instance
-  end  
+  end
 
   # Raise an error if the Nonbillable billing mode is mixed with any other mode
   def check_for_mixed_billing_mode(product)

--- a/db/migrate/20200414202107_add_metadata_to_log_events.rb
+++ b/db/migrate/20200414202107_add_metadata_to_log_events.rb
@@ -1,5 +1,5 @@
 class AddMetadataToLogEvents < ActiveRecord::Migration[5.2]
   def change
-    add_column :log_events, :metadata, :text 
+    add_column :log_events, :metadata, :text
   end
 end

--- a/db/migrate/20231116194445_update_duration_rate_rate_and_subsidy_to_per_minute_values.rb
+++ b/db/migrate/20231116194445_update_duration_rate_rate_and_subsidy_to_per_minute_values.rb
@@ -2,7 +2,7 @@
 
 class UpdateDurationRateRateAndSubsidyToPerMinuteValues < ActiveRecord::Migration[7.0]
   class DurationRate < ApplicationRecord; end
-  
+
   def up
     DurationRate.update_all("rate = rate / 60.0, subsidy = subsidy / 60.0")
   end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -364,7 +364,7 @@ RSpec.describe Account do
         @facility2_accounts = [@nufs_account]
 
         Account.config.facility_account_types.each do |class_name|
-          # ensures namespaced accounts like OsuRelms::NonPurchaseOrderAccount 
+          # ensures namespaced accounts like OsuRelms::NonPurchaseOrderAccount
           # don't turn into :"osu_relms/non_purchase_order_account"
           class_sym = class_name.underscore.split("/").last.to_sym
           @facility1_accounts << FactoryBot.create(class_sym, account_users_attributes: account_users_attributes_hash(user: @user), facility: @facility1)

--- a/spec/models/instrument_issue_spec.rb
+++ b/spec/models/instrument_issue_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe InstrumentIssue do
   end
 
   describe "send_notification", active_job: :test do
-    let(:valid_issue) do 
+    let(:valid_issue) do
       user = create(:user)
       product = create(:setup_instrument)
 
@@ -19,7 +19,7 @@ RSpec.describe InstrumentIssue do
       order = create(:order, account: account, created_by_user: user, user: user)
       order_detail = create(:order_detail, order: order, product: product)
 
-      described_class.new(user: create(:user), product: product, order_detail: order_detail, message: "Hello") 
+      described_class.new(user: create(:user), product: product, order_detail: order_detail, message: "Hello")
     end
 
     it "returns a truthy value" do

--- a/spec/models/reports/account_transaction_report_spec.rb
+++ b/spec/models/reports/account_transaction_report_spec.rb
@@ -52,11 +52,11 @@ RSpec.describe Reports::AccountTransactionsReport do
           expect(report.to_csv.lines.first).to include("Price,Adjustment,Total")
         end
       end
-      
+
       describe "excludes the order's dispute details if feature is OFF", feature_setting: { export_order_disputes: false } do
         it "generates headers without Dispute details" do
           expect(report.to_csv.lines.first).not_to include(
-            OrderDetail.human_attribute_name(:dispute_at), 
+            OrderDetail.human_attribute_name(:dispute_at),
             OrderDetail.human_attribute_name(:dispute_reason),
             OrderDetail.human_attribute_name(:dispute_resolved_at),
             OrderDetail.human_attribute_name(:dispute_resolved_reason)

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe Statement do
             other_facility_statement = create(:statement, account: account, created_by: user.id, facility: facility3)
             other_facility_statement.add_order_detail(order_detail_from_unrelated_facility)
           end
-          
+
           it "does NOT display a message" do
             expect(statement).not_to be_display_cross_core_messsage
           end

--- a/spec/services/log_event_searcher_spec.rb
+++ b/spec/services/log_event_searcher_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe LogEventSearcher do
     let(:product) { create(:setup_item) }
     let(:order_detail) { create(:order_detail, order: order, product: product) }
     let!(:log_event) { create(:log_event, loggable: order_detail, event_type: :resolve) }
-    
+
     it "finds the order detail" do
       results = described_class.new(query: "#{order.id}-#{order_detail.id}").search
       expect(results).to include(log_event)

--- a/spec/services/research_safety_adapters/scishield_training_synchronizer_spec.rb
+++ b/spec/services/research_safety_adapters/scishield_training_synchronizer_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ResearchSafetyAdapters::ScishieldTrainingSynchronizer do
 
       it "adds courses to database" do
         expect(ScishieldTraining.count).to eq 0
-        synchronizer.synchronize 
+        synchronizer.synchronize
         expect(ScishieldTraining.count).to eq 3
         expect(ScishieldTraining.all.map(&:course_name)).to contain_exactly(*course_names)
       end

--- a/spec/support/shared_examples/hidden_price_groups_shared_examples.rb
+++ b/spec/support/shared_examples/hidden_price_groups_shared_examples.rb
@@ -29,7 +29,7 @@ RSpec.shared_examples "with hidden price groups" do |item_type|
 
     fill_in "note", with: "This is my note"
     click_button "Add Pricing Rules"
-    
+
     expect(page).to have_content(base_price_group.name)
     expect(page).to have_content(price_group_to_hide.name)
 
@@ -41,7 +41,7 @@ RSpec.shared_examples "with hidden price groups" do |item_type|
     expect(page).to have_content("Price Group was successfully updated")
 
     visit send("facility_#{item_type}_price_policies_path", facility, item)
-    
+
     expect(page).to have_content("Current Pricing Rules")
 
     expect(page).to have_content(base_price_group.name)

--- a/spec/system/admin/manage_order_detail_spec.rb
+++ b/spec/system/admin/manage_order_detail_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Managing an order detail" do
   before do
     login_as logged_in_user
   end
-  
+
   describe "shows order detail with custom status" do
     let!(:custom_status) do
       OrderStatus.create!(

--- a/vendor/engines/sanger_sequencing/spec/presenters/sanger_sequencing/well_plate_presenter_spec.rb
+++ b/vendor/engines/sanger_sequencing/spec/presenters/sanger_sequencing/well_plate_presenter_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe SangerSequencing::WellPlatePresenter, feature_setting: { well_pla
       let(:expected_results_group) { a_kind_of(String) }
       let(:expected_instrument_protocol) { a_kind_of(String) }
       let(:expected_analysis_protocol) { a_kind_of(String) }
-      
+
       it "renders using alternative_csv_columns" do
         expect(sample_rows[0]).to match(["A01", "PGEM_F", "CQLS", expected_results_group, expected_instrument_protocol, expected_analysis_protocol])
         expect(sample_rows[1]).to match(["B01", samples[0].id.to_s, samples[0].submission.order_detail.user.username, expected_results_group, expected_instrument_protocol, expected_analysis_protocol])

--- a/vendor/engines/secure_rooms/app/controllers/secure_rooms/ethernet_ports_controller.rb
+++ b/vendor/engines/secure_rooms/app/controllers/secure_rooms/ethernet_ports_controller.rb
@@ -7,12 +7,12 @@ module SecureRooms
   class EthernetPortsController < ApplicationController
 
     admin_tab :all
-    
+
     before_action :init_current_facility
     before_action :init_product
     before_action :authenticate_user!
     before_action :check_acting_as
-    
+
     layout "two_column"
 
     def edit

--- a/vendor/engines/secure_rooms/spec/system/edit_secure_room_ethernet_ports_spec.rb
+++ b/vendor/engines/secure_rooms/spec/system/edit_secure_room_ethernet_ports_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Secure Room Ethernet Ports" do
       fill_in "secure_room_tablet_circuit_number", with: "2"
       fill_in "secure_room_tablet_port_number", with: "4000"
       fill_in "secure_room_tablet_location_description", with: "The tablet is near the card reader"
-    
+
       click_button "Save"
       room.reload
 
@@ -38,5 +38,5 @@ RSpec.describe "Secure Room Ethernet Ports" do
       expect(room.tablet_circuit_number).to eq("2")
       expect(room.tablet_port_number).to eq(4000)
       expect(room.tablet_location_description).to eq("The tablet is near the card reader")
-    end 
+    end
 end


### PR DESCRIPTION
## Notes

> This is part of NUOPEN-58

- Enable cop to detect trailing whitespace
- Run rubocop autocorrect