### PR TITLE
Nuopen 266 fix styling issues

### DIFF
--- a/app/assets/stylesheets/app/reports.scss
+++ b/app/assets/stylesheets/app/reports.scss
@@ -16,7 +16,7 @@
   }
 
   .reportForm__downloads a {
-    display: block;
+    display: inline-block;
     padding-top: 2.3em;
   }
 

--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -459,13 +459,14 @@ p.per-minute {
   margin-top: -0.25em;
 }
 
-p.per-minute-show {
-  @extend .per-minute;
-  margin-top: 0;
-}
+.price-policy-table {
+  input[type="text"] {
+    width: 80%;
+  }
 
-.price-policy-table input[type=text] {
-  width: 80%;
+  .negative-number {
+    display: block;
+  }
 }
 
 /* Account Fields */

--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -120,7 +120,7 @@ legend {
 }
 
 ul, ol {
-  &.nav,
+  &.nav:not(.sidebar-nav),
   &.navbar-nav,
   &.list-unstyled,
   &.list-inline,

--- a/app/assets/stylesheets/nucore.scss
+++ b/app/assets/stylesheets/nucore.scss
@@ -456,7 +456,7 @@ p.per-minute {
   font-style: italic;
   @extend .text-muted;
   font-size: 85%;
-  margin-top: -0.75em;
+  margin-top: -0.25em;
 }
 
 p.per-minute-show {

--- a/app/views/facility_accounts_reconciliation/_action_row.html.haml
+++ b/app/views/facility_accounts_reconciliation/_action_row.html.haml
@@ -1,47 +1,47 @@
 .row.table-actions.form-horizontal
-  .col-md-1.select_all_none= select_all_link
-  .col-md-1.pull-right= submit_tag t("facility_accounts_reconciliation.index.submit"), class: ["btn", "btn-primary", "js--requireValueForSubmit"], data: { disable_with: t("facility_accounts_reconciliation.index.submit") }
+  .col-md-3.select_all_none= select_all_link
+  .col-md-9.text-right= submit_tag t("facility_accounts_reconciliation.index.submit"), class: ["btn", "btn-primary", "js--requireValueForSubmit"], data: { disable_with: t("facility_accounts_reconciliation.index.submit") }
 
 - if local_assigns[:show_order_status]
   .row.table-actions.form-horizontal
-    .form-group.fields
-      = label_tag :order_status, t("facility_accounts_reconciliation.index.order_status"), class: "control-label"
-      .controls
+    .form-group
+      = label_tag :order_status, t("facility_accounts_reconciliation.index.order_status"), class: "control-label col-md-2"
+      .col-md-4
         = select_tag :order_status,
           options_for_select(reconcile_statuses),
-          class: "js--orderStatusSelect"
+          class: "js--orderStatusSelect form-control"
 - if local_assigns[:date]
   .js--bulkReconcileFields
     .row.table-actions.form-horizontal
       .js--bulkReconcileDateField
-        .form-group.fields
-          = label_tag :reconciled_at, OrderDetail.human_attribute_name(:reconciled_at), class: "control-label"
-          .controls
+        .form-group
+          = label_tag :reconciled_at, OrderDetail.human_attribute_name(:reconciled_at), class: "control-label col-md-2"
+          .col-md-4
             = text_field_tag :reconciled_at,
               format_usa_date(Time.current),
-              class: :datepicker__data,
+              class: "datepicker__data form-control",
               data: { min_date: unreconciled_order_details.map(&:journal_or_statement_date).min.iso8601, max_date: Time.current.iso8601 }
     .row.table-actions.form-horizontal
-      .form-group.fields
-        = label_tag :bulk_note_checkbox, t("facility_accounts_reconciliation.index.bulk_note_checkbox"), class: "control-label"
-        .controls
+      .form-group
+        = label_tag :bulk_note_checkbox, t("facility_accounts_reconciliation.index.bulk_note_checkbox"), class: "control-label col-md-2"
+        .col-md-10
           = check_box_tag :bulk_note_checkbox
 
     .row.table-actions.form-horizontal.js--bulkNoteInput
-      .form-group.fields
-        = label_tag :bulk_note, t("facility_accounts_reconciliation.index.bulk_note"), class: "control-label"
-        .controls
-          = text_field_tag :bulk_note
+      .form-group
+        = label_tag :bulk_note, t("facility_accounts_reconciliation.index.bulk_note"), class: "control-label col-md-2"
+        .col-md-6
+          = text_field_tag :bulk_note, nil, class: "form-control"
 
     - if show_reconciliation_deposit_number
       .row.table-actions.form-horizontal.js--bulkNoteInput
-        .form-group.fields
+        .form-group
           = label_tag :bulk_deposit_number,
             text("facility_accounts_reconciliation.index.bulk_deposit_number"),
-            class: "control-label",
+            class: "control-label col-md-2",
             title: text("facility_accounts_reconciliation.index.bulk_deposit_number_hint"),
             data: { toggle: "tooltip" }
-          .controls
+          .col-md-4
             %span
               = text("facility_accounts_reconciliation.index.bulk_deposit_number_prefix")
-            = text_field_tag :bulk_deposit_number
+            = text_field_tag :bulk_deposit_number, nil, class: "form-control"

--- a/app/views/facility_journals/index.html.haml
+++ b/app/views/facility_journals/index.html.haml
@@ -34,11 +34,14 @@
             %td= f.input :reference, label: false, input_html: { class: 'form-control' }
             %td= f.input :description, label: false, input_html: { class: 'form-control' }
             %td
-              = select_tag :journal_status, options_for_select([[' ', nil], ['Succeeded, no errors', 'succeeded'], ['Succeeded, with errors', 'succeeded_errors'], ['Failed', 'failed']], params[:journal_status]), class: 'form-control'
-              = submit_tag t(".journal.close"),
-                data: { confirm: t(".journal.confirm") },
-                class: ["btn", "btn-primary"]
-            %td= number_to_currency(pending_journal.amount)
+              .form-group
+                = select_tag :journal_status, options_for_select([[' ', nil], ['Succeeded, no errors', 'succeeded'], ['Succeeded, with errors', 'succeeded_errors'], ['Failed', 'failed']], params[:journal_status]), class: 'form-control'
+              .form-group
+                = submit_tag t(".journal.close"),
+                  data: { confirm: t(".journal.confirm") },
+                  class: ["btn", "btn-primary", "btn-block"]
+            %td.text-right
+              = number_to_currency(pending_journal.amount)
 
 %h2= t(".head.closed")
 - if @journals.blank?

--- a/app/views/reports/report.html.haml
+++ b/app/views/reports/report.html.haml
@@ -11,7 +11,7 @@
   %ul.list-inline.options#filter
     = render "report_controls", form: f
 
-  %ul#control.reportForm.inline.reportForm__downloads
+  %ul#control.reportForm.list-inline.reportForm__downloads
     %li
       = link_to t("reports.export.export"), "#", id: "export"
     %li

--- a/vendor/engines/secure_rooms/app/views/secure_rooms/ethernet_ports/edit.haml
+++ b/vendor/engines/secure_rooms/app/views/secure_rooms/ethernet_ports/edit.haml
@@ -30,6 +30,6 @@
   = f.input :tablet_location_description,
     label: text("views.admin.secure_rooms.card_readers.ethernet_port_fields.location_description")
 
-  %ul.inline
+  %ul.list-inline
     %li= f.submit text("shared.save"), class: ["btn", "btn-primary"]
     %li= link_to text("shared.cancel"), facility_secure_room_card_readers_path(@current_facility, @product)


### PR DESCRIPTION
# Release Notes

Make some corrections needed after the bootstrap upgrade:

1- Fix reconcile purchase orders form:

before:
<img width="1009" height="393" alt="Screenshot 2025-08-08 at 10 29 21 AM" src="https://github.com/user-attachments/assets/a4884524-c98b-474b-aadc-774c498671dc" />

now:
<img width="918" height="589" alt="Screenshot 2025-08-08 at 10 07 29 AM" src="https://github.com/user-attachments/assets/20fa6a2b-b2ba-43f5-abe3-446d42122458" />

2- Fix side menu padding:

before:
<img width="338" height="474" alt="Screenshot 2025-08-08 at 10 43 59 AM" src="https://github.com/user-attachments/assets/c62708ad-f715-4def-af18-835924e44e9c" />

now:
<img width="333" height="477" alt="Screenshot 2025-08-08 at 10 45 09 AM" src="https://github.com/user-attachments/assets/89dc57e2-eb0f-4234-a5fa-e8351020b972" />

3- Fix pending journals modal

before:
<img width="917" height="238" alt="Screenshot 2025-08-08 at 10 46 50 AM" src="https://github.com/user-attachments/assets/d07f686e-0bec-4876-86ee-225d59c69be2" />

now:
<img width="903" height="256" alt="Screenshot 2025-08-08 at 10 46 29 AM" src="https://github.com/user-attachments/assets/c53e0bb0-9101-405e-8354-5d13a2c83c61" />

4- Fix export reports links

before:
<img width="300" height="118" alt="Screenshot 2025-08-08 at 10 48 47 AM" src="https://github.com/user-attachments/assets/8ec39bbf-4029-4632-8681-1c2a1ed22d0e" />

now:
<img width="375" height="213" alt="Screenshot 2025-08-08 at 10 49 14 AM" src="https://github.com/user-attachments/assets/90672374-885a-4052-9da2-a167b84d3443" />

5- Fix price policy form styling

before:
<img width="835" height="601" alt="Screenshot 2025-08-08 at 11 17 04 AM" src="https://github.com/user-attachments/assets/7b51d6e5-08d7-426e-ab28-30481deaa92b" />

after:
<img width="862" height="626" alt="Screenshot 2025-08-08 at 11 16 33 AM" src="https://github.com/user-attachments/assets/4f381be9-52b8-4997-8c9f-46ebc9b786e0" />

