### PR TITLE
[NU-409] Fix sortable column order in Oracle

### DIFF
--- a/app/controllers/concerns/sortable_column_controller.rb
+++ b/app/controllers/concerns/sortable_column_controller.rb
@@ -11,7 +11,7 @@ module SortableColumnController
   def sort_clause
     Array(sort_lookup_hash[sort_column]).map do |clause|
       [clause, sort_direction].join(" ")
-    end.join(", ")
+    end
   end
 
   private

--- a/spec/system/admin/all_transactions_search_spec.rb
+++ b/spec/system/admin/all_transactions_search_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "All Transactions Search", :js do
     before { login_as director }
 
     it "can sort by order number while filtering by account owner and type" do
-      # use random string to ease matching
+      # use custom string to ease matching
       allow_any_instance_of(Order).to receive(:id).and_wrap_original do |method|
         "test_prefix_#{method.call}"
       end

--- a/spec/system/admin/all_transactions_search_spec.rb
+++ b/spec/system/admin/all_transactions_search_spec.rb
@@ -45,10 +45,10 @@ RSpec.describe "All Transactions Search", :js do
 
       order_ids =
         facility
-          .order_details
-          .complete
-          .for_accounts(some_account)
-          .pluck(:order_id)
+        .order_details
+        .complete
+        .for_accounts(some_account)
+        .pluck(:order_id)
 
       expect(order_ids.map { |odid| "test_prefix_#{odid}" }).to appear_in_order
     end

--- a/spec/system/admin/all_transactions_search_spec.rb
+++ b/spec/system/admin/all_transactions_search_spec.rb
@@ -19,6 +19,41 @@ RSpec.describe "All Transactions Search", :js do
     end
   end
 
+  describe "sorting by columns" do
+    let(:some_account) { facility.order_details.complete.last.account }
+
+    before { login_as director }
+
+    it "can sort by order number while filtering by account owner and type" do
+      # use random string to ease matching
+      allow_any_instance_of(Order).to receive(:id).and_wrap_original do |method|
+        "test_prefix_#{method.call}"
+      end
+
+      visit facility_transactions_path(facility)
+
+      select_from_chosen(some_account.model_name.human, from: "Payment Source Type")
+      select_from_chosen(some_account.owner_user.full_name, from: "Owners")
+
+      click_button "Filter"
+
+      expect(page).to have_content("Transaction History")
+
+      within("#table_billing") do
+        first("a", text: "Order").click
+      end
+
+      order_ids =
+        facility
+          .order_details
+          .complete
+          .for_accounts(some_account)
+          .pluck(:order_id)
+
+      expect(order_ids.map { |odid| "test_prefix_#{odid}" }).to appear_in_order
+    end
+  end
+
   describe "date field order" do
     let(:order_detail_ids) do
       page.all("a.manage-order-detail").map(&:text)


### PR DESCRIPTION
Oracle adapter uses `first_value()` SQL function when implementing `columns_for_distinct()` method, which is used by active record, in this case, when there's an order by clause and some conditions apply on the joined tables.

We were providing several order criteria as a string which made first_value to be called with multiple arguments thus giving an error.

The fix is to provide multiple order criteria as independent entries.

Reference:
- FIRST_VALUE(): https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/FIRST_VALUE.html
- Oracle adapter `columns_for_distinct()`: https://github.com/rsim/oracle-enhanced/blob/1ad893df4f3c083c8c6044e57f5b06c80cad2b28/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb#L652