### PR TITLE
[Fix] Notification sending for global billing

### DIFF
--- a/app/services/notification_sender.rb
+++ b/app/services/notification_sender.rb
@@ -75,9 +75,11 @@ class NotificationSender
   end
 
   def notify_accounts
+    args = current_facility.cross_facility? ? {} : { facility: current_facility }
+
     accounts_by_user.each do |user, accounts|
       Notifier.review_orders(
-        user:, accounts:, facility: current_facility,
+        user:, accounts:, **args
       ).deliver_later
     end
   end


### PR DESCRIPTION
## Notes

On PR #5218 I changed how notifications where queued from using `.delay` to `ActionMailer::Base.deliver_later`. This broke the case when global billing admin user triggers this use case with the facility `Facility.cross_facility` which is always built on the fly and has no id, thus it cannot be serialized when queued.