### PR TITLE
[UMASS-167] Fix page jump when expanding collapsed notes

### DIFF
--- a/app/views/shared/_statements_table.html.haml
+++ b/app/views/shared/_statements_table.html.haml
@@ -69,12 +69,16 @@
                   %strong= "#{t('statements.notes')}:"
               %div
                 %small= s.reconcile_notes.shift
-              %ul.unstyled.collapse{ id: "statement-notes-#{s.id}" }
+              - collapsable_section_id = "statement-notes-#{s.id}"
+              %ul.unstyled.collapse{ id: collapsable_section_id }
                 - s.reconcile_notes.each do |note|
                   %li
                     %small= note
               - if s.reconcile_notes.length > 0
-                %a{ role: "button", href: "#statement-notes-#{s.id}", data: { toggle: "collapse", target: "#statement-notes-#{s.id}" } }
+                %a{ role: "button",
+                href: "##{collapsable_section_id}",
+                data: { toggle: "collapse" },
+                aria: { expanded: false, controls: collapsable_section_id } }
                   %small= t("statements.expand")
 
 


### PR DESCRIPTION
## Notes

When clicking expand on the statement history notes the page jumped to focus the target element.
Follow bootstrap example: https://getbootstrap.com/docs/4.0/components/collapse/#example