### PR TITLE
[NUOPEN-239] Fix engine specs

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -37,13 +37,7 @@ jobs:
         id: glob
         with:
           files: |
-            vendor/engines/bulk_email/spec/**/*_spec.rb
-            vendor/engines/c2po/spec/**/*_spec.rb
-            vendor/engines/dataprobe/spec/**/*_spec.rb
-            vendor/engines/projects/spec/**/*_spec.rb
-            vendor/engines/saml_authentication/spec/**/*_spec.rb
-            vendor/engines/sanger_sequencing/spec/**/*_spec.rb
-            vendor/engines/split_accounts/spec/**/*_spec.rb
+            vendor/engines/*/spec/**/*_spec.rb
 
       - run: bundle exec rails assets:precompile
       - run: bundle exec rspec ${{ steps.glob.outputs.paths }}

--- a/spec/controllers/offline_reservations_controller_spec.rb
+++ b/spec/controllers/offline_reservations_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe OfflineReservationsController do
       end
 
       it "does not triggers an email" do
-        expect { post :create, params: params }.not_to change(ActionMailer::Base.deliveries, :count)
+        expect { post :create, params: params }.not_to enqueue_mail
       end
     end
   end

--- a/spec/controllers/order_management/order_details_controller_spec.rb
+++ b/spec/controllers/order_management/order_details_controller_spec.rb
@@ -899,7 +899,7 @@ RSpec.describe OrderManagement::OrderDetailsController do
               end
 
               it "does not trigger an email" do
-                expect { do_request }.not_to change(ActionMailer::Base.deliveries, :count)
+                expect { do_request }.not_to enqueue_mail
               end
             end
           end
@@ -916,7 +916,7 @@ RSpec.describe OrderManagement::OrderDetailsController do
             end
 
             it "does not trigger an email" do
-              expect { do_request }.not_to change(ActionMailer::Base.deliveries, :count)
+              expect { do_request }.not_to enqueue_mail
             end
           end
         end

--- a/spec/controllers/training_requests_controller_spec.rb
+++ b/spec/controllers/training_requests_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe TrainingRequestsController, feature_setting: { training_requests:
 
         describe "no contacts are assigned" do
           let(:training_request_contacts) { "" }
-          it "does not send an email" do
+          it "does not send an email", :perform_enqueued_jobs do
             expect { do_request }.not_to change(ActionMailer::Base.deliveries, :count)
           end
         end
@@ -80,7 +80,7 @@ RSpec.describe TrainingRequestsController, feature_setting: { training_requests:
         end
 
         it "does not send an email" do
-          expect { do_request }.not_to change(ActionMailer::Base.deliveries, :count)
+          expect { do_request }.not_to enqueue_mail
         end
       end
     end

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -1208,7 +1208,7 @@ RSpec.describe Reservation do
       end
 
       it "does not trigger an email" do
-        expect { reservation.start_reservation! }.not_to change(ActionMailer::Base.deliveries, :count)
+        expect { reservation.start_reservation! }.not_to enqueue_mail
       end
     end
 
@@ -1229,7 +1229,7 @@ RSpec.describe Reservation do
       end
 
       it "does not trigger an email" do
-        expect { reservation.start_reservation! }.not_to change(ActionMailer::Base.deliveries, :count)
+        expect { reservation.start_reservation! }.not_to enqueue_mail
       end
     end
 
@@ -1247,7 +1247,7 @@ RSpec.describe Reservation do
       end
 
       it "does not trigger an email" do
-        expect { reservation.start_reservation! }.not_to change(ActionMailer::Base.deliveries, :count)
+        expect { reservation.start_reservation! }.not_to enqueue_mail
       end
     end
   end

--- a/spec/services/order_row_importer_spec.rb
+++ b/spec/services/order_row_importer_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe OrderRowImporter do
       it_behaves_like "an order was created"
 
       it "does not trigger any emails" do
-        expect { subject.import }.not_to change(ActionMailer::Base.deliveries, :count)
+        expect { subject.import }.not_to enqueue_mail
       end
 
       it "puts the order detail into Completed status" do

--- a/spec/services/results_file_notifier_spec.rb
+++ b/spec/services/results_file_notifier_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ResultsFileNotifier do
 
   describe "with notifications disabled", feature_setting: { results_file_notifications: false } do
     it "does not send a notification" do
-      expect { notifier.notify }.not_to change(ActionMailer::Base.deliveries, :count)
+      expect { notifier.notify }.not_to enqueue_mail
     end
   end
 

--- a/spec/services/statement_creator_spec.rb
+++ b/spec/services/statement_creator_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe StatementCreator do
 
     context "when statement emailing is off", feature_setting: { send_statement_emails: false } do
       it "does not send statements" do
-        expect { creator.send_statement_emails }.not_to change(ActionMailer::Base.deliveries, :count)
+        expect { creator.send_statement_emails }.not_to enqueue_mail
       end
     end
   end

--- a/vendor/engines/secure_rooms/spec/services/secure_rooms/access_handlers/order_handler_spec.rb
+++ b/vendor/engines/secure_rooms/spec/services/secure_rooms/access_handlers/order_handler_spec.rb
@@ -111,7 +111,9 @@ RSpec.describe SecureRooms::AccessHandlers::OrderHandler, type: :service do
         it { is_expected.to be_problem }
 
         it "triggers an email" do
-          expect { described_class.process(occupancy) }.to change(ActionMailer::Base.deliveries, :count).by(1)
+          expect { described_class.process(occupancy) }.to(
+            enqueue_mail(ProblemOrderMailer, :notify_user)
+          )
         end
       end
     end

--- a/vendor/engines/secure_rooms/spec/support/auto_orphan_occupancy_spec.rb
+++ b/vendor/engines/secure_rooms/spec/support/auto_orphan_occupancy_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe SecureRooms::AutoOrphanOccupancy, :time_travel do
       end
 
       it "triggers an email" do
-        expect { action.perform }.to change(ActionMailer::Base.deliveries, :count).by(1)
+        expect { action.perform }.to enqueue_mail(ProblemOrderMailer, :notify_user)
       end
     end
 
@@ -87,7 +87,7 @@ RSpec.describe SecureRooms::AutoOrphanOccupancy, :time_travel do
       end
 
       it "does not trigger an email" do
-        expect { action.perform }.not_to change(ActionMailer::Base.deliveries, :count)
+        expect { action.perform }.not_to enqueue_mail
       end
     end
 


### PR DESCRIPTION
## Notes

- Some engines specs were not running in the CI. I've fixed mailer matchers on those and added to the CI.
- Use mailer matcher for email not delivered specs