### PR TITLE
Keep filters after invoice reconciliation  error

### DIFF
--- a/app/controllers/facility_accounts_reconciliation_controller.rb
+++ b/app/controllers/facility_accounts_reconciliation_controller.rb
@@ -53,11 +53,11 @@ class FacilityAccountsReconciliationController < ApplicationController
       end
 
       flash[:notice] = "#{count} payment#{'s' unless count == 1} successfully updated" if count > 0
+      redirect_to([account_route.to_sym, :facility_accounts])
     else
       flash[:error] = reconciler.full_errors.join("<br />").html_safe
+      redirect_to([account_route.to_sym, :facility_accounts, redirect_params])
     end
-
-    redirect_to([account_route.to_sym, :facility_accounts])
   end
 
   private
@@ -95,5 +95,12 @@ class FacilityAccountsReconciliationController < ApplicationController
     return unless params[:order_status] == "unrecoverable"
 
     authorize!(:mark_unrecoverable, OrderDetail)
+  end
+
+  def redirect_params
+    {
+      search: params[:search]&.permit!,
+      page: params[:page]
+    }
   end
 end

--- a/app/views/facility_accounts_reconciliation/index.html.haml
+++ b/app/views/facility_accounts_reconciliation/index.html.haml
@@ -14,6 +14,15 @@
 - if @unreconciled_details.any?
   - show_reconciliation_deposit_number = SettingsHelper.feature_on?(:show_reconciliation_deposit_number)
   = form_tag([:update, account_route.to_sym, FacilityAccount], method: :post, class: "js--reconcileForm") do
+    - if params[:search].present?
+      - params[:search].each do |key, value|
+        - if value.is_a?(Array)
+          - value.each do |v|
+            = hidden_field_tag "search[#{key}][]", v
+        - else
+          = hidden_field_tag "search[#{key}]", value
+    - if params[:page].present?
+      = hidden_field_tag :page, params[:page]
     = render "action_row", date: true,
       unreconciled_order_details: @unreconciled_details,
       show_reconciliation_deposit_number: show_reconciliation_deposit_number,

--- a/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
+++ b/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
@@ -56,6 +56,32 @@ RSpec.describe FacilityAccountsReconciliationController do
                               } }
     end
 
+    describe "when there is an error" do
+      let(:reconciled_at) { 1.day.from_now } # This will cause an error
+      let(:search_params) { { accounts: [account.id], page: 2 } }
+
+      it "preserves search parameters in the redirect" do
+        post :update, params: {
+          facility_id: facility.url_name,
+          account_type: "ReconciliationTestAccount",
+          reconciled_at: formatted_reconciled_at,
+          search: search_params,
+          page: 2,
+          order_detail: {
+            order_detail.id.to_s => {
+              reconciled: "1",
+              reconciled_note: "A note",
+            },
+          }
+        }
+
+        location = response.redirect_url
+        expect(location).to include("/facilities/#{facility.url_name}/accounts/reconciliation_tests")
+        expect(location).to include("search%5Baccounts%5D%5B%5D=#{account.id}")
+        expect(location).to include("page=2")
+      end
+    end
+
     describe "reconciliation date", :time_travel do
       describe "with a reconciliation date of today" do
         let(:reconciled_at) { Time.current }


### PR DESCRIPTION
# Release Notes

Fixes a bug on the Invoice Reconciliation page where, after an error, all filters and pagination were cleared. Now, when an error occurs, the page preserves the applied filters and pagination, and displays the corresponding error message.

# Screenshot

![Screenshot 2025-06-26 at 4 33 53 PM](https://github.com/user-attachments/assets/0aa2dc36-4457-4c72-a934-332304ec89ac)


# Additional Context

- The search filters and pagination are now preserved by including them as hidden fields in the reconciliation form and ensuring they are passed back on redirect after an error.
- The controller was updated to safely permit and forward the search and page parameters on error.
- The test was improved to ensure that filters and pagination are preserved and not duplicated in the redirect URL.
