### PR TITLE
[NOPEN-238] Update mark as unrecoverable permissions

### DIFF
--- a/app/controllers/facility_accounts_reconciliation_controller.rb
+++ b/app/controllers/facility_accounts_reconciliation_controller.rb
@@ -12,7 +12,7 @@ class FacilityAccountsReconciliationController < ApplicationController
   before_action :init_current_facility
   before_action :check_billing_access
   before_action :set_billing_navigation
-  before_action :check_billing_access_to_mark_as_unrecoverable, only: :update
+  before_action :authorize_mark_unrecoverable, only: :update
 
   def index
     order_details = unreconciled_details
@@ -32,8 +32,6 @@ class FacilityAccountsReconciliationController < ApplicationController
   end
 
   def update
-    return redirect_to([account_route.to_sym, :facility_accounts])
-
     reconciled_at = parse_usa_date(params[:reconciled_at])
     reconciler = OrderDetails::Reconciler.new(
       unreconciled_details,
@@ -93,10 +91,9 @@ class FacilityAccountsReconciliationController < ApplicationController
     )
   end
 
-  def check_billing_access_to_mark_as_unrecoverable
-    return unless params[:order_status] == "unrecoverable" && cannot?(:mark_unrecoverable, OrderDetail)
+  def authorize_mark_unrecoverable
+    return unless params[:order_status] == "unrecoverable"
 
-    flash[:error] = t("controllers.facility_accounts_reconciliation.cannot_mark_as_unrecoverable")
-    redirect_to([account_route.to_sym, :facility_accounts])
+    authorize!(:mark_unrecoverable, OrderDetail)
   end
 end

--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -123,7 +123,7 @@ class OrderManagement::OrderDetailsController < ApplicationController
       @order_statuses = OrderStatus.non_protected_statuses(current_facility)
     end
 
-    if !@order_detail.unrecoverable? && cannot?(:mark_unrecoverable, OrderDetail)
+    unless @order_detail.unrecoverable? || can?(:mark_unrecoverable, OrderDetail)
       @order_statuses.reject! { |status| status.name == OrderStatus::UNRECOVERABLE }
     end
   end

--- a/app/controllers/order_management/order_details_controller.rb
+++ b/app/controllers/order_management/order_details_controller.rb
@@ -154,8 +154,7 @@ class OrderManagement::OrderDetailsController < ApplicationController
   end
 
   def authorize_mark_unrecoverable
-    return if @order_detail.unrecoverable? ||
-              update_params[:state] != OrderStatus.unrecoverable.id
+    return if @order_detail.unrecoverable? || update_params[:order_status_id].to_s != OrderStatus.unrecoverable.id.to_s
 
     authorize!(:mark_unrecoverable, OrderDetail)
   end

--- a/app/helpers/order_details_helper.rb
+++ b/app/helpers/order_details_helper.rb
@@ -8,4 +8,11 @@ module OrderDetailsHelper
     order_detail.fulfilled_at.blank? || order_detail.fulfilled_at_changed?
   end
 
+  def reconcile_status
+    [
+      ["Reconciled", :reconciled],
+      can?(:mark_unrecoverable, OrderDetail) ? ["Unrecoverable", :unrecoverable] : nil
+    ].compact
+  end
+
 end

--- a/app/helpers/order_details_helper.rb
+++ b/app/helpers/order_details_helper.rb
@@ -8,7 +8,7 @@ module OrderDetailsHelper
     order_detail.fulfilled_at.blank? || order_detail.fulfilled_at_changed?
   end
 
-  def reconcile_status
+  def reconcile_statuses
     [
       ["Reconciled", :reconciled],
       can?(:mark_unrecoverable, OrderDetail) ? ["Unrecoverable", :unrecoverable] : nil

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -28,6 +28,8 @@ class Ability
       facility_administrator_abilities(user, resource, controller)
       facility_director_abilities(user, resource, controller)
       account_manager_abilities(user, resource)
+      cannot :mark_unrecoverable, OrderDetail
+
       global_billing_administrator_abilities(user, resource)
 
       account_administrator_abilities(user, resource, controller)
@@ -124,6 +126,7 @@ class Ability
   def global_billing_administrator_abilities(user, resource)
     return unless user.global_billing_administrator?
 
+    can :mark_unrecoverable, OrderDetail
     can :manage, [Account, Journal, OrderDetail]
     can :manage, Statement if resource.is_a?(Facility)
     can [:send_receipt, :show], Order

--- a/app/views/facility_accounts_reconciliation/_action_row.html.haml
+++ b/app/views/facility_accounts_reconciliation/_action_row.html.haml
@@ -8,7 +8,7 @@
       = label_tag :order_status, t("facility_accounts_reconciliation.index.order_status"), class: "control-label"
       .controls
         = select_tag :order_status,
-          options_for_select(reconcile_status),
+          options_for_select(reconcile_statuses),
           class: "js--orderStatusSelect"
 - if local_assigns[:date]
   .js--bulkReconcileFields

--- a/app/views/facility_accounts_reconciliation/_action_row.html.haml
+++ b/app/views/facility_accounts_reconciliation/_action_row.html.haml
@@ -8,7 +8,7 @@
       = label_tag :order_status, t("facility_accounts_reconciliation.index.order_status"), class: "control-label"
       .controls
         = select_tag :order_status,
-          options_for_select([["Reconciled", "reconciled"], ["Unrecoverable", "unrecoverable"]]),
+          options_for_select(reconcile_status),
           class: "js--orderStatusSelect"
 - if local_assigns[:date]
   .js--bulkReconcileFields

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -36,9 +36,6 @@ en:
         success: "Payment source activated successfully"
         failure: "Cannot activate. %{errors}"
 
-    facility_accounts_reconciliation:
-      cannot_mark_as_unrecoverable: "You do not have permission to mark payments as unrecoverable. Please contact your Global Administrator for help."
-
     facility_notifications:
       no_selection: No orders selected
       errors_html: We experienced the following errors. Please try again.<br/>%{errors}

--- a/spec/requests/order_management/order_details_spec.rb
+++ b/spec/requests/order_management/order_details_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "order_management/order_details", type: :request do
+  let(:facility) { create(:setup_facility) }
+  let(:product) { create(:setup_service, facility:) }
+  let(:order) { create(:purchased_order, product:) }
+  let(:order_detail) { order.order_details.last }
+
+  describe "mark as unrecoverable" do
+    let(:params) do
+      {
+        order_detail: {
+          id: order_detail.id,
+          order_status_id: OrderStatus.unrecoverable.id
+        }
+      }
+    end
+
+    before do
+      order_detail.change_status!(OrderStatus.complete)
+      order_detail.update(statement: create(:statement))
+    end
+
+    context "as non allowed user", :disable_requests_local do
+      it "does not update the status" do
+        login_as(create(:user, :facility_administrator, facility:))
+
+        put(
+          manage_facility_order_order_detail_path(facility, order, order_detail),
+          params:
+        )
+
+        expect(response).to have_http_status(:forbidden)
+        expect(order_detail.reload.unrecoverable?).to be false
+      end
+    end
+
+    context "as administrator" do
+      it "changes the order detail status" do
+        login_as(create(:user, :administrator))
+
+        put(
+          manage_facility_order_order_detail_path(facility, order, order_detail),
+          params:
+        )
+
+        expect(response).to have_http_status(:found)
+        expect(order_detail.reload.unrecoverable?).to be true
+      end
+    end
+  end
+end

--- a/spec/system/admin/manage_order_detail_spec.rb
+++ b/spec/system/admin/manage_order_detail_spec.rb
@@ -282,6 +282,8 @@ RSpec.describe "Managing an order detail" do
         instrument.price_policies.update_all(cancellation_cost: 5)
         # reservation is set for tomorrow, we need min_cancel_hours to be longer than time to reserve_start_at
         instrument.update_attribute(:min_cancel_hours, 48)
+
+        visit manage_facility_order_order_detail_path(facility, order, order_detail)
       end
 
       it "cancels without a fee" do
@@ -318,6 +320,8 @@ RSpec.describe "Managing an order detail" do
         fill_in "Resolution Notes", with: "a resolution"
         click_button "Resolve Dispute"
 
+        expect(page).to have_content("The order was successfully updated")
+
         expect(order_detail.reload.dispute_resolved_at).to be_present
         expect(LogEvent).to be_exist(loggable: order_detail, event_type: :resolve)
       end
@@ -337,6 +341,8 @@ RSpec.describe "Managing an order detail" do
         visit manage_facility_order_order_detail_path(facility, order_detail.order, order_detail)
         fill_in "Resolution Notes", with: "a resolution"
         click_button "Resolve Dispute"
+
+        expect(page).to have_content("The order was successfully updated")
 
         expect(order_detail.reload.dispute_resolved_at).to be_present
         expect(LogEvent).to be_exist(loggable: order_detail, event_type: :resolve)

--- a/spec/system/admin/manage_order_detail_spec.rb
+++ b/spec/system/admin/manage_order_detail_spec.rb
@@ -365,6 +365,8 @@ RSpec.describe "Managing an order detail" do
       fill_in "Reconciliation Note", with: "adding a note"
       click_button "Save"
 
+      expect(page).to have_content("The order was successfully updated")
+
       expect(order_detail.reload).to be_reconciled
       expect(order_detail.reconciled_note).to eq("adding a note")
     end


### PR DESCRIPTION
## Notes

- Use cancancan with custom action to authorize marking an order as unrecoverable
- Hide Unrecoverable option to non allowed users