### PR TITLE
[Tech Task][NUOPEN-223] Flaky spec: instrument schedule positions matching before page change

### DIFF
--- a/spec/system/admin/instrument_schedule_positions_spec.rb
+++ b/spec/system/admin/instrument_schedule_positions_spec.rb
@@ -44,6 +44,9 @@ RSpec.describe "Instrument Schedule Display Order" do
       visit facility_instrument_schedule_position_path(facility)
       click_link "Instrument Display Order"
       click_link "Edit"
+
+      wait_for { page.has_css?("form.instrument_schedule_position") }
+
       expect(["First", "Shared schedule: Second Schedule", "AAA New", "CCC New", "ZZZ New"]).to appear_in_order
       select "Second Schedule", from: "Instrument Schedules"
 


### PR DESCRIPTION
## Notes

Wait for page to change before matching content. This fixes the flaky spec in `spec/syste/admin/instrument_schedule_positions_spec:47` (https://github.com/wyeworks/nucore-open/actions/runs/14593360285/job/40933450962)