### PR TITLE
[NUOPEN-229] Add total price row in Estimate show

### DIFF
--- a/app/models/estimate.rb
+++ b/app/models/estimate.rb
@@ -11,6 +11,10 @@ class Estimate < ApplicationRecord
   validate :expires_at_cannot_be_in_the_past
   validates :expires_at, presence: true
 
+  def total_cost
+    estimate_details.sum(&:cost)
+  end
+
   private
 
   def expires_at_cannot_be_in_the_past

--- a/app/views/facility_estimates/show.html.haml
+++ b/app/views/facility_estimates/show.html.haml
@@ -39,3 +39,8 @@
           - elsif estimate_detail.duration_unit.present?
             = "#{estimate_detail.duration} #{t(".days")}"
         %td.currency= number_to_currency(estimate_detail.cost)
+  %tfoot
+    %tr
+      %td{colspan: 3}
+      %td.currency
+        %strong=number_to_currency(@estimate.total_cost)

--- a/spec/system/admin/creating_an_estimate_spec.rb
+++ b/spec/system/admin/creating_an_estimate_spec.rb
@@ -100,5 +100,9 @@ RSpec.describe(
     expect(page).to have_content ActionController::Base.helpers.number_to_currency(instrument_price_policy.usage_rate * 180) # 1.5 hours * 2 = 3 hours
     expect(page).to have_content "#{other_item.name} (#{other_facility.name})"
     expect(page).to have_content ActionController::Base.helpers.number_to_currency(other_item_price_policy.unit_cost) # 1 item
+    total = other_item_price_policy.unit_cost +
+            item_price_policy.unit_cost * 2 +
+            instrument_price_policy.usage_rate * 180
+    expect(page).to have_content ActionController::Base.helpers.number_to_currency(total)
   end
 end

--- a/spec/system/admin/creating_an_estimate_spec.rb
+++ b/spec/system/admin/creating_an_estimate_spec.rb
@@ -101,8 +101,8 @@ RSpec.describe(
     expect(page).to have_content "#{other_item.name} (#{other_facility.name})"
     expect(page).to have_content ActionController::Base.helpers.number_to_currency(other_item_price_policy.unit_cost) # 1 item
     total = other_item_price_policy.unit_cost +
-            item_price_policy.unit_cost * 2 +
-            instrument_price_policy.usage_rate * 180
+            (item_price_policy.unit_cost * 2) +
+            (instrument_price_policy.usage_rate * 180)
     expect(page).to have_content ActionController::Base.helpers.number_to_currency(total)
   end
 end


### PR DESCRIPTION
# Release Notes
* Add total price row in Estimate show

# Screenshot
![image](https://github.com/user-attachments/assets/70006e19-aef4-4561-b8d7-c24c1cf0890b)


