### PR TITLE
Disable credit card payment source

### DIFF
--- a/app/models/account_config.rb
+++ b/app/models/account_config.rb
@@ -47,7 +47,7 @@ class AccountConfig
 
   # An array of account types where creation should be disabled
   def creation_disabled_types
-    @creation_disabled_types ||= []
+    @creation_disabled_types ||= ["CreditCardAccount"]
   end
 
   def creation_enabled_types

--- a/spec/models/account_config_spec.rb
+++ b/spec/models/account_config_spec.rb
@@ -145,11 +145,33 @@ RSpec.describe AccountConfig, type: :model do
     end
   end
 
+  describe "#creation_disabled_types" do
+    it "includes CreditCardAccount by default" do
+      expect(instance.creation_disabled_types).to include("CreditCardAccount")
+    end
+  end
+
   describe "#creation_enabled_types" do
     it "does not included disabled account types" do
       expect(instance.creation_enabled_types).to include("NufsAccount")
       instance.creation_disabled_types << "NufsAccount"
       expect(instance.creation_enabled_types).not_to include("NufsAccount")
+    end
+  end
+
+  describe "#account_types_for_facility" do
+    let(:facility) { double("facility") }
+
+    context "when action is :create" do
+      it "excludes CreditCardAccount from available types" do
+        allow(instance).to receive(:account_types).and_return(["NufsAccount", "CreditCardAccount"])
+        allow(facility).to receive(:try).with(:cross_facility?).and_return(false)
+
+        result = instance.account_types_for_facility(facility, :create)
+
+        expect(result).to include("NufsAccount")
+        expect(result).not_to include("CreditCardAccount")
+      end
     end
   end
 


### PR DESCRIPTION
# Release Notes

Credit card payment source option is no longer available when creating new payment accounts. Existing credit card accounts remain unaffected and continue to function normally.

# Screenshot
before:
![Screenshot 2025-06-24 at 11 40 31 AM](https://github.com/user-attachments/assets/f553ac21-ba19-4663-90ad-60315dfa1207)

after:
![Screenshot 2025-06-24 at 11 38 54 AM](https://github.com/user-attachments/assets/cf9cb79d-647c-4aa1-a9f9-c0b38988a32b)

# Additional Context

## Technical Details
- Added `"CreditCardAccount"` to `AccountConfig.creation_disabled_types` 
- This prevents the credit card option from appearing in the account type selection tabs
- Existing credit card accounts continue to work for existing transactions and users


# Accessibility
- [x] Did you scan for accessibility issues? - No accessibility impact (removal of UI element)
- [x] Did you check our accessibility goal checklist? - N/A for this change
- [x] Did you add accessibility [specs](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-rspec/README.md)? - N/A for this change
