### PR TITLE
[NU-408] Fix daily booking skip review instrument creation

### DIFF
--- a/app/services/price_policy_builder.rb
+++ b/app/services/price_policy_builder.rb
@@ -98,6 +98,9 @@ class PricePolicyBuilder
       price_group_id: price_group.id,
       product_id: product.id,
       can_purchase: false,
+      usage_rate: product.daily_booking? ? nil : usage_rate_for(product),
+      usage_rate_daily: product.daily_booking? ? 0 : nil,
+      usage_subsidy_daily: product.daily_booking? ? 0 : nil,
     )
   end
 
@@ -131,7 +134,9 @@ class PricePolicyBuilder
       start_date: 1.month.ago,
       expire_date: 75.years.from_now,
       price_group:,
-      usage_rate: usage_rate_for(product),
+      usage_rate: product.daily_booking? ? nil : usage_rate_for(product),
+      usage_rate_daily: product.daily_booking? ? 0 : nil,
+      usage_subsidy_daily: product.daily_booking? ? 0 : nil,
       minimum_cost: 0,
       cancellation_cost: 0,
       usage_subsidy: 0,

--- a/app/services/price_policy_builder.rb
+++ b/app/services/price_policy_builder.rb
@@ -98,7 +98,7 @@ class PricePolicyBuilder
       price_group_id: price_group.id,
       product_id: product.id,
       can_purchase: false,
-      usage_rate: product.daily_booking? ? nil : usage_rate_for(product),
+      usage_rate: product.daily_booking? ? nil : self.class.usage_rate_for(product),
       usage_rate_daily: product.daily_booking? ? 0 : nil,
       usage_subsidy_daily: product.daily_booking? ? 0 : nil,
     )

--- a/app/services/price_policy_builder.rb
+++ b/app/services/price_policy_builder.rb
@@ -94,13 +94,14 @@ class PricePolicyBuilder
   end
 
   def new_price_policy(price_group)
+    attributes = self.class.usage_rate_attributes(product)
     model_class.new(
       price_group_id: price_group.id,
       product_id: product.id,
       can_purchase: false,
-      usage_rate: product.daily_booking? ? nil : self.class.usage_rate_for(product),
-      usage_rate_daily: product.daily_booking? ? 0 : nil,
-      usage_subsidy_daily: product.daily_booking? ? 0 : nil,
+      usage_rate: attributes[:usage_rate],
+      usage_rate_daily: attributes[:usage_rate_daily],
+      usage_subsidy_daily: attributes[:usage_subsidy_daily],
     )
   end
 
@@ -128,15 +129,17 @@ class PricePolicyBuilder
   end
 
   def self.create_price_policy_for(product, price_group)
+    attributes = usage_rate_attributes(product)
+
     PricePolicy.create(
       type: "#{product.type}PricePolicy",
       product:,
       start_date: 1.month.ago,
       expire_date: 75.years.from_now,
       price_group:,
-      usage_rate: product.daily_booking? ? nil : usage_rate_for(product),
-      usage_rate_daily: product.daily_booking? ? 0 : nil,
-      usage_subsidy_daily: product.daily_booking? ? 0 : nil,
+      usage_rate: attributes[:usage_rate],
+      usage_rate_daily: attributes[:usage_rate_daily],
+      usage_subsidy_daily: attributes[:usage_subsidy_daily],
       minimum_cost: 0,
       cancellation_cost: 0,
       usage_subsidy: 0,
@@ -150,6 +153,14 @@ class PricePolicyBuilder
 
   def self.usage_rate_for(product)
     ["Service", "Item"].include?(product.type) ? nil : 0
+  end
+
+  def self.usage_rate_attributes(product)
+    {
+      usage_rate: product.daily_booking? ? nil : usage_rate_for(product),
+      usage_rate_daily: product.daily_booking? ? 0 : nil,
+      usage_subsidy_daily: product.daily_booking? ? 0 : nil,
+    }
   end
 
 end

--- a/spec/services/price_policy_builder_spec.rb
+++ b/spec/services/price_policy_builder_spec.rb
@@ -51,6 +51,34 @@ RSpec.describe PricePolicyBuilder do
 
       it_behaves_like "a correctly created PricePolicy"
     end
+
+    context "when product is an Instrument with Daily Booking pricing mode" do
+      let(:product) do
+        create(:instrument,
+               facility: facility,
+               billing_mode: "Skip Review",
+               pricing_mode: Instrument::Pricing::SCHEDULE_DAILY)
+      end
+      let!(:price_groups) { create_list(:price_group, 2) }
+      let!(:usage_rate) { nil }
+
+      before do
+        subject
+      end
+
+      it "creates PricePolicy with daily rate fields for all price groups" do
+        price_groups.each do |pg|
+          policy = product.price_policies.find_by(price_group: pg)
+          expect(policy).to be_present
+          expect(policy.type).to eq("InstrumentPricePolicy")
+          expect(policy.usage_rate).to be_nil
+          expect(policy.usage_rate_daily).to eq(0)
+          expect(policy.usage_subsidy_daily).to eq(0)
+          expect(policy.can_purchase?).to be(true)
+          expect(policy.note).to eq("Price rule automatically created because of billing mode")
+        end
+      end
+    end
   end
 
   describe ".create_nonbillable_for" do


### PR DESCRIPTION
# Release Notes

Fixed automatic price policy creation for instruments with daily booking pricing mode when using "Skip Review" billing mode. The system now properly initializes daily-specific pricing fields to ensure correct pricing configuration for daily-based reservations.

# Additional Context

## Problem
When creating price policies for instruments configured with daily booking pricing mode through the "Skip Review" billing mode, the `PricePolicyBuilder` service was not properly handling the daily-specific pricing fields (`usage_rate_daily` and `usage_subsidy_daily`). This caused issues in the automatic price policy generation process.

## Solution
- Updated `PricePolicyBuilder.create_price_policy_for` method to conditionally set pricing fields based on daily booking mode
- Updated `PricePolicyBuilder.new_price_policy` method for consistency across all creation paths
- When `product.daily_booking?` is true:
  - `usage_rate` is set to `nil`
  - `usage_rate_daily` and `usage_subsidy_daily` are initialized to `0`

## Files Changed
- `app/services/price_policy_builder.rb`
- `spec/services/price_policy_builder_spec.rb`

# Accessibility
- [x] Did you scan for accessibility issues? (N/A - Backend only change)
- [x] Did you check our accessibility goal checklist? (N/A - Backend only change)
- [x] Did you add accessibility [specs](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-rspec/README.md)? (N/A - Backend only change)