### PR TITLE
Adjust open contract field

### DIFF
--- a/vendor/engines/c2po/app/views/facility_accounts/account_fields/_purchase_order_account.html.haml
+++ b/vendor/engines/c2po/app/views/facility_accounts/account_fields/_purchase_order_account.html.haml
@@ -27,6 +27,6 @@
   hint: text("ar_number_hint"),
   hint_html: { class: "help-inline" }
 - if SettingsHelper.feature_on?(:show_account_opencontract_field)
-  = f.input :open_contract
+  = f.input :open_contract, as: :text, input_html: { rows: 4 }
 
 = render_view_hook "additional_fields", f: f


### PR DESCRIPTION
# Release Notes

Make Open contract/Special Comments field expandable so users can read the whole text when editing  a Purchase Order Payment Source.

# Screenshot

<img width="834" height="398" alt="Screenshot 2025-08-18 at 9 42 19 PM" src="https://github.com/user-attachments/assets/c8c3c33a-a890-40b5-aebc-9e7ecaf2ab5c" />

<img width="906" height="457" alt="Screenshot 2025-08-18 at 9 42 08 PM" src="https://github.com/user-attachments/assets/01f52d93-e0d1-4b4d-a34f-f7b2cf72c3b3" />


# Additional Context

This field is only show under the show_account_opencontract_field FF and UMASS is the only school which has it turned on.
