### PR TITLE
[Tech tasks][NUOPEN-223] Flaky specs: increase stub instance ids

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,6 +17,9 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 # Keep factory_bot v4 build strategy behaviour
 # https://github.com/thoughtbot/factory_bot/blob/v6.5.0/GETTING_STARTED.md#build-strategies-1
 FactoryBot.use_parent_strategy = false
+# Increase stub instances ids so they
+# don't overlap with db instances
+FactoryBot::Strategy::Stub.next_id = 100_000
 
 RSpec.configure do |config|
   config.filter_rails_from_backtrace!


### PR DESCRIPTION
## Notes

- Increase IDs used by `FactoryBot.build_stubbed` so they don't overlap DB ids causing flaky specs like `spec/models/order_detail_spec:163` (https://github.com/wyeworks/nucore-open/actions/runs/14593368046/job/40933472282)