### PR TITLE
[UMASS-161] Toggle hide inactive products in user access list

### DIFF
--- a/app/assets/javascripts/app/submit_on_change.js
+++ b/app/assets/javascripts/app/submit_on_change.js
@@ -1,0 +1,21 @@
+/**
+  * By adding the class `js--submit-on-change` to a form
+  * it will submit on any input change.
+  *
+  * i.e. to filter forms
+  */
+$(function () {
+  function setupSubmitOnChange(form) {
+    console.log("Setup js--submit-on-change")
+    form.addEventListener("change", function() {
+      form.submit()
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", function() {
+    document
+      .querySelectorAll("form.js--submit-on-change")
+      .forEach(setupSubmitOnChange)
+    console.log("Setup js--submit-on-change")
+  })
+}());

--- a/app/assets/javascripts/app/submit_on_change.js
+++ b/app/assets/javascripts/app/submit_on_change.js
@@ -6,7 +6,6 @@
   */
 $(function () {
   function setupSubmitOnChange(form) {
-    console.log("Setup js--submit-on-change")
     form.addEventListener("change", function() {
       form.submit()
     });
@@ -16,6 +15,5 @@ $(function () {
     document
       .querySelectorAll("form.js--submit-on-change")
       .forEach(setupSubmitOnChange)
-    console.log("Setup js--submit-on-change")
   })
 }());

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -98,7 +98,10 @@ class UsersController < ApplicationController
     raise ActiveRecord::RecordNotFound if current_facility.cross_facility?
 
     @facility = current_facility
-    @products_by_type = Product.for_facility(@facility).requiring_approval_by_type
+    product_relation = Product.for_facility(@facility)
+    product_relation = product_relation.active if params[:hide_inactive] == "1"
+
+    @products_by_type = product_relation.requiring_approval_by_type
     @training_requested_product_ids = @user.training_requests.pluck(:product_id)
     @user_approved_at_for_product_id = @user.approval_dates_by_product
   end

--- a/app/views/users/access_list.html.haml
+++ b/app/views/users/access_list.html.haml
@@ -15,6 +15,14 @@
   %p.notice= text("users.access_list.no_products", name: @user.full_name)
 
 - else
+  .row
+    .pull-right
+      = form_with(url: facility_user_access_list_path(current_facility),
+        method: :get, class: "js--submit-on-change") do |f|
+        .checkbox
+          = f.check_box :hide_inactive, checked: params[:hide_inactive] == "1"
+          = f.label :hide_inactive, t(".hide_inactive")
+
   = form_for :user, url: facility_user_access_list_approvals_path(@facility, @user) do |form|
     - @products_by_type.each_pair do |product_type, products|
       %h3= product_type.pluralize
@@ -40,7 +48,7 @@
                 - if training_requested_for?(product)
                   %span.label.label-important
                     = text("users.access_list.training_requested")
-                = link_to product, [product.facility, product, :users]
+                = link_to product.to_s_with_status, [product.facility, product, :users]
               %td.product-column
                 - if access_granted_at.present?
                   = month_day_year(access_granted_at)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1130,6 +1130,7 @@ en:
       training_requested: Training Requested
       update_approvals:
         submit: "Update Access List"
+      hide_inactive: Hide inactive Products
 
     new_external:
       head: "Add User"

--- a/spec/system/admin/user_access_list_spec.rb
+++ b/spec/system/admin/user_access_list_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "User access list" do
           expect(page).to have_content(product2.name)
         end
 
-        # Toggle hidde inactive
+        # Toggle hide inactive
         check("Hide inactive Products")
 
         within("table") do

--- a/spec/system/admin/user_access_list_spec.rb
+++ b/spec/system/admin/user_access_list_spec.rb
@@ -4,12 +4,12 @@ require "rails_helper"
 
 RSpec.describe "User access list" do
   describe "as facility director" do
-    let(:facility) { FactoryBot.create(:setup_facility) }
-    let(:admin) { create(:user, :facility_administrator, facility: facility) }
+    let(:facility) { create(:setup_facility) }
+    let(:admin) { create(:user, :facility_administrator, facility:) }
     let(:user) { create(:user) }
-    let!(:product1) { create(:item, facility: facility, requires_approval: true) }
-    let!(:product2) { create(:item, facility: facility, requires_approval: true) }
-    let!(:product_user) { create(:product_user, user: user, product: product1)}
+    let!(:product1) { create(:item, facility:, requires_approval: true) }
+    let!(:product2) { create(:item, facility:, requires_approval: true) }
+    let!(:product_user) { create(:product_user, user:, product: product1)}
 
     it "can approve access to a product and logs it" do
       expect(user.reload.products).to contain_exactly(product1)
@@ -26,7 +26,7 @@ RSpec.describe "User access list" do
       expect(user.reload.products).to contain_exactly(product2)
 
       expect(LogEvent.find_by(loggable: product_user, event_type: :delete, user: admin)).to be_present
-      product_user2 = ProductUser.find_by(product: product2, user: user)
+      product_user2 = ProductUser.find_by(product: product2, user:)
       expect(LogEvent.find_by(loggable: product_user2, event_type: :create, user: admin)).to be_present
     end
 
@@ -39,6 +39,37 @@ RSpec.describe "User access list" do
         click_button "Update Access List"
       end.not_to change(LogEvent, :count)
     end
-  end
 
+    context "describe inactive product filter" do
+      before do
+        login_as admin
+
+        product1.update(is_archived: true)
+      end
+
+      it "can hide inactive products", :js do
+        visit facility_user_access_list_path(facility, user)
+
+        within("table") do
+          expect(page).to have_content("#{product1.name} (inactive)")
+          expect(page).to have_content(product2.name)
+        end
+
+        # Toggle hidde inactive
+        check("Hide inactive Products")
+
+        within("table") do
+          expect(page).not_to have_content("#{product1.name} (inactive)")
+          expect(page).to have_content(product2.name)
+        end
+
+        # Toggle hide again
+        uncheck("Hide inactive Products")
+
+        within("table") do
+          expect(page).to have_content("#{product1.name} (inactive)")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Notes

On the user product access list, add a checkbox to toggle hide inactive products.
Also added `(inactive)` label next to the name.

## Screenshots

![Captura de pantalla 2025-05-12 a la(s) 16 31 46](https://github.com/user-attachments/assets/cd84fa4e-3d50-4545-b5bb-29dae7cbe8d0)
