### PR TITLE
[Chore] Remove duplicate fullcalendar.css

### DIFF
--- a/app/views/shared/headers/_calendar.html.haml
+++ b/app/views/shared/headers/_calendar.html.haml
@@ -6,4 +6,3 @@
     if (module === 'jquery') return window.jQuery;
   };
 = stylesheet_link_tag 'jquery.qtip'
-= stylesheet_link_tag 'fullcalendar'


### PR DESCRIPTION
## Notes

Remove stylesheet include tag including fullcalendar css again and overriding styles that had been already included and overrided in applicaiton.css.