### PR TITLE
[UMASS-161] Hide inactive products by default

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -99,7 +99,7 @@ class UsersController < ApplicationController
 
     @facility = current_facility
     product_relation = Product.for_facility(@facility)
-    product_relation = product_relation.active if params[:hide_inactive] == "1"
+    product_relation = product_relation.active unless params[:show_inactive] == "1"
 
     @products_by_type = product_relation.requiring_approval_by_type
     @training_requested_product_ids = @user.training_requests.pluck(:product_id)

--- a/app/views/users/access_list.html.haml
+++ b/app/views/users/access_list.html.haml
@@ -20,8 +20,8 @@
       = form_with(url: facility_user_access_list_path(current_facility),
         method: :get, class: "js--submit-on-change") do |f|
         .checkbox
-          = f.check_box :hide_inactive, checked: params[:hide_inactive] == "1"
-          = f.label :hide_inactive, t(".hide_inactive")
+          = f.check_box :show_inactive, checked: params[:show_inactive] == "1"
+          = f.label :show_inactive, t(".show_inactive")
 
   = form_for :user, url: facility_user_access_list_approvals_path(@facility, @user) do |form|
     - @products_by_type.each_pair do |product_type, products|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1139,7 +1139,7 @@ en:
       training_requested: Training Requested
       update_approvals:
         submit: "Update Access List"
-      hide_inactive: Hide inactive Products
+      show_inactive: Show inactive Products
 
     new_external:
       head: "Add User"

--- a/spec/system/admin/user_access_list_spec.rb
+++ b/spec/system/admin/user_access_list_spec.rb
@@ -47,27 +47,27 @@ RSpec.describe "User access list" do
         product1.update(is_archived: true)
       end
 
-      it "can hide inactive products", :js do
+      it "can show inactive products", :js do
         visit facility_user_access_list_path(facility, user)
 
         within("table") do
+          expect(page).to_not have_content("#{product1.name} (inactive)")
+          expect(page).to have_content(product2.name)
+        end
+
+        # Toggle show inactive
+        check("Show inactive Products")
+
+        within("table") do
           expect(page).to have_content("#{product1.name} (inactive)")
           expect(page).to have_content(product2.name)
         end
 
-        # Toggle hide inactive
-        check("Hide inactive Products")
+        # Toggle show again
+        uncheck("Show inactive Products")
 
         within("table") do
-          expect(page).not_to have_content("#{product1.name} (inactive)")
-          expect(page).to have_content(product2.name)
-        end
-
-        # Toggle hide again
-        uncheck("Hide inactive Products")
-
-        within("table") do
-          expect(page).to have_content("#{product1.name} (inactive)")
+          expect(page).to_not have_content("#{product1.name} (inactive)")
         end
       end
     end


### PR DESCRIPTION
## Notes

On the user product access list, hide inactive products by default. Change "Hide inactive products" checkbox by "Show inactive Products".

## Screenshot

![Captura de pantalla 2025-05-15 a la(s) 14 58 39](https://github.com/user-attachments/assets/db5fea8e-472f-4289-b9f6-bf376f864b97)
