### PR TITLE
[OSU-52] Fix translation missing condition

### DIFF
--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -23,13 +23,11 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
   end
 
   def warnings
-    warnings = []
-
-    problem_description_key.then do |problem_key|
-      warnings << Notice.new(problem_key, :warning) if problem_key.present? && problem?
+    if problem?
+      [Notice.new(problem_description_key || :problem_out_of_sync, :warning)]
+    else
+      []
     end
-
-    warnings
   end
 
   def notices

--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -25,8 +25,8 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
   def warnings
     warnings = []
 
-    problem_description_key.then do |problem_keys|
-      warnings << Notice.new(problem_keys, :warning) if problem_keys.present? && problem?
+    problem_description_key.then do |problem_key|
+      warnings << Notice.new(problem_key, :warning) if problem_key.present? && problem?
     end
 
     warnings

--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -25,7 +25,9 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
   def warnings
     warnings = []
 
-    warnings << Notice.new(problem_description_key, :warning) if problem?
+    problem_description_key.then do |problem_keys|
+      warnings << Notice.new(problem_keys, :warning) if problem_keys.present? && problem?
+    end
 
     warnings
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -840,6 +840,9 @@ en:
       awaiting_payment:
         alert: This order has been !statemented_downcase!, but is not yet reconciled
         badge: Awaiting Payment
+      problem_out_of_sync:
+        alert: The problem has been resolved, please save this order to remove the alert
+        badge: Problem out of sync
     note: "Note: %{note}"
 
   product_accessories:

--- a/spec/presenters/order_detail_notice_presenter_spec.rb
+++ b/spec/presenters/order_detail_notice_presenter_spec.rb
@@ -76,6 +76,11 @@ RSpec.describe OrderDetailNoticePresenter do
       expect(presenter.badges_to_html).to have_badge("Missing Price Policy").with_level(:important)
     end
 
+    it "detects problem flag without problem description" do
+      allow(order_detail).to receive_messages(problem?: true, problem_description_key: nil)
+      expect(presenter.badges_to_html).to have_badge("Problem out of sync").with_level(:important)
+    end
+
     it "can have multiple badges" do
       # These examples are technically mutually exclusive, but this validates the
       # presenter can handle it.


### PR DESCRIPTION
## Note

Fix missing translation caused by order details with `problem_description_key` nil but `problem` attribute set to true.