### PR TITLE
[Shared dev][NUOPEN-255] Rename User and Name fields in Estimate

### DIFF
--- a/app/controllers/facility_estimates_controller.rb
+++ b/app/controllers/facility_estimates_controller.rb
@@ -103,7 +103,7 @@ class FacilityEstimatesController < ApplicationController
 
   def facility_estimate_params
     params.require(:estimate).permit(
-      :name, :price_group_id, :user_id, :custom_name, :note, :expires_at,
+      :description, :price_group_id, :user_id, :custom_name, :note, :expires_at,
       estimate_details_attributes: [:id, :product_id, :quantity, :duration, :duration_unit, :_destroy]
     )
   end

--- a/app/services/estimates/estimate_csv_service.rb
+++ b/app/services/estimates/estimate_csv_service.rb
@@ -11,7 +11,7 @@ module Estimates
     def to_csv
       CSV.generate do |csv|
         csv << ["Estimate Information"]
-        csv << ["ID", "Description", "Created By", "User", "Expiration Date"]
+        csv << ["ID", "Description", "Created By", "Username", "Expiration Date"]
         csv << [@estimate.id, @estimate.description, @estimate.created_by_user.full_name, @estimate.user_display_name, format_usa_date(@estimate.expires_at)]
         csv << []
 

--- a/app/services/estimates/estimate_csv_service.rb
+++ b/app/services/estimates/estimate_csv_service.rb
@@ -11,8 +11,8 @@ module Estimates
     def to_csv
       CSV.generate do |csv|
         csv << ["Estimate Information"]
-        csv << ["ID", "Name", "Created By", "User", "Expiration Date"]
-        csv << [@estimate.id, @estimate.name, @estimate.created_by_user.full_name, @estimate.user_display_name, format_usa_date(@estimate.expires_at)]
+        csv << ["ID", "Description", "Created By", "User", "Expiration Date"]
+        csv << [@estimate.id, @estimate.description, @estimate.created_by_user.full_name, @estimate.user_display_name, format_usa_date(@estimate.expires_at)]
         csv << []
 
         csv << ["Products"]

--- a/app/views/facility_estimates/index.html.haml
+++ b/app/views/facility_estimates/index.html.haml
@@ -35,14 +35,14 @@
     %thead
       %tr
         %th= Estimate.human_attribute_name(:id)
-        %th= Estimate.human_attribute_name(:name)
+        %th= Estimate.human_attribute_name(:description)
         %th= Estimate.human_attribute_name(:user)
         %th= Estimate.human_attribute_name(:expires_at)
     %tbody
       - @estimates.each do |estimate|
         %tr{class: ("row-warning" if estimate.expires_at < Time.current)}
           %td= link_to estimate.id, facility_estimate_path(current_facility, estimate)
-          %td= estimate.name
+          %td= estimate.description
           %td= estimate.user_display_name
           %td= format_usa_date(estimate.expires_at)
 - else

--- a/app/views/facility_estimates/new.html.haml
+++ b/app/views/facility_estimates/new.html.haml
@@ -5,7 +5,7 @@
 
 = simple_form_for @estimate, url: facility_estimates_path(@estimate.facility), method: :post do |f|
   .inline-form-controls
-    = f.input :name
+    = f.input :description
     .span-4
       = f.label :price_group_id, EstimateDetail.human_attribute_name(:price_group_id)
       = f.input_field :price_group_id,

--- a/app/views/facility_estimates/show.html.haml
+++ b/app/views/facility_estimates/show.html.haml
@@ -2,7 +2,7 @@
   = current_facility
 
 - header = "#{Estimate.model_name.human} ##{@estimate.id}"
-- header = @estimate.name.present? ? "#{header} - #{@estimate.name}" : header
+- header = @estimate.description.present? ? "#{header} - #{@estimate.description}" : header
 
 %h2= header
 

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -251,7 +251,7 @@ en:
       affiliate:
         subaffiliates_enabled: Allows subaffiliates
       estimate:
-        name: Name
+        description: Description
         user: User
         user_display_name: User
         custom_name: Custom Name

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -252,9 +252,9 @@ en:
         subaffiliates_enabled: Allows subaffiliates
       estimate:
         description: Description
-        user: User
-        user_display_name: User
-        custom_name: Custom Name
+        user: Username
+        user_display_name: Username
+        custom_name: Custom Username
         created_by_user: Created By
         expires_at: Expires at
         note: Notes

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -525,7 +525,7 @@ en:
       add: Add Estimate
       all_users: All Users
       clear_filter: Clear Filters
-      filter_user: Filter by User
+      filter_user: Filter by Username
       hide_expired: Hide expired estimates
       no_estimates: No estimates found
       search: Search
@@ -541,7 +541,7 @@ en:
       add_products_to_estimate: Add Products to Estimate
       cancel: Cancel
       create: Create an Estimate
-      custom_name_placeholder: "Enter custom name"
+      custom_name_placeholder: "Enter custom username"
       head: Add Estimate
       or: "or"
     show:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -529,7 +529,7 @@ en:
       hide_expired: Hide expired estimates
       no_estimates: No estimates found
       search: Search
-      search_placeholder: Search by name or ID
+      search_placeholder: Search by description or ID
     create:
       success: Estimate successfully created
       error: There was an error creating the estimate

--- a/db/migrate/20250523193939_rename_name_in_estimates.rb
+++ b/db/migrate/20250523193939_rename_name_in_estimates.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameNameInEstimates < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :estimates, :name, :description
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_05_20_161459) do
+ActiveRecord::Schema[7.0].define(version: 2025_05_23_193939) do
   create_table "account_facility_joins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "facility_id", null: false
     t.integer "account_id", null: false
@@ -173,7 +173,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_05_20_161459) do
   end
 
   create_table "estimates", charset: "utf8mb3", force: :cascade do |t|
-    t.string "name"
+    t.string "description"
     t.text "note"
     t.datetime "expires_at"
     t.bigint "facility_id", null: false

--- a/spec/factories/estimates.rb
+++ b/spec/factories/estimates.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     user
     price_group
     association :created_by_user, factory: :user
-    name { "Test Estimate" }
+    description { "Test Estimate" }
     note { "This is a test estimate" }
     expires_at { 30.days.from_now }
   end

--- a/spec/services/estimates/estimate_csv_service_spec.rb
+++ b/spec/services/estimates/estimate_csv_service_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Estimates::EstimateCsvService do
 
       it "generates the header section correctly" do
         expect(csv_rows[0]).to eq(["Estimate Information"])
-        expect(csv_rows[1]).to eq(["ID", "Description", "Created By", "User", "Expiration Date"])
+        expect(csv_rows[1]).to eq(["ID", "Description", "Created By", "Username", "Expiration Date"])
         expect(csv_rows[2]).to eq(
           [
             estimate.id.to_s,

--- a/spec/services/estimates/estimate_csv_service_spec.rb
+++ b/spec/services/estimates/estimate_csv_service_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Estimates::EstimateCsvService do
     create(:estimate,
            user:,
            created_by_user: creator,
-           name: "Test Estimate",
+           description: "Test Estimate",
            price_group:,
            expires_at: 1.week.from_now)
   end
@@ -57,7 +57,7 @@ RSpec.describe Estimates::EstimateCsvService do
 
       it "generates the header section correctly" do
         expect(csv_rows[0]).to eq(["Estimate Information"])
-        expect(csv_rows[1]).to eq(["ID", "Name", "Created By", "User", "Expiration Date"])
+        expect(csv_rows[1]).to eq(["ID", "Description", "Created By", "User", "Expiration Date"])
         expect(csv_rows[2]).to eq(
           [
             estimate.id.to_s,

--- a/spec/system/admin/creating_an_estimate_spec.rb
+++ b/spec/system/admin/creating_an_estimate_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe(
 
     fill_in "Note", with: "This is a test estimate"
 
-    fill_in "User", with: user.first_name
+    fill_in "Username", with: user.first_name
     find(".ui-autocomplete li", text: user.full_name).click
 
     expect(page).to have_content "Add Products to Estimate"
@@ -110,7 +110,7 @@ RSpec.describe(
       remove_button.click
     end
 
-    fill_in "User", with: user.first_name
+    fill_in "Username", with: user.first_name
     find(".ui-autocomplete li", text: user.full_name).click
 
     click_button "Add Estimate"
@@ -147,7 +147,7 @@ RSpec.describe(
     fill_in "Description", with: "New User Estimate"
     select_from_chosen price_group.name, from: "Price group"
 
-    fill_in "User", with: "Michael Smith"
+    fill_in "Username", with: "Michael Smith"
 
     expect(page).to have_content "Add Products to Estimate"
     select_from_chosen item.name, from: "Product"

--- a/spec/system/admin/creating_an_estimate_spec.rb
+++ b/spec/system/admin/creating_an_estimate_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe(
     click_link "Add Estimate"
     expect(page).to have_content "Create an Estimate"
 
-    fill_in "Name", with: "Test Estimate"
+    fill_in "Description", with: "Test Estimate"
     fill_in "Expires at", with: 1.month.from_now.strftime("%m/%d/%Y")
     select_from_chosen price_group.name, from: "Price group"
 
@@ -144,7 +144,7 @@ RSpec.describe(
     click_link "Add Estimate"
     expect(page).to have_content "Create an Estimate"
 
-    fill_in "Name", with: "New User Estimate"
+    fill_in "Description", with: "New User Estimate"
     select_from_chosen price_group.name, from: "Price group"
 
     fill_in "User", with: "Michael Smith"

--- a/spec/system/admin/viewing_estimates_spec.rb
+++ b/spec/system/admin/viewing_estimates_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe "Viewing estimates", :disable_requests_local do
   let(:staff) { create(:user, :staff, facility:) }
   let(:regular_user) { create(:user) }
 
-  let!(:estimate1) { create(:estimate, facility:, name: "First Estimate", created_at: 2.days.ago) }
-  let!(:estimate2) { create(:estimate, facility:, name: "Second Estimate", created_at: 1.day.ago) }
+  let!(:estimate1) { create(:estimate, facility:, description: "First Estimate", created_at: 2.days.ago) }
+  let!(:estimate2) { create(:estimate, facility:, description: "Second Estimate", created_at: 1.day.ago) }
 
   context "viewing index page" do
     context "as authorized roles" do
@@ -30,7 +30,7 @@ RSpec.describe "Viewing estimates", :disable_requests_local do
           click_link estimate1.id
 
           expect(page).to have_content "Estimate ##{estimate1.id}"
-          expect(page).to have_content estimate1.name
+          expect(page).to have_content estimate1.description
           expect(page).to have_content estimate1.user.full_name
           expect(page).to have_content estimate1.created_by_user.full_name
           expect(page).to have_content estimate1.note


### PR DESCRIPTION
# Release Notes
* Rename User and Name fields in Estimate

# Screenshot
## Index
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/d955ea4c-8a2f-4073-91cf-efff22700889" />

## New
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/c09bf604-de6a-45fe-ae19-14716dcdaa32" />

## Show
<img width="1209" alt="image" src="https://github.com/user-attachments/assets/1e681659-515d-4d44-a14b-ff3468618412" />


# Additional Context
Decided to only rename in the DB the `name` field. `user` is still called the same but the display name is changed to "Username"