### PR TITLE
[NUOPEN-235] Autocoplete username on estimates edit screen

### DIFF
--- a/app/views/facility_estimates/_form.html.haml
+++ b/app/views/facility_estimates/_form.html.haml
@@ -13,6 +13,7 @@
       = f.label :custom_name, Estimate.human_attribute_name(:user)
       = f.input_field :custom_name,
         class: "js--user-autocomplete",
+        value: (@estimate.user.try(:name) || @estimate.custom_name),
         data: { search_url: search_facility_estimates_path, user_input_id: "estimate_user_id" }
       = f.hidden_field :user_id
 

--- a/app/views/facility_estimates/_form.html.haml
+++ b/app/views/facility_estimates/_form.html.haml
@@ -13,7 +13,7 @@
       = f.label :custom_name, Estimate.human_attribute_name(:user)
       = f.input_field :custom_name,
         class: "js--user-autocomplete",
-        value: (@estimate.user.try(:name) || @estimate.custom_name),
+        value: (@estimate.user_display_name),
         data: { search_url: search_facility_estimates_path, user_input_id: "estimate_user_id" }
       = f.hidden_field :user_id
 

--- a/spec/system/admin/editing_an_estimate_spec.rb
+++ b/spec/system/admin/editing_an_estimate_spec.rb
@@ -85,6 +85,9 @@ RSpec.describe "Editing an estimate", :js do
     click_link "Edit"
     expect(page).to have_content "Edit Estimate"
 
+    user_input = find_field("User")
+    expect(user_input.value).to eq user.full_name
+
     fill_in "User", with: "Custom Name"
 
     click_button "Update"


### PR DESCRIPTION
# Release Notes

While opening the estimate edit view for an estimate with an existing user, the username field was shown as empty. With this change, it autofills the username on the form
