### PR TITLE
Revert "Bump mailgun-ruby from 1.3.6 to 1.3.7"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem "rubyzip"
 gem "prawn-rails"
 
 ## Email
-gem "mailgun-ruby", "~>1.3.7"
+gem "mailgun-ruby", "~>1.3.6"
 
 ## other
 gem "delayed_job_active_record"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -396,7 +396,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    mailgun-ruby (1.3.7)
+    mailgun-ruby (1.3.6)
       faraday (~> 2.1)
       faraday-multipart (~> 1.1.0)
       mime-types
@@ -775,7 +775,7 @@ DEPENDENCIES
   kt-paperclip
   ldap_authentication!
   letter_opener
-  mailgun-ruby (~> 1.3.7)
+  mailgun-ruby (~> 1.3.6)
   mysql2
   nested_form_fields
   net-imap


### PR DESCRIPTION
Reverts wyeworks/nucore-open#5457