### PR TITLE
Auto stop previous reservation

### DIFF
--- a/app/mailers/auto_end_reservation_mailer.rb
+++ b/app/mailers/auto_end_reservation_mailer.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class AutoEndReservationMailer < ApplicationMailer
+
+  def notify_auto_ended(reservation, _ended_by_user)
+    @reservation = reservation
+    @order_detail = reservation.order_detail
+    @user = @reservation.user
+    @facility = @order_detail.facility
+    @product = @order_detail.product
+
+    reply_to = @facility.email || Settings.email.from
+
+    mail(
+      to: @user.email,
+      reply_to: reply_to,
+      subject: text("notify_auto_ended.subject",
+                    facility: @facility.abbreviation,
+                    product: @product.name)
+    )
+  end
+
+  protected
+
+  def translation_scope
+    "views.auto_end_reservation_mailer"
+  end
+
+end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -178,6 +178,11 @@ class Reservation < ApplicationRecord
   end
 
   def start_reservation!
+    # Auto-end functionality: automatically end previous reservations when feature is enabled
+    if SettingsHelper.feature_on?(:auto_end_reservations_on_next_start)
+      AutoEndPreviousReservation.new(product, user).end_previous_reservations!
+    end
+
     # If there are any reservations running over their time on the shared schedule,
     # kick them over to the problem queue.
     product.schedule.products.flat_map(&:started_reservations).each do |reservation|

--- a/app/services/auto_end_previous_reservation.rb
+++ b/app/services/auto_end_previous_reservation.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class AutoEndPreviousReservation
+
+  def initialize(product, current_user)
+    @product = product
+    @current_user = current_user
+  end
+
+  def end_previous_reservations!
+    return unless SettingsHelper.feature_on?(:auto_end_reservations_on_next_start)
+    return unless timer_based_instrument?
+
+    reservations_to_end = previous_reservations
+
+    reservations_to_end.each do |reservation|
+      auto_end_reservation(reservation)
+    end
+  end
+
+  private
+
+  def timer_based_instrument?
+    @product.control_mechanism == Relay::CONTROL_MECHANISMS[:timer] ||
+      @product.control_mechanism == Relay::CONTROL_MECHANISMS[:relay]
+  end
+
+  def previous_reservations
+    @product.reservations.joins(:order_detail)
+            .where(actual_end_at: nil)
+            .where(reserve_end_at: ...Time.current)
+            .where(order_details: { canceled_at: nil })
+            .where.not(actual_start_at: nil)
+  end
+
+  def auto_end_reservation(reservation)
+    reservation.update!(actual_end_at: Time.current)
+    reservation.order_detail.complete!
+
+    # Send notification email to user whose reservation was auto-ended
+    AutoEndReservationMailer.notify_auto_ended(reservation, @current_user).deliver_later
+
+    LogEvent.log(reservation.order_detail, :auto_ended_by_next_reservation, @current_user,
+                 metadata: { cause: :auto_end_on_next_start })
+  end
+
+end

--- a/app/views/auto_end_reservation_mailer/notify_auto_ended.html.haml
+++ b/app/views/auto_end_reservation_mailer/notify_auto_ended.html.haml
@@ -1,0 +1,9 @@
+= html("body",
+  user: @user,
+  facility: @facility.name,
+  facility_email: @facility.email,
+  product: @product.name,
+  reservation_time: l(@reservation.reserve_start_at, format: :usa) + " - " + l(@reservation.actual_end_at, format: :usa),
+  order_detail: @order_detail,
+  order_detail_link: order_order_detail_url(@order_detail.order, @order_detail),
+  total_cost: @order_detail.total)

--- a/app/views/auto_end_reservation_mailer/notify_auto_ended.text.erb
+++ b/app/views/auto_end_reservation_mailer/notify_auto_ended.text.erb
@@ -1,0 +1,12 @@
+<%=
+  text("body",
+    user: @user.full_name,
+    facility: @facility.name,
+    facility_email: @facility.email,
+    product: @product.name,
+    reservation_time: l(@reservation.reserve_start_at, format: :usa) + " - " + l(@reservation.actual_end_at, format: :usa),
+    order_detail: @order_detail.to_s,
+    order_detail_link: facility_order_order_detail_url(@facility, @order_detail.order, @order_detail),
+    total_cost: @order_detail.total
+  )
+%> 

--- a/config/locales/en.log_event_types.yml
+++ b/config/locales/en.log_event_types.yml
@@ -24,6 +24,7 @@ en:
       price_change: Order's price was manually changed
       resolve_from_problem_queue: Problem order resolved
       updated_fulfilled_at: Fulfilled date updated on completed order
+      auto_ended_by_next_reservation: Reservation automatically ended when another user started a new reservation
     order_import:
       created: Bulk Order Import
     product_user:

--- a/config/locales/views/en.auto_end_reservation_mailer.yml
+++ b/config/locales/views/en.auto_end_reservation_mailer.yml
@@ -1,0 +1,23 @@
+en:
+  views:
+    auto_end_reservation_mailer:
+      notify_auto_ended:
+        subject: "%{facility} - Your %{product} reservation has been automatically ended"
+        body: |
+          Hello %{user},
+
+          Your reservation for %{product} at %{facility} has been automatically ended 
+          because another user started their reservation.
+
+          **Reservation Details:**
+          - **Instrument:** %{product}
+          - **Time:** %{reservation_time}
+          - **Order:** [#%{order_detail}](%{order_detail_link})
+          - **Total Cost:** %{total_cost}
+
+          You have been charged for the actual time used. If you believe there is an error
+          with the timing or charges, please [contact the facility](mailto:%{facility_email}).
+
+          Thank you,
+
+          %{facility} 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -172,6 +172,7 @@ feature:
   hide_account_far_future_expiration: false
   show_account_price_groups_tab: false
   purchase_order_monetary_cap: false
+  auto_end_reservations_on_next_start: false
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/doc/HOWTO_feature_flags.md
+++ b/doc/HOWTO_feature_flags.md
@@ -57,3 +57,4 @@
 * `reservations: grace_period`, `reservations: timeout_period`, `occupancies: timeout_period`, `billing: review_period` various grace periods, time periods, and review periods
 * `active_storage` use `ActiveStorage` if `true`, or `Paperclip` if `false`
 * `active_storage_for_images_only` enables `ActiveStorage` for the `DownloadableFiles::Image` module. This flag needs to be enabled even if `active_storage` is
+* `auto_end_reservations_on_next_start` Automatically end previous reservations for timer/relay controlled instruments, when another user starts a new reservation.

--- a/spec/mailers/auto_end_reservation_mailer_spec.rb
+++ b/spec/mailers/auto_end_reservation_mailer_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AutoEndReservationMailer do
+  let(:facility) { create(:setup_facility) }
+  let(:instrument) { create(:setup_instrument, facility: facility, contact_email: "default@example.com") }
+  let(:user) { create(:user) }
+  let(:ended_by_user) { create(:user) }
+  let(:reservation) { create(:purchased_reservation, product: instrument, user: user, actual_end_at: Time.current) }
+  let(:mail) { described_class.notify_auto_ended(reservation, ended_by_user) }
+
+  describe "#notify_auto_ended" do
+    it "renders the headers" do
+      expect(mail.subject).to eq("#{facility.abbreviation} - Your #{instrument.name} reservation has been automatically ended")
+      expect(mail.to).to eq([user.email])
+      expect(mail.reply_to).to eq([facility.email])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match(user.full_name)
+      expect(mail.body.encoded).to match(instrument.name)
+      expect(mail.body.encoded).to match(facility.name)
+      expect(mail.body.encoded).to match("automatically ended")
+    end
+
+    context "when facility has no email" do
+      before do
+        facility.update!(email: nil)
+      end
+
+      it "uses default reply-to" do
+        expect(mail.reply_to).to eq([Settings.email.from])
+      end
+    end
+  end
+end

--- a/spec/services/auto_end_previous_reservation_spec.rb
+++ b/spec/services/auto_end_previous_reservation_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AutoEndPreviousReservation do
+  let(:facility) { create(:setup_facility) }
+  let(:instrument) { create(:setup_instrument, :timer, facility: facility) }
+  let(:current_user) { create(:user) }
+  let(:previous_user) { create(:user) }
+
+  describe "#end_previous_reservations!" do
+    subject { described_class.new(instrument, current_user).end_previous_reservations! }
+
+    context "when feature flag is enabled", feature_setting: { auto_end_reservations_on_next_start: true } do
+      context "with a timer-based instrument" do
+        let!(:previous_reservation) do
+          reservation = build(:purchased_reservation,
+                              product: instrument,
+                              user: previous_user,
+                              reserve_start_at: 2.hours.ago,
+                              reserve_end_at: 1.hour.ago,
+                              actual_start_at: 2.hours.ago,
+                              actual_end_at: nil)
+          reservation.save!(validate: false)
+          reservation
+        end
+
+        it "ends the previous reservation" do
+          expect do
+            subject
+          end.to change { previous_reservation.reload.actual_end_at }.from(nil)
+        end
+
+        it "completes the order detail" do
+          expect do
+            subject
+          end.to change { previous_reservation.order_detail.reload.state }.to("complete")
+        end
+
+        it "sends notification email" do
+          expect do
+            subject
+          end.to enqueue_mail(AutoEndReservationMailer, :notify_auto_ended)
+        end
+
+        it "logs the auto-end event" do
+          subject
+
+          log_event = LogEvent.find_by(
+            loggable: previous_reservation.order_detail,
+            event_type: :auto_ended_by_next_reservation,
+            user: current_user
+          )
+
+          expect(log_event).to be_present
+          expect(log_event.metadata).to eq("cause" => "auto_end_on_next_start")
+        end
+
+        context "when previous reservation is already ended" do
+          before { previous_reservation.update_column(:actual_end_at, 30.minutes.ago) }
+
+          it "does not modify the reservation" do
+            expect do
+              subject
+            end.not_to change { previous_reservation.reload.actual_end_at }
+          end
+        end
+
+        context "when previous reservation is canceled" do
+          before { previous_reservation.order_detail.update_column(:canceled_at, 1.hour.ago) }
+
+          it "does not modify the reservation" do
+            expect do
+              subject
+            end.not_to change { previous_reservation.reload.actual_end_at }
+          end
+        end
+      end
+
+      context "with a manual instrument" do
+        let(:manual_instrument) { create(:instrument, facility: facility, no_relay: true) }
+        subject { described_class.new(manual_instrument, current_user).end_previous_reservations! }
+
+        it "does not end reservations for manual instruments" do
+          expect do
+            subject
+          end.not_to enqueue_mail
+        end
+      end
+
+      context "when feature flag is disabled", feature_setting: { auto_end_reservations_on_next_start: false } do
+        it "does not end previous reservations" do
+          expect do
+            subject
+          end.not_to enqueue_mail
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Release Notes

Add a feature under a feature flag that automatically ends an open reservation when another user starts a new reservation, notifying the previous user. This feature only applies to timer/relay instruments
