### PR TITLE
[UMASS-124] Fix transaction order date sorting

### DIFF
--- a/app/controllers/concerns/sortable_billing_table.rb
+++ b/app/controllers/concerns/sortable_billing_table.rb
@@ -21,8 +21,9 @@ module SortableBillingTable
   end
 
   def default_sort_lookup_hash
+
     {
-      "date_range_field" => "order_details.fulfilled_at",
+      "date_range_field" => "order_details.#{order_detail_date_range_field}",
       "order_number" => ["order_details.order_id", "order_details.id"],
       "order_detail_number" => "order_details.id",
       "ordered_for" => ["users.last_name", "order_details.fulfilled_at"],
@@ -33,6 +34,10 @@ module SortableBillingTable
 
   def enable_sorting
     @sorting_enabled = true
+  end
+
+  def order_detail_date_range_field
+    @date_range_field || "fulfilled_at"
   end
 
 end


### PR DESCRIPTION
## Notes

Fix order details (transactions) sorting by date field. The date field changes depending on the filters between `ordered_at` and `fulfilled_at`. The former was not taking into account for sorting.