### PR TITLE
[NU-399] Default product blank on add to order

### DIFF
--- a/app/assets/javascripts/app/merge_orders.js
+++ b/app/assets/javascripts/app/merge_orders.js
@@ -55,6 +55,8 @@ window.MergeOrder = class MergeOrder {
     const defaultButtonText = button.data("default-button-text");
     const crossCoreButtonText = button.data("cross-core-button-text");
 
+    const mergeOrders = this;
+
     return facilityField.on("change", (event) => {
       const selectedElement = $(event.target).find(":selected");
       const productsUrl = selectedElement.data("products-path");
@@ -62,9 +64,6 @@ window.MergeOrder = class MergeOrder {
       const originalOrderFacility = selectedElement.data("original-order-facility");
       const originalOrder = selectedElement.data("original-order");
       const facility_id = $(event.target).val();
-      const includeBlank = JSON.parse(
-        accountField.data("include-blank")
-      );
 
       $.ajax({
         type: "get",
@@ -73,6 +72,12 @@ window.MergeOrder = class MergeOrder {
         success(data) {
           // Populate dropdown
           productField.empty();
+
+          const rawIncludeBlank = productField.attr("include_blank")
+          if (rawIncludeBlank && JSON.parse(rawIncludeBlank)) {
+            productField.append('<option value=""></option>');
+          }
+
           data = JSON.parse(data);
           data.forEach(function (product) {
             return productField.append(
@@ -86,6 +91,7 @@ window.MergeOrder = class MergeOrder {
             );
           });
 
+          mergeOrders.initTimeBasedServices()
           productField.trigger("chosen:updated");
 
           // Update button text
@@ -109,7 +115,8 @@ window.MergeOrder = class MergeOrder {
           accountField.empty();
           data = JSON.parse(data);
 
-          if (includeBlank) {
+          const rawIncludeBlank = accountField.attr("include_blank");
+          if (rawIncludeBlank && JSON.parse(rawIncludeBlank)) {
             accountField.append('<option value=""></option>');
           }
 

--- a/app/assets/javascripts/app/merge_orders.js
+++ b/app/assets/javascripts/app/merge_orders.js
@@ -32,7 +32,7 @@ window.MergeOrder = class MergeOrder {
       this.$duration_display_field.prop("disabled", !is_timed);
       this.$duration_hidden_field.prop("disabled", !is_timed);
 
-      this.$duration_display_container.toggle(is_timed);
+      this.$duration_display_container.toggle(!!is_timed);
 
       if (is_timed) { this.$quantity_field.val(1); }
       return this.$quantity_field.prop("disabled", is_timed);
@@ -54,8 +54,6 @@ window.MergeOrder = class MergeOrder {
     const originalFacilityId = button.data("original-facility");
     const defaultButtonText = button.data("default-button-text");
     const crossCoreButtonText = button.data("cross-core-button-text");
-
-    const mergeOrders = this;
 
     return facilityField.on("change", (event) => {
       const selectedElement = $(event.target).find(":selected");
@@ -91,7 +89,6 @@ window.MergeOrder = class MergeOrder {
             );
           });
 
-          mergeOrders.initTimeBasedServices()
           productField.trigger("chosen:updated");
 
           // Update button text

--- a/app/controllers/facility_orders_controller.rb
+++ b/app/controllers/facility_orders_controller.rb
@@ -155,6 +155,13 @@ class FacilityOrdersController < ApplicationController
         }
       end
     end
+
+    @merge_order_form_facility =
+      if (param_facility_id = params.dig(:add_to_order_form, :facility_id))
+        Facility.find(param_facility_id)
+      else
+        current_facility
+      end
   end
 
   def missing_reservation_order_ids(project_order_ids)

--- a/app/views/facility_orders/_merge_order_form.html.haml
+++ b/app/views/facility_orders/_merge_order_form.html.haml
@@ -17,9 +17,9 @@
         .margin_x
           = f.label :product_id, Product.model_name.human
           = f.input_field :product_id,
-            collection: current_facility.products.mergeable_into_order.alphabetized.map { |p| [p.name, p.id, {"data-timed-product" => p.order_quantity_as_time?}] },
+            collection: @merge_order_form_facility.products.mergeable_into_order.alphabetized.map { |p| [p.name, p.id, {"data-timed-product" => p.order_quantity_as_time?}] },
             class: "js--edit-order__product js--chosen",
-            include_blank: false
+            include_blank: true
 
         .js--edit-order__duration-container
           = f.label :duration, Product.human_attribute_name(:duration)

--- a/spec/system/admin/adding_to_an_order_spec.rb
+++ b/spec/system/admin/adding_to_an_order_spec.rb
@@ -4,12 +4,34 @@ require "rails_helper"
 
 RSpec.describe "Adding to an existing order" do
   let(:facility) { product.facility }
-  let(:order) { create(:purchased_order, product: product, ordered_at: 1.week.ago) }
-  let(:user) { create(:user, :staff, facility: facility) }
+  let(:order) { create(:purchased_order, product:, ordered_at: 1.week.ago) }
+  let(:user) { create(:user, :staff, facility:) }
   let!(:other_account) { create(:nufs_account, :with_account_owner, owner: order.user, description: "Other Account") }
 
   before do
     login_as user
+  end
+
+  describe "submitting blank product" do
+    let(:product) { create(:setup_item, :with_facility_account) }
+    let(:second_facility) { cross_product.facility }
+    let!(:cross_product) { create(:setup_item, :with_facility_account) }
+
+    it "renders errors and populates products select correctly" do
+      visit facility_order_path(facility, order)
+
+      expect(page).to(
+        have_select("Product", options: ["", product.name])
+      )
+
+      select second_facility.name, from: "Facility"
+      click_button "Add To Order"
+
+      expect(page).to have_content("Product can't be blank")
+      expect(page).to(
+        have_select("Product", options: ["", cross_product.name])
+      )
+    end
   end
 
   describe "adding an item" do
@@ -145,7 +167,7 @@ RSpec.describe "Adding to an existing order" do
   describe "adding an instrument reservation" do
     describe "from same facility" do
       let(:product) { create(:setup_item, :with_facility_account) }
-      let!(:instrument) { create(:setup_instrument, facility: facility) }
+      let!(:instrument) { create(:setup_instrument, facility:) }
 
       before do
         visit facility_order_path(facility, order)
@@ -179,7 +201,7 @@ RSpec.describe "Adding to an existing order" do
 
     describe "from same facility (with feature flag on)", :js do
       let(:product) { create(:setup_item, :with_facility_account) }
-      let!(:instrument) { create(:setup_instrument, facility: facility) }
+      let!(:instrument) { create(:setup_instrument, facility:) }
       let(:user) { create(:user, :facility_administrator, facility:) }
 
       before do


### PR DESCRIPTION
## Notes

On manage order form, set default product to empty option instead of selecting the first one.