### PR TITLE
[NUOPEN-263] Compute notices on render

### DIFF
--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -5,12 +5,18 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
   include ActionView::Helpers::OutputSafetyHelper
 
   def statuses
-    notice_keys.map { |s| Notice.new(s) }
+    # TODO: Use self.notice_keys
+    notice_service.notices.map { |s| Notice.new(s) }
+  end
+
+  def notice_service
+    @notice_service ||= OrderDetails::NoticesService.new(self)
   end
 
   def warnings
     if problem?
-      [Notice.new(problem_description_key || :problem_out_of_sync, :warning)]
+      # TODO: Use self.problem_description_key
+      [Notice.new(notice_service.problems.first || :problem_out_of_sync, :warning)]
     else
       []
     end

--- a/app/presenters/order_detail_notice_presenter.rb
+++ b/app/presenters/order_detail_notice_presenter.rb
@@ -4,19 +4,27 @@ class OrderDetailNoticePresenter < DelegateClass(OrderDetail)
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::OutputSafetyHelper
 
-  def statuses
-    # TODO: Use self.notice_keys
-    notice_service.notices.map { |s| Notice.new(s) }
+  def notices_service
+    @notices_service ||= OrderDetails::NoticesService.new(self)
   end
 
-  def notice_service
-    @notice_service ||= OrderDetails::NoticesService.new(self)
+  def statuses
+    values = if SettingsHelper.feature_on?(:stored_order_notices)
+               notice_keys
+             else
+               notices_service.notices
+             end
+    values.map { |s| Notice.new(s) }
   end
 
   def warnings
     if problem?
-      # TODO: Use self.problem_description_key
-      [Notice.new(notice_service.problems.first || :problem_out_of_sync, :warning)]
+      problem_key = if SettingsHelper.feature_on?(:stored_order_notices)
+                      problem_description_key
+                    else
+                      notices_service.problems.first
+                    end
+      [Notice.new(problem_key || :problem_out_of_sync, :warning)]
     else
       []
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -179,6 +179,7 @@ feature:
   reference_statement_invoice_number: false
   billing_table_price_groups: false
   reference_statement_invoice_number: false
+  stored_order_notices: false
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/spec/presenters/order_detail_notice_presenter_spec.rb
+++ b/spec/presenters/order_detail_notice_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe OrderDetailNoticePresenter do
   let(:order_detail) { OrderDetail.new(note: "Treat me like a double") }
   let(:presenter) { described_class.new(order_detail) }
 
-  describe "badges_to_html" do
+  describe "badges_to_html", feature_setting: { stored_order_notices: true } do
     matcher :have_html_badge do |expected_text|
       match do |string|
         level_class = case @level


### PR DESCRIPTION
## Notes

There're are order notices that depend on the current time so this disables static notices until we find a workaround.