### PR TITLE
[NUOPEN-261] Fix transactions statemented filter

### DIFF
--- a/app/controllers/concerns/sortable_billing_table.rb
+++ b/app/controllers/concerns/sortable_billing_table.rb
@@ -28,7 +28,10 @@ module SortableBillingTable
       "ordered_for" => ["users.last_name", "order_details.fulfilled_at"],
       "payment_source" => "order_details.account_id",
       "order_status" => "order_details.order_status_id",
-    }
+    }.tap do |hash|
+      # journal_or_statement_date sorting is handled in DateRangeSearcher
+      hash.delete "date_range_field" if order_detail_date_range_field == "journal_or_statement_date"
+    end
   end
 
   def enable_sorting

--- a/app/services/transaction_search/date_range_searcher.rb
+++ b/app/services/transaction_search/date_range_searcher.rb
@@ -3,15 +3,24 @@
 module TransactionSearch
 
   class DateRangeSearcher < BaseSearcher
-
     include DateHelper
+
     FIELDS = %w(ordered_at fulfilled_at journal_or_statement_date reconciled_at).freeze
 
     attr_reader :date_range_field
 
-    def self.options(only: FIELDS)
-      FIELDS.map { |field| [I18n.t(field, scope: "admin.transaction_search.date_range_fields"), field] }
-            .select { |_label, value| value.in?(only) }
+    class << self
+      include TextHelpers::Translation
+
+      def options(only: FIELDS)
+        FIELDS
+          .map { |field| [text(field), field] }
+          .select { |_label, value| value.in?(only) }
+      end
+
+      def translation_scope
+        "admin.transaction_search.date_range_fields"
+      end
     end
 
     def options

--- a/app/services/transaction_search/date_range_searcher.rb
+++ b/app/services/transaction_search/date_range_searcher.rb
@@ -4,14 +4,13 @@ module TransactionSearch
 
   class DateRangeSearcher < BaseSearcher
     include DateHelper
+    extend TextHelpers::Translation
 
     FIELDS = %w(ordered_at fulfilled_at journal_or_statement_date reconciled_at).freeze
 
     attr_reader :date_range_field
 
     class << self
-      include TextHelpers::Translation
-
       def options(only: FIELDS)
         FIELDS
           .map { |field| [text(field), field] }

--- a/spec/system/admin/all_transactions_search_spec.rb
+++ b/spec/system/admin/all_transactions_search_spec.rb
@@ -73,8 +73,20 @@ RSpec.describe "All Transactions Search", :js do
     end
 
     context "when statemented/journaled" do
+      let(:account) { create(:account, :with_account_owner) }
       let(:sorted_order_details) do
-        order_details.ordered_by_action_date(:journal_or_statement_date)
+        order_details
+      end
+      let(:statemented_order_detail) { facility.order_details.complete.last }
+
+      before do
+        statement = Statement.create!(facility:, account:, created_by: director.id)
+        StatementRow.create!(
+          statement:,
+          order_detail: statemented_order_detail,
+        )
+        statemented_order_detail.update_columns(statement_id: statement.id)
+
       end
 
       it "can filter orders" do
@@ -89,7 +101,7 @@ RSpec.describe "All Transactions Search", :js do
 
         expect(
           sorted_order_details.map do |od|
-            I18n.l(od.ordered_at.to_date, format: :usa)
+            I18n.l(od.journal_or_statement_date.to_date, format: :usa)
           end
         ).to appear_in_order
       end

--- a/spec/system/admin/all_transactions_search_spec.rb
+++ b/spec/system/admin/all_transactions_search_spec.rb
@@ -71,6 +71,29 @@ RSpec.describe "All Transactions Search", :js do
         ).to appear_in_order
       end
     end
+
+    context "when statemented/journaled" do
+      let(:sorted_order_details) do
+        order_details.ordered_by_action_date(:journal_or_statement_date)
+      end
+
+      it "can filter orders" do
+        visit facility_transactions_path(facility)
+
+        select(
+          I18n.t("admin.transaction_search.date_range_fields.journal_or_statement_date"),
+          from: "search[date_range_field]",
+        )
+
+        click_button("Filter")
+
+        expect(
+          sorted_order_details.map do |od|
+            I18n.l(od.ordered_at.to_date, format: :usa)
+          end
+        ).to appear_in_order
+      end
+    end
   end
 
   it "can do a basic search" do

--- a/spec/system/admin/all_transactions_search_spec.rb
+++ b/spec/system/admin/all_transactions_search_spec.rb
@@ -73,6 +73,12 @@ RSpec.describe "All Transactions Search", :js do
     end
 
     context "when statemented/journaled" do
+      include TextHelpers::Translation
+
+      def translation_scope
+        ""
+      end
+
       let(:account) { create(:account, :with_account_owner) }
       let(:sorted_order_details) do
         order_details
@@ -93,7 +99,7 @@ RSpec.describe "All Transactions Search", :js do
         visit facility_transactions_path(facility)
 
         select(
-          I18n.t("admin.transaction_search.date_range_fields.journal_or_statement_date"),
+          text("admin.transaction_search.date_range_fields.journal_or_statement_date"),
           from: "search[date_range_field]",
         )
 


### PR DESCRIPTION
## Notes

Sorting for transactions in statement/journal state is done in a model scope (as oposed to the other cases which are simple order clauses) so I exclude it from the sorting logic.
I also fixed Date range select options locale which was missing a nested translation which is only supported by the `text_helpers` gem.

## Screenshot

![Captura de pantalla 2025-06-24 a la(s) 11 44 22](https://github.com/user-attachments/assets/e9186d4d-2855-46c6-90e4-ba117df2ad9b)
