### PR TITLE
[UMASS-176][Fix] Remove style to first reconcile note

### DIFF
--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -64,7 +64,9 @@ class Statement < ApplicationRecord
   end
 
   def order_details_notes(note_field)
-    order_details.filter_map { |od| od.send(note_field) }.uniq
+    order_details.filter_map do |od|
+      od.send(note_field)&.strip.presence
+    end.uniq
   end
 
   def invoice_date

--- a/app/views/shared/_statements_table.html.haml
+++ b/app/views/shared/_statements_table.html.haml
@@ -67,9 +67,8 @@
               %div
                 %small
                   %strong= "#{t('statements.notes')}:"
-              %ul
-                %li
-                  %small= s.reconcile_notes.shift
+              %div
+                %small= s.reconcile_notes.shift
               %ul.unstyled.collapse{ id: "statement-notes-#{s.id}" }
                 - s.reconcile_notes.each do |note|
                   %li

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -140,6 +140,36 @@ RSpec.describe Statement do
       it "is not in the unreconciled scope" do
         expect(described_class.unreconciled).not_to include(statement)
       end
+
+      describe "#order_details_notes" do
+        subject { statement.order_details_notes(:reconciled_note) }
+
+        let(:order_detail1) { statement.order_details.first }
+        let(:order_detail2) { statement.order_details.second }
+
+        before do
+          order_detail1.update(reconciled_note: "Some note")
+          order_detail2.update(reconciled_note: "Some other note")
+        end
+
+        it "includes reconcile notes" do
+          expect(subject).to(
+            match(["Some note", "Some other note"])
+          )
+        end
+
+        it "filters out nil notes" do
+          order_detail1.update(reconciled_note: nil)
+
+          expect(subject).to eq(["Some other note"])
+        end
+
+        it "filters out whitespace notes" do
+          order_detail1.update(reconciled_note: "        ")
+
+          expect(subject).to eq(["Some other note"])
+        end
+      end
     end
 
     context "#remove_order_detail" do


### PR DESCRIPTION
## Notes

- Remove `<ul/>` element bullet point from first note item
- Don't render empty notes when reconcile note field is ""

### Bugs screenshot

<img width="721" alt="Captura de pantalla 2025-04-15 a la(s) 17 35 18" src="https://github.com/user-attachments/assets/fe3309ac-7d1b-4b1e-b38f-41c453932392" />
