### PR TITLE
[NU-402] Add monetary cap field to P.O.s

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -171,6 +171,7 @@ feature:
   show_account_opencontract_field: false
   hide_account_far_future_expiration: false
   show_account_price_groups_tab: false
+  purchase_order_monetary_cap: false
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/db/migrate/20250611145625_add_monetary_cap_to_accounts.rb
+++ b/db/migrate/20250611145625_add_monetary_cap_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddMonetaryCapToAccounts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :accounts, :monetary_cap, :decimal, precision: 10, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_05_23_193939) do
+ActiveRecord::Schema[7.0].define(version: 2025_06_11_145625) do
   create_table "account_facility_joins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "facility_id", null: false
     t.integer "account_id", null: false
@@ -52,6 +52,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_05_23_193939) do
     t.string "outside_contact_info"
     t.string "ar_number"
     t.string "open_contract"
+    t.decimal "monetary_cap", precision: 10, scale: 2
     t.index ["affiliate_id"], name: "index_accounts_on_affiliate_id"
   end
 

--- a/spec/system/admin/managing_payment_sources_spec.rb
+++ b/spec/system/admin/managing_payment_sources_spec.rb
@@ -42,12 +42,12 @@ RSpec.describe "Managing accounts" do
 
       context "when feature flag is enabled", feature_setting: { purchase_order_monetary_cap: true } do
         it "shows the monetary cap field", :aggregate_failures do
-          expect(page).to have_field("Monetary Cap")
+          expect(page).to have_field("purchase_order_account_monetary_cap")
           expect(page).to have_content("Optional monetary cap for this purchase order account")
         end
 
         it "can set and save monetary cap value" do
-          fill_in "Monetary Cap", with: "1500.75"
+          fill_in "purchase_order_account_monetary_cap", with: "1500.75"
           click_on "Save"
 
           expect(page).to have_content("The payment source was successfully updated")
@@ -58,7 +58,7 @@ RSpec.describe "Managing accounts" do
 
       context "when feature flag is disabled", feature_setting: { purchase_order_monetary_cap: false } do
         it "does not show the monetary cap field" do
-          expect(page).not_to have_field("Monetary Cap")
+          expect(page).not_to have_field("purchase_order_account_monetary_cap")
           expect(page).not_to have_content("Optional monetary cap for this purchase order account")
         end
       end

--- a/vendor/engines/c2po/app/models/purchase_order_account.rb
+++ b/vendor/engines/c2po/app/models/purchase_order_account.rb
@@ -7,6 +7,7 @@ class PurchaseOrderAccount < Account
   include AffiliateAccount
 
   validates_presence_of :account_number
+  validates :monetary_cap, numericality: { greater_than: 0, allow_blank: true }, if: -> { SettingsHelper.feature_on?(:purchase_order_monetary_cap) }
 
   def to_s(with_owner = false, flag_suspended = true, with_facility: true)
     desc = super(with_owner, false)

--- a/vendor/engines/c2po/app/services/purchase_order_account_builder.rb
+++ b/vendor/engines/c2po/app/services/purchase_order_account_builder.rb
@@ -20,7 +20,7 @@ class PurchaseOrderAccountBuilder < AccountBuilder
       :formatted_expires_at,
       :outside_contact_info,
       :ar_number,
-    ] + permitted_account_params
+    ] + (SettingsHelper.feature_on?(:purchase_order_monetary_cap) ? [:monetary_cap] : []) + permitted_account_params
   end
 
   # Override strong_params for `update` account.
@@ -34,7 +34,7 @@ class PurchaseOrderAccountBuilder < AccountBuilder
       :formatted_expires_at,
       :outside_contact_info,
       :ar_number,
-    ] + permitted_account_params
+    ] + (SettingsHelper.feature_on?(:purchase_order_monetary_cap) ? [:monetary_cap] : []) + permitted_account_params
   end
 
   # Hooks into superclass's `build` method.

--- a/vendor/engines/c2po/app/views/c2po/facility_accounts/show/_additional_account_fields.html.haml
+++ b/vendor/engines/c2po/app/views/c2po/facility_accounts/show/_additional_account_fields.html.haml
@@ -3,5 +3,7 @@
 - elsif account.is_a?(PurchaseOrderAccount)
   = f.input :outside_contact_info
   = f.input :ar_number
+  - if SettingsHelper.feature_on?(:purchase_order_monetary_cap)
+    = f.input :monetary_cap, label: "Monetary Cap"
   - if SettingsHelper.feature_on?(:show_account_opencontract_field)
     = f.input :open_contract

--- a/vendor/engines/c2po/app/views/c2po/facility_accounts/show/_additional_account_fields.html.haml
+++ b/vendor/engines/c2po/app/views/c2po/facility_accounts/show/_additional_account_fields.html.haml
@@ -4,6 +4,6 @@
   = f.input :outside_contact_info
   = f.input :ar_number
   - if SettingsHelper.feature_on?(:purchase_order_monetary_cap)
-    = f.input :monetary_cap, label: "Monetary Cap"
+    = f.input :monetary_cap, label: Account.human_attribute_name(:monetary_cap)
   - if SettingsHelper.feature_on?(:show_account_opencontract_field)
     = f.input :open_contract

--- a/vendor/engines/c2po/app/views/facility_accounts/account_fields/_purchase_order_account.html.haml
+++ b/vendor/engines/c2po/app/views/facility_accounts/account_fields/_purchase_order_account.html.haml
@@ -6,7 +6,7 @@
 = f.input :description, required: true
 
 - if SettingsHelper.feature_on?(:purchase_order_monetary_cap)
-  = f.input :monetary_cap, label: "Monetary Cap", 
+  = f.input :monetary_cap, label: Account.human_attribute_name(:monetary_cap), 
     input_html: { step: 0.01 }, 
     hint: "Optional monetary cap for this purchase order account",
     hint_html: { class: "help-inline" }

--- a/vendor/engines/c2po/app/views/facility_accounts/account_fields/_purchase_order_account.html.haml
+++ b/vendor/engines/c2po/app/views/facility_accounts/account_fields/_purchase_order_account.html.haml
@@ -5,6 +5,12 @@
 
 = f.input :description, required: true
 
+- if SettingsHelper.feature_on?(:purchase_order_monetary_cap)
+  = f.input :monetary_cap, label: "Monetary Cap", 
+    input_html: { step: 0.01 }, 
+    hint: "Optional monetary cap for this purchase order account",
+    hint_html: { class: "help-inline" }
+
 - if SettingsHelper.feature_on?(:account_reference_field)
   = f.input :reference
 

--- a/vendor/engines/c2po/config/locales/en.yml
+++ b/vendor/engines/c2po/config/locales/en.yml
@@ -46,6 +46,7 @@ en:
       purchase_order_account:
         account_number: Payment Source
         ar_number: Account Receivable Number
+        monetary_cap: Monetary Cap
       credit_card_account:
         account_number: Payment Source
         name_on_card: Name On Card

--- a/vendor/engines/c2po/spec/models/purchase_order_account_spec.rb
+++ b/vendor/engines/c2po/spec/models/purchase_order_account_spec.rb
@@ -32,4 +32,24 @@ RSpec.describe PurchaseOrderAccount do
     account.facilities << facility2
     expect(account.to_s).to include "2 #{Facility.model_name.human.pluralize}"
   end
+
+  describe "monetary_cap validation" do
+    context "when feature flag is enabled", feature_setting: { purchase_order_monetary_cap: true } do
+      it "is valid with a positive monetary_cap" do
+        account.monetary_cap = 1000.50
+        expect(account).to be_valid
+      end
+
+      it "is valid with nil monetary_cap" do
+        account.monetary_cap = nil
+        expect(account).to be_valid
+      end
+
+      it "is invalid with negative monetary_cap" do
+        account.monetary_cap = -100
+        expect(account).not_to be_valid
+        expect(account.errors[:monetary_cap]).to include("must be greater than 0")
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Release Notes

Add a monetary cap field to purchase orders

# Screenshot

![Screenshot 2025-06-11 at 1 16 10 PM](https://github.com/user-attachments/assets/f4118e1d-53bf-4ab7-9b5f-6ecc7cc1c482)
![Screenshot 2025-06-11 at 1 16 19 PM](https://github.com/user-attachments/assets/09b0dce7-acf0-49ab-b8c4-56cb2417b63d)
