### PR TITLE
[UMASS-142] Add filter to email log events

### DIFF
--- a/app/controllers/email_log_events_controller.rb
+++ b/app/controllers/email_log_events_controller.rb
@@ -3,9 +3,23 @@
 class EmailLogEventsController < GlobalSettingsController
 
   def index
-    @email_log_events = LogEvent.with_email_type.paginate(
-      per_page: 50, page: params[:page]
-    ).includes(:loggable).reverse_chronological
+    @email_log_events = LogEventSearcher.new(
+      relation: LogEvent.with_email_type,
+      start_date: parse_usa_date(index_params[:start_date]),
+      end_date: parse_usa_date(index_params[:end_date]),
+      events: index_params[:events],
+    ).search.includes(:loggable).reverse_chronological.paginate(
+      per_page: 50, page: index_params[:page]
+    )
+  end
+
+  def index_params
+    params.permit(
+      :start_date,
+      :end_date,
+      :page,
+      events: []
+    )
   end
 
 end

--- a/app/helpers/email_log_events_helper.rb
+++ b/app/helpers/email_log_events_helper.rb
@@ -3,6 +3,12 @@
 module EmailLogEventsHelper
   EMAIL_OBJECT_THRESHOLD = 50
 
+  def email_log_events_options
+    LogEvent::EMAIL_EVENT_TYPES.map do |event_type|
+      [text("log_event/event_type.#{event_type}"), event_type]
+    end
+  end
+
   def decorated_log_events(events)
     events.map { |event| EmailLogEventPresenter.new(event) }
   end

--- a/app/helpers/log_events_helper.rb
+++ b/app/helpers/log_events_helper.rb
@@ -3,11 +3,11 @@
 module LogEventsHelper
 
   def log_events_options
-    LogEventSearcher::ALLOWED_EVENTS.map { |event| [dropdown_title(event), event] }.sort
+    Reports::LogEventsReport::ALLOWED_EVENTS.map { |event| [dropdown_title(event), event] }.sort
   end
 
   def dropdown_title(event)
-    text("dropdown_titles.#{event}", default: event.to_sym)
+    text("dropdown_titles.#{event}", default: text("log_event/event_type.#{event}"))
   end
 
 end

--- a/app/models/log_event.rb
+++ b/app/models/log_event.rb
@@ -37,11 +37,6 @@ class LogEvent < ApplicationRecord
     )
   end
 
-  def self.search(start_date: nil, end_date: nil, events: [], query: nil)
-    LogEventSearcher.new(
-      start_date:, end_date:, events:, query:).search
-  end
-
   # The reason that we are doing this is because in some case we can't add a default value to a text column
   def metadata
     self[:metadata] || {}
@@ -52,7 +47,7 @@ class LogEvent < ApplicationRecord
   end
 
   def locale_tag
-    "#{loggable_type.underscore.downcase}.#{event_type}"
+    "log_event/event_type.#{loggable_type.underscore.downcase}.#{event_type}"
   end
 
   def loggable_to_s

--- a/app/models/reports/log_events_report.rb
+++ b/app/models/reports/log_events_report.rb
@@ -1,4 +1,4 @@
-## frozen_string_literal: true
+# frozen_string_literal: true
 
 module Reports
 
@@ -6,10 +6,28 @@ module Reports
 
     include Reports::CsvExporter
 
+    ALLOWED_EVENTS = [
+      "account.create", "account.update",
+      "account_user.create", "account_user.delete",
+      "user.create", "user.suspended", "user.unsuspended",
+      "user.default_price_group_changed",
+      "account.suspended", "account.unsuspended",
+      "journal.create", "statement.create",
+      "user_role.create", "user_role.delete",
+      "order_detail.dispute", "order_detail.resolve",
+      "order_detail.notify", "order_detail.review",
+      "order_detail.problem_queue", "order_detail.price_change",
+      "order_detail.resolve_from_problem_queue",
+      "product_user.create", "product_user.delete",
+      "price_group_member.create", "price_group_member.delete",
+      "facility.activate", "facility.deactivate",
+      "price_group.create", "price_group.delete",
+    ].freeze
+
     def initialize(start_date:, end_date:, events:, query:)
       @start_date = start_date
       @end_date = end_date
-      @events = events
+      @events = whitelist_events(events)
       @query = query
     end
 
@@ -24,12 +42,13 @@ module Reports
     end
 
     def log_events
-      LogEvent.search(
+      LogEventSearcher.new(
+        relation: LogEvent.non_email_type,
         start_date: @start_date,
         end_date: @end_date,
         events: @events,
         query: @query,
-      ).includes(:user, :loggable).reverse_chronological
+      ).search.includes(:user, :loggable).reverse_chronological
     end
 
     def report_data_query
@@ -48,6 +67,10 @@ module Reports
 
     def translation_scope
       "views.log_events.index"
+    end
+
+    def whitelist_events(events)
+      Array(events).select { |event| event.in?(ALLOWED_EVENTS) }
     end
 
   end

--- a/app/views/email_log_events/index.html.haml
+++ b/app/views/email_log_events/index.html.haml
@@ -6,6 +6,10 @@
 
 %h2= text("pages.email_event_log")
 
+= render "log_events/filter_form",
+  event_type_options: email_log_events_options,
+  exclude_query_field: true
+
 = will_paginate(@email_log_events)
 
 %table.table.table-striped.table-hover.email-logs

--- a/app/views/log_events/_filter_form.html.haml
+++ b/app/views/log_events/_filter_form.html.haml
@@ -1,0 +1,25 @@
+= form_tag(request.path, method: :get, class: "search_form") do
+  .row
+    .span3
+      = label_tag(text(:start_date))
+      = text_field_tag(:start_date, params[:start_date], class: :datepicker__data)
+    .span3
+      = label_tag(text(:end_date))
+      = text_field_tag(:end_date, params[:end_date], class: :datepicker__data)
+  .row
+    .span3
+      = label_tag(text(:event_filter))
+      = select_tag(:events,
+        options_for_select(event_type_options, params[:events]),
+        multiple: true,
+        class: "js--chosen",
+        data: { placeholder: text(:event_placeholder) })
+    - unless local_assigns[:exclude_query_field]
+      .span3
+        = label_tag(text(:query))
+        = text_field_tag(:query, params[:query])
+  .row
+    .span6
+      = submit_tag(text(:submit), class: "btn")
+      = hidden_field_tag :email, current_user.email, disabled: true
+      = hidden_field_tag :format, params[:format], disabled: true

--- a/app/views/log_events/_filter_form.html.haml
+++ b/app/views/log_events/_filter_form.html.haml
@@ -1,14 +1,14 @@
 = form_tag(request.path, method: :get, class: "search_form") do
   .row
     .span3
-      = label_tag(text(:start_date))
-      = text_field_tag(:start_date, params[:start_date], class: :datepicker__data)
+      = label_tag(:start_date, text(:start_date))
+      = text_field_tag(:start_date, params[:start_date], class: :datepicker__data, autocomplete: "off")
     .span3
-      = label_tag(text(:end_date))
-      = text_field_tag(:end_date, params[:end_date], class: :datepicker__data)
+      = label_tag(:end_date, text(:end_date))
+      = text_field_tag(:end_date, params[:end_date], class: :datepicker__data, autocomplete: "off")
   .row
     .span3
-      = label_tag(text(:event_filter))
+      = label_tag(:events, text(:event_filter))
       = select_tag(:events,
         options_for_select(event_type_options, params[:events]),
         multiple: true,
@@ -16,7 +16,7 @@
         data: { placeholder: text(:event_placeholder) })
     - unless local_assigns[:exclude_query_field]
       .span3
-        = label_tag(text(:query))
+        = label_tag(:query, text(:query))
         = text_field_tag(:query, params[:query])
   .row
     .span6

--- a/app/views/log_events/index.html.haml
+++ b/app/views/log_events/index.html.haml
@@ -6,36 +6,8 @@
 
 %h2= text("pages.event_log")
 
-= form_tag(log_events_path, method: :get, class: "search_form") do
-
-  .row
-    .span3
-      = label_tag(text(:query))
-      = text_field_tag(:query, params[:query])
-
-    .span3
-      = label_tag(text(:start_date))
-      = text_field_tag(:start_date, params[:start_date], class: :datepicker__data)
-
-  .row
-    .span3
-      = label_tag(text(:event_filter))
-      = select_tag(:events,
-        options_for_select(log_events_options, params[:events]),
-        multiple: true,
-        class: "js--chosen",
-        data: { placeholder: text(:event_placeholder) })
-
-    .span3
-      = label_tag(text(:end_date))
-      = text_field_tag(:end_date, params[:end_date], class: :datepicker__data)
-
-  .row
-    .span3
-      = submit_tag(text(:filter), class: "btn")
-      = hidden_field_tag :email, current_user.email, disabled: true
-      = hidden_field_tag :format, params[:format], disabled: true
-
+= render "filter_form",
+  event_type_options: log_events_options
 
 = will_paginate(@log_events)
 
@@ -47,7 +19,7 @@
       %th= text("event")
       %th= text("object")
       %th= Facility.model_name.human
-      %th= text("user_label")
+      %th= text("user")
 
   %tbody
     - @log_events.each do |log_event|

--- a/config/locales/en.log_event_types.yml
+++ b/config/locales/en.log_event_types.yml
@@ -1,0 +1,50 @@
+en:
+  log_event/event_type:
+    account:
+      create: Payment Source created
+      update: Payment Source updated
+      suspended: Payment Source suspended
+      unsuspended: Payment Source unsuspended
+    account_user:
+      create: Payment Source User added
+      delete: Payment Source User removed
+    journal:
+      create: Journal created
+      closed: Journal closed
+    statement:
+      create: "!Statement! created"
+      closed: "!Statement! closed"
+    order_detail:
+      dispute: Order disputed
+      resolve: Order dispute resolved
+      notify: Billing notified
+      review: Order reviewed
+      problem_queue: Order added to problem queue %{cause}
+      price_change: Order's price was manually changed
+      resolve_from_problem_queue: Problem order resolved
+      updated_fulfilled_at: Fulfilled date updated on completed order
+    order_import:
+      created: Bulk Order Import
+    product_user:
+      create: User added to access list
+      delete: User removed from access list
+    price_group_member:
+      create: "%{member_type} added to price group"
+      delete: "%{member_type} removed from price group"
+    facility:
+      activate: Turned on all relays
+      deactivate: Turned off all relays
+    price_group:
+      create: Price Group created
+      delete: Price Group deleted
+    user:
+      access_locked: User access locked due to too many login attempts
+      create: User added
+      suspended: User suspended
+      unsuspended: User unsuspended
+      default_price_group_changed: User price group changed to %{price_group_rate}
+    user_role:
+      create: Role added
+      delete: Role removed
+    review_orders_email: "Review Orders Email"
+    statement_email: "!Statement! Email"

--- a/config/locales/views/admin/en.log_events.yml
+++ b/config/locales/views/admin/en.log_events.yml
@@ -2,6 +2,10 @@ en:
   views:
     log_events:
       index:
+        event_time: Event Time
+        event: Event
+        object: Object
+        user: User
         dropdown_titles:
           order_detail:
             problem_queue: Order added to problem queue
@@ -10,59 +14,10 @@ en:
           price_group_member:
             create: "User or account added to price group"
             delete: "User or account removed from price group"
-        account:
-          create: Payment Source created
-          update: Payment Source updated
-          suspended: Payment Source suspended
-          unsuspended: Payment Source unsuspended
-        account_user:
-          create: Payment Source User added
-          delete: Payment Source User removed
-        journal:
-          create: Journal created
-          closed: Journal closed
-        statement:
-          create: "!Statement! created"
-          closed: "!Statement! closed"
-        order_detail:
-          dispute: Order disputed
-          resolve: Order dispute resolved
-          notify: Billing notified
-          review: Order reviewed
-          problem_queue: Order added to problem queue %{cause}
-          price_change: Order's price was manually changed
-          resolve_from_problem_queue: Problem order resolved
-          updated_fulfilled_at: Fulfilled date updated on completed order
-        order_import:
-          created: Bulk Order Import
-        product_user:
-          create: User added to access list
-          delete: User removed from access list
-        price_group_member:
-          create: "%{member_type} added to price group"
-          delete: "%{member_type} removed from price group"
-        facility:
-          activate: Turned on all relays
-          deactivate: Turned off all relays
-        price_group:
-          create: Price Group created
-          delete: Price Group deleted
+      filter_form:
         end_date: End Date
         event_filter: Event
         event_placeholder: Filter on one or more events
-        event_time: Event Time
-        event: Event
-        filter: Filter
-        object: Object
+        submit: Filter
         query: Query
         start_date: Start Date
-        user:
-          access_locked: User access locked due to too many login attempts
-          create: User added
-          suspended: User suspended
-          unsuspended: User unsuspended
-          default_price_group_changed: User price group changed to %{price_group_rate}
-        user_role:
-          create: Role added
-          delete: Role removed
-        user_label: User

--- a/spec/system/admin/email_log_events_spec.rb
+++ b/spec/system/admin/email_log_events_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "email log_events page" do
+  let(:some_user) { create(:user, first_name: "Socrates") }
+  let(:facility) { create(:setup_facility) }
+  let(:product) { create(:setup_service, facility:) }
+  let(:order) { create(:setup_order, product:) }
+  let(:order_detail) { order.order_details.first }
+  let(:admin) { create(:user, :administrator) }
+  let(:statement) { create(:statement, order_details: [order_detail]) }
+
+  let(:email) do
+    double(
+      "Email",
+      to: "random@example.com",
+      subject: "Some Subject"
+    )
+  end
+
+  before do
+    [
+      [some_user, :review_orders_email],
+      [statement, :statement_email],
+    ].each do |loggable, event_type|
+      LogEvent.log_email(
+        loggable,
+        event_type,
+        email
+      )
+    end
+  end
+
+  describe "email log events filtering" do
+    before { login_as create(:user, :administrator) }
+
+    it "filter events by type" do
+      visit email_log_events_path
+
+      select(
+        "#{I18n.t('Statement')} Email",
+        from: "Event",
+      )
+
+      click_button("Filter")
+
+      within("table.table") do
+        expect(page).to have_content(I18n.t("Statement"))
+        expect(page).to_not have_content("Review Orders")
+      end
+    end
+
+    context "filter by date" do
+      let(:log_event1) { LogEvent.where(event_type: :review_orders_email).first }
+      let(:log_event2) { LogEvent.where(event_type: :statement_emails).first }
+
+      before do
+        log_event1.update(event_time: 1.week.ago)
+      end
+
+      it "filter events by date" do
+        visit email_log_events_path
+
+        fill_in("End Date", with: I18n.l(1.day.ago.to_date, format: :usa))
+
+        click_button("Filter")
+
+        within("table.table") do
+          expect(page).to have_content("Review Orders")
+          expect(page).to_not have_content(I18n.t("Statement"))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Notes

- Add filters to email log by reusing the log events page form and search clases
- Move form to its own partial view
- Move events locales to its own file

## Screenshot

![Captura de pantalla 2025-04-24 a la(s) 11 59 25](https://github.com/user-attachments/assets/c22ffc1f-a5f2-4297-a30f-833e003f93fc)
