### PR TITLE
[NUOPEN-233] Fix Estimate flow

### DIFF
--- a/app/controllers/facility_estimates_controller.rb
+++ b/app/controllers/facility_estimates_controller.rb
@@ -75,7 +75,7 @@ class FacilityEstimatesController < ApplicationController
   end
 
   def update
-    if @estimate.update(facility_estimate_params)
+    if @estimate.update(facility_estimate_params) && @estimate.recalculate
       flash[:notice] = t(".success")
       redirect_to facility_estimate_path(current_facility, @estimate)
     else

--- a/app/controllers/facility_estimates_controller.rb
+++ b/app/controllers/facility_estimates_controller.rb
@@ -106,11 +106,14 @@ class FacilityEstimatesController < ApplicationController
   def recalculate
     if @estimate.recalculate
       flash[:notice] = t(".success")
+      redirect_to facility_estimate_path(current_facility, @estimate)
     else
-      flash[:error] = t(".error")
+      set_collections_for_select
+
+      flash.now[:error] = t(".error")
+      render :edit
     end
 
-    redirect_to facility_estimate_path(current_facility, @estimate)
   end
 
   def duplicate

--- a/app/controllers/facility_estimates_controller.rb
+++ b/app/controllers/facility_estimates_controller.rb
@@ -113,13 +113,12 @@ class FacilityEstimatesController < ApplicationController
       flash.now[:error] = t(".error")
       render :edit
     end
-
   end
 
   def duplicate
     duplicated_estimate = @estimate.duplicate(current_user)
 
-    if duplicated_estimate.pesisted?
+    if duplicated_estimate.persisted?
       flash[:notice] = t(".success")
       redirect_to facility_estimate_path(current_facility, duplicated_estimate)
     else

--- a/app/controllers/facility_estimates_controller.rb
+++ b/app/controllers/facility_estimates_controller.rb
@@ -58,7 +58,9 @@ class FacilityEstimatesController < ApplicationController
   end
 
   def create
-    @estimate = current_facility.estimates.new(facility_estimate_params.merge(created_by_id: current_user.id))
+    @estimate = current_facility.estimates.new(
+      facility_estimate_params.merge(created_by_id: current_user.id)
+    )
 
     if @estimate.save
       flash[:notice] = t(".success")
@@ -75,13 +77,14 @@ class FacilityEstimatesController < ApplicationController
   end
 
   def update
-    if @estimate.update(facility_estimate_params) && @estimate.recalculate
+    if @estimate.update(facility_estimate_params)
       flash[:notice] = t(".success")
       redirect_to facility_estimate_path(current_facility, @estimate)
     else
       set_collections_for_select
 
       flash.now[:error] = t(".error")
+
       render :edit
     end
   end
@@ -134,8 +137,12 @@ class FacilityEstimatesController < ApplicationController
 
   def facility_estimate_params
     raw_params = params.require(:estimate).permit(
-      :description, :price_group_id, :user_id, :custom_name, :note, :expires_at,
-      estimate_details_attributes: [:id, :product_id, :quantity, :duration, :duration_unit, :_destroy]
+      :description, :price_group_id, :user_id,
+      :custom_name, :note, :expires_at,
+      estimate_details_attributes: [
+        :id, :product_id, :quantity, :duration,
+        :duration_unit, :_destroy, :recalculate,
+      ]
     )
     if raw_params[:expires_at].present?
       raw_params[:expires_at] = parse_usa_date(raw_params[:expires_at])

--- a/app/controllers/facility_estimates_controller.rb
+++ b/app/controllers/facility_estimates_controller.rb
@@ -119,12 +119,15 @@ class FacilityEstimatesController < ApplicationController
   def duplicate
     duplicated_estimate = @estimate.duplicate(current_user)
 
-    if duplicated_estimate.present?
+    if duplicated_estimate.pesisted?
       flash[:notice] = t(".success")
       redirect_to facility_estimate_path(current_facility, duplicated_estimate)
     else
+      @estimate = duplicated_estimate
+      set_collections_for_select
+
       flash[:error] = t(".error")
-      redirect_to facility_estimate_path(current_facility, @estimate)
+      render :new
     end
   end
 

--- a/app/models/estimate.rb
+++ b/app/models/estimate.rb
@@ -48,10 +48,20 @@ class Estimate < ApplicationRecord
   end
 
   def recalculate
+    success = true
+
     transaction do
-      estimate_details.each(&:assign_price_policy_and_cost)
-      save
+      if estimate_details.all?(&:assign_price_policy_and_cost)
+        save!
+      else
+        success = false
+      end
+    rescue StandardError
+      success = false
+      raise ActiveRecord::Rollback
     end
+
+    success
   end
 
   private

--- a/app/models/estimate.rb
+++ b/app/models/estimate.rb
@@ -27,7 +27,8 @@ class Estimate < ApplicationRecord
     duplicated_estimate = dup
     duplicated_estimate.created_by_id = created_by_user.id
     duplicated_estimate.expires_at = 1.month.from_now
-    duplicated_estimate.description = "Copy of #{description}"
+
+    duplicated_estimate.description = "Copy of #{description.presence || id}"
 
     details_to_copy = estimate_details.map(&:dup)
 
@@ -49,7 +50,7 @@ class Estimate < ApplicationRecord
       else
         success = false
       end
-    rescue StandardError
+    rescue ActiveRecord::RecordInvalid
       success = false
       raise ActiveRecord::Rollback
     end

--- a/app/models/estimate_detail.rb
+++ b/app/models/estimate_detail.rb
@@ -28,12 +28,17 @@ class EstimateDetail < ApplicationRecord
   def assign_price_policy_and_cost
     pp = product.cheapest_price_policy(self, Time.current)
 
-    return if pp.blank?
+    if pp.blank?
+      errors.add(:base, I18n.t("activerecord.errors.models.estimate_detail.no_price_policy"))
+      return false
+    end
 
     cost = pp.estimate_cost_from_estimate_detail(self)
 
     self.price_policy = pp
     self.cost = cost
+
+    true
   end
 
   private

--- a/app/models/estimate_detail.rb
+++ b/app/models/estimate_detail.rb
@@ -8,7 +8,8 @@ class EstimateDetail < ApplicationRecord
   belongs_to :price_policy
 
   before_save :clear_duration_fields
-  before_save :assign_price_policy_and_cost
+  before_create :assign_price_policy_and_cost
+  before_update :assign_price_policy_and_cost, if: :recalculate
 
   validates :quantity, presence: true, numericality: { greater_than: 0 }
   validates :duration, numericality: { greater_than: 0 }, allow_nil: true
@@ -16,6 +17,10 @@ class EstimateDetail < ApplicationRecord
   validate :price_policy_exists
 
   delegate :user, to: :estimate
+
+  # Used to trigger before_save callback and
+  # perform a recalculation on save
+  attribute :recalculate
 
   def price_groups
     if product.nonbillable_mode?

--- a/app/models/estimate_detail.rb
+++ b/app/models/estimate_detail.rb
@@ -18,8 +18,7 @@ class EstimateDetail < ApplicationRecord
 
   delegate :user, to: :estimate
 
-  # Used to trigger before_save callback and
-  # perform a recalculation on save
+  # Used to trigger before_update callback
   attribute :recalculate
 
   def price_groups

--- a/app/views/facility_estimates/_estimate_detail.html.haml
+++ b/app/views/facility_estimates/_estimate_detail.html.haml
@@ -7,6 +7,7 @@
     = hidden_field_tag "#{id_prefix}[duration_unit]", estimate_detail.duration_unit
   
   = hidden_field_tag "#{id_prefix}[_destroy]", false, class: 'destroy-field', id: "destroy_#{index}"
+  = hidden_field_tag "#{id_prefix}[recalculate]", true
 
   %td
     %div

--- a/spec/system/admin/duplicating_an_estimate_spec.rb
+++ b/spec/system/admin/duplicating_an_estimate_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe "Estimate Duplication", :js do
       within("#estimate_products_table") do
         estimate.estimate_details.each do |estimate_detail|
           expect(page).to have_content(estimate_detail.product.name)
+          expect(page).to have_css(".error-inline", text: "No price policy found.")
         end
       end
     end

--- a/spec/system/admin/editing_an_estimate_spec.rb
+++ b/spec/system/admin/editing_an_estimate_spec.rb
@@ -101,4 +101,21 @@ RSpec.describe "Editing an estimate", :js do
     expect(estimate.user_id).to be_nil
     expect(estimate.custom_name).to eq("Custom Name")
   end
+
+  it "recalculates the cost when updating" do
+    old_cost = item_price_policy.unit_cost
+    new_cost = 100
+    item_price_policy.update(unit_cost: new_cost)
+
+    visit facility_estimate_path(facility, estimate)
+    expect(page).to have_content ActionController::Base.helpers.number_to_currency(old_cost)
+
+    click_link "Edit"
+    expect(page).to have_content "Edit Estimate"
+
+    click_button "Update"
+
+    expect(page).to have_content "Estimate was successfully updated"
+    expect(page).to have_content ActionController::Base.helpers.number_to_currency(new_cost)
+  end
 end

--- a/spec/system/admin/recalculating_estimate_spec.rb
+++ b/spec/system/admin/recalculating_estimate_spec.rb
@@ -41,4 +41,21 @@ RSpec.describe(
     expect(updated_at).to be > 3.hours.ago
     expect(page).to have_content "Prices last updated: #{I18n.l(updated_at, format: :usa)}"
   end
+
+  context "when recalculating fails" do
+    let(:another_price_group) { create(:price_group, facility:) }
+
+    before do
+      estimate.update_columns(price_group_id: another_price_group.id)
+
+      visit facility_estimate_path(facility, estimate)
+    end
+
+    it "redirects to edit page" do
+      click_link "Recalculate"
+
+      expect(page).to have_content "Edit Estimate"
+      expect(page).to have_content "No price policy found."
+    end
+  end
 end


### PR DESCRIPTION
# Release Notes

* Fix Estimate flow

# Additional Context

* Make recalculation happen when clicking “Update”. ✅ 
* If “Recalculate” fails, redirect user to Edit page, so they can make the necessary changes. ✅ 
* If “Duplicate” fails, redirect user to New page, so they can see the errors and make any changes before saving. ✅ 