### PR TITLE
[NU-28] Mass journal transaction unreconcile

### DIFF
--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -196,7 +196,7 @@ class FacilityJournalsController < ApplicationController
     )
 
     if reconciler.reconcile_all > 0
-      flash[:notice] = format_success_message(reconciler.count, "reconciled")
+      flash[:notice] = format_success_message(reconciler.count, "reconcile")
     else
       flash[:error] = reconciler.full_errors.join("<br />").html_safe
     end
@@ -221,7 +221,7 @@ class FacilityJournalsController < ApplicationController
 
     end
 
-    flash[:notice] = format_success_message(unreconciled_count, "unreconciled") if unreconciled_count > 0
+    flash[:notice] = format_success_message(unreconciled_count, "unreconcile") if unreconciled_count > 0
     flash[:error] = errors.join("<br />").html_safe if errors.any?
   end
 

--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -137,23 +137,107 @@ class FacilityJournalsController < ApplicationController
   end
 
   def reconcile
+    process_reconciliation_action(:reconcile)
+  end
+
+  def unreconcile
+    process_reconciliation_action(:unreconcile)
+  end
+
+  private
+
+  def process_reconciliation_action(action)
+    selected_ids = get_selected_order_ids
+
+    if selected_ids.empty?
+      flash[:error] = I18n.t("controllers.facility_journals.#{action}.errors.none_selected")
+      redirect_to [current_facility, @journal] and return
+    end
+
+    orders = find_orders_for_action(action, selected_ids)
+
+    if orders.empty?
+      flash[:notice] = I18n.t("controllers.facility_journals.#{action}.errors.none_eligible")
+      redirect_to [current_facility, @journal] and return
+    end
+
+    send("#{action}_orders", orders)
+    redirect_to [current_facility, @journal]
+  end
+
+  def get_selected_order_ids
+    order_detail_params = params[:order_detail] || {}
+    order_detail_params.select do |_id, attrs|
+      attrs[:selected] == "1"
+    end.keys
+  end
+
+  def format_success_message(count, action)
+    I18n.t("controllers.facility_journals.#{action}.success", count: count)
+  end
+
+  def find_orders_for_action(action, ids)
+    case action
+    when :reconcile
+      @journal.order_details.where(id: ids).where.not(state: "reconciled")
+    when :unreconcile
+      @journal.order_details.where(id: ids, state: "reconciled")
+    end
+  end
+
+  def reconcile_orders(orders)
+    filtered_params = build_reconciler_params(orders.pluck(:id))
+
     reconciler = OrderDetails::Reconciler.new(
-      @journal.order_details,
-      params[:order_detail],
+      orders,
+      filtered_params,
       @journal.journal_date,
       "reconciled"
     )
 
     if reconciler.reconcile_all > 0
-      count = reconciler.count
-      flash[:notice] = "#{count} payment#{'s' unless count == 1} successfully reconciled" if count > 0
+      flash[:notice] = format_success_message(reconciler.count, "reconciled")
     else
       flash[:error] = reconciler.full_errors.join("<br />").html_safe
     end
-    redirect_to [current_facility, @journal]
   end
 
-  private
+  def unreconcile_orders(orders)
+    unreconciled_count = 0
+    errors = []
+
+    orders.readonly(false).each do |order_detail|
+
+      if order_detail.update!(
+        state: "complete",
+        order_status: OrderStatus.complete,
+        reconciled_at: nil,
+        deposit_number: nil
+      )
+        unreconciled_count += 1
+      end
+    rescue => e
+      errors << "Order ##{order_detail}: #{e.message}"
+
+    end
+
+    flash[:notice] = format_success_message(unreconciled_count, "unreconciled") if unreconciled_count > 0
+    flash[:error] = errors.join("<br />").html_safe if errors.any?
+  end
+
+  def build_reconciler_params(order_ids)
+    order_detail_params = params[:order_detail] || {}
+    selected_params = {}
+
+    order_ids.each do |id|
+      id_str = id.to_s
+      if order_detail_params[id_str]
+        selected_params[id_str] = order_detail_params[id_str].merge("reconciled" => "1")
+      end
+    end
+
+    selected_params
+  end
 
   def new_journal_from_params
     @journal = Journal.new(

--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -154,7 +154,11 @@ class FacilityJournalsController < ApplicationController
       order_status
     )
 
-    count = reconciler.send("#{action}_all")
+    count = if action == :reconcile
+              reconciler.reconcile_all
+            else
+              reconciler.unreconcile_all
+            end
 
     if count > 0
       flash[:notice] = I18n.t("controllers.facility_journals.#{action}.success", count: count)

--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -87,7 +87,7 @@ module OrderDetails
 
       selected_ids = @params.select { |_, p| p[:selected] == "1" }.keys
 
-      selected_ids.any? ? @order_detail_scope.where(id: selected_ids) : []
+      @order_detail_scope.where(id: selected_ids)
     end
 
     def reconciling?

--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -92,7 +92,7 @@ module OrderDetails
     # but we do need to make sure to allow them on the same day.
     def all_journals_and_statements_must_be_before_reconciliation_date
       return unless reconciled_at.present?
-      if @order_details.any? { |od| od.journal_or_statement_date.beginning_of_day > reconciled_at }
+      if @order_details.any? { |od| od.journal_or_statement_date&.beginning_of_day&.> reconciled_at }
         errors.add(:reconciled_at, :after_all_journal_dates)
       end
     end

--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -9,8 +9,8 @@ module OrderDetails
     attr_reader :persist_errors, :count, :order_details, :reconciled_at
 
     validates :reconciled_at, presence: true, if: :reconciling?
-    validate :reconciliation_must_be_in_past, if: :reconciling?
-    validate :all_journals_and_statements_must_be_before_reconciliation_date, if: :reconciling?
+    validate :reconciliation_must_be_in_past, if: -> { reconciled_at.present? && reconciling? }
+    validate :all_journals_and_statements_must_be_before_reconciliation_date, if: -> { reconciled_at.present? && reconciling? }
 
     def initialize(
       order_detail_scope,
@@ -103,7 +103,7 @@ module OrderDetails
     private
 
     def reconciling?
-      @reconciled_at.present?
+      @order_status == "reconciled"
     end
 
     def allowed(params)

--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -8,33 +8,79 @@ module OrderDetails
 
     attr_reader :persist_errors, :count, :order_details, :reconciled_at
 
-    validates :reconciled_at, :order_details, presence: true
-    validate :reconciliation_must_be_in_past
-    validate :all_journals_and_statements_must_be_before_reconciliation_date
+    validates :reconciled_at, presence: true, if: :reconciling?
+    validate :reconciliation_must_be_in_past, if: :reconciling?
+    validate :all_journals_and_statements_must_be_before_reconciliation_date, if: :reconciling?
 
     def initialize(
       order_detail_scope,
       params,
       reconciled_at,
-      order_status,
+      order_status = nil,
       bulk_reconcile: false,
       **kwargs
     )
       @params = params || ActionController::Parameters.new
       @order_status = order_status || "reconciled"
-      @order_details = order_detail_scope.readonly(false).find_ids(to_be_reconciled.keys)
+      @order_detail_scope = order_detail_scope.readonly(false)
       @reconciled_at = reconciled_at
       @bulk_note = kwargs[:bulk_note] if bulk_reconcile
       @bulk_deposit_number = kwargs[:bulk_deposit_number] if bulk_reconcile
+
+      @order_details = []
+      if @params.present? && !@params.empty?
+        selected_ids = @params.select { |_, p| p[:selected] == "1" }.keys
+        if selected_ids.any?
+          @order_details = @order_detail_scope.where(id: selected_ids)
+        end
+      end
     end
 
     def reconcile_all
       return 0 unless valid?
       @count = 0
+      @persist_errors = []
+
       OrderDetail.transaction do
         order_details.each do |od|
-          od_params = @params[od.id.to_s]
-          update_status(od, od_params)
+          next if od.reconciled?
+
+          od_params = @params[od.id.to_s] || {}
+          begin
+            od.assign_attributes(allowed(od_params))
+            od.reconciled_at = @reconciled_at
+            od.reconciled_note = @bulk_note if @bulk_note.present?
+            od.deposit_number = @bulk_deposit_number if @bulk_deposit_number.present?
+            od.change_status!(OrderStatus.reconciled)
+            @count += 1
+          rescue => e
+            @persist_errors << "Order ##{od.id}: #{e.message}"
+            raise ActiveRecord::Rollback
+          end
+        end
+      end
+      @count
+    end
+
+    def unreconcile_all
+      @count = 0
+      @persist_errors = []
+
+      OrderDetail.transaction do
+        order_details.each do |od|
+          next unless od.reconciled?
+
+          begin
+            od.update!(
+              state: "complete",
+              order_status: OrderStatus.complete,
+              reconciled_at: nil,
+              deposit_number: nil
+            )
+            @count += 1
+          rescue => e
+            @persist_errors << "Order ##{od.id}: #{e.message}"
+          end
         end
       end
       @count
@@ -46,33 +92,8 @@ module OrderDetails
 
     private
 
-    # The params hash comes in with the unchecked IDs as well. Filter out to only
-    # those we're going to reconcile. Returns an array of IDs.
-    def to_be_reconciled
-      @params.select { |_order_detail_id, params| params[:reconciled] == "1" }
-    end
-
-    def update_status(order_detail, params)
-      order_detail.assign_attributes(allowed(params))
-
-      if @order_status == "reconciled"
-        order_detail.reconciled_at = @reconciled_at
-        order_detail.reconciled_note = @bulk_note if @bulk_note.present?
-        order_detail.deposit_number = @bulk_deposit_number if @bulk_deposit_number.present?
-        order_detail.change_status!(OrderStatus.reconciled)
-      else
-        order_detail.reconciled_at = nil
-        order_detail.deposit_number = nil
-        order_detail.unrecoverable_note = @bulk_note if @bulk_note.present?
-        order_detail.change_status!(OrderStatus.unrecoverable)
-      end
-      @count += 1
-    rescue => e
-      @error_fields = { order_detail.id => order_detail.errors.collect { |field, _error| field } }
-      @persist_errors = order_detail.errors.full_messages
-      @persist_errors = [e.message] if @persist_errors.empty?
-      @count = 0
-      raise ActiveRecord::Rollback
+    def reconciling?
+      @reconciled_at.present?
     end
 
     def allowed(params)
@@ -88,10 +109,8 @@ module OrderDetails
       errors.add(:reconciled_at, :must_be_in_past) if reconciled_at > Time.current.end_of_day
     end
 
-    # You cannot set the reconciliation date for a date before the journal/statement date,
-    # but we do need to make sure to allow them on the same day.
     def all_journals_and_statements_must_be_before_reconciliation_date
-      return unless reconciled_at.present?
+      return unless reconciled_at.present? && @order_details.present?
       if @order_details.any? { |od| od.journal_or_statement_date&.beginning_of_day&.> reconciled_at }
         errors.add(:reconciled_at, :after_all_journal_dates)
       end

--- a/app/views/facility_accounts_reconciliation/_table.html.haml
+++ b/app/views/facility_accounts_reconciliation/_table.html.haml
@@ -15,7 +15,7 @@
   %tbody
     - @unreconciled_details.each do |order_detail|
       %tr
-        %td.centered= check_box_tag "order_detail[#{order_detail.id}][selected]", "1", false, id: "order_detail_#{order_detail.id}_reconciled", class: "toggle", aria: {label: t("facility_accounts_reconciliation.index.checkbox_label", order_number:  order_detail.to_s)}
+        %td.centered= check_box_tag "order_detail[#{order_detail.id}][selected]", "1", false, class: "toggle", aria: {label: t("facility_accounts_reconciliation.index.checkbox_label", order_number:  order_detail.to_s)}
         %td= "##{order_detail.statement_invoice_number}"
         %td
           = order_detail.account

--- a/app/views/facility_accounts_reconciliation/_table.html.haml
+++ b/app/views/facility_accounts_reconciliation/_table.html.haml
@@ -15,7 +15,7 @@
   %tbody
     - @unreconciled_details.each do |order_detail|
       %tr
-        %td.centered= check_box_tag "order_detail[#{order_detail.id}][reconciled]", "1", false, class: "toggle", aria: {label: t("facility_accounts_reconciliation.index.checkbox_label", order_number:  order_detail.to_s)}
+        %td.centered= check_box_tag "order_detail[#{order_detail.id}][selected]", "1", false, id: "order_detail_#{order_detail.id}_reconciled", class: "toggle", aria: {label: t("facility_accounts_reconciliation.index.checkbox_label", order_number:  order_detail.to_s)}
         %td= "##{order_detail.statement_invoice_number}"
         %td
           = order_detail.account

--- a/app/views/facility_journals/show.html.haml
+++ b/app/views/facility_journals/show.html.haml
@@ -41,16 +41,26 @@
   %p= t(".instruct.orders")
 
 - if @journal.order_details.present?
-  = form_tag facility_journal_reconcile_path(current_facility, @journal), method: :post do
-    - journal_is_submittable = @journal.submittable?
+  - journal_is_submittable = @journal.submittable?
+  - has_reconciled = @journal.order_details.where(state: "reconciled").any?
+  - has_unreconciled = @journal.order_details.where.not(state: "reconciled").any?
+  - journal_can_reconcile = @journal.successful? && has_unreconciled
+  - journal_can_unreconcile = @journal.successful? && has_reconciled
+  - show_checkboxes = journal_is_submittable || journal_can_unreconcile || journal_can_reconcile
+  
+  = form_tag facility_journal_reconcile_path(current_facility, @journal), method: :post, id: "journal-form" do
     %table.table.table-striped.table-hover
       %thead
-        - if journal_is_submittable
+        - if show_checkboxes
           %tr.borderless
             %th{colspan: 3}= select_all_link
-            %th.currency{colspan: 3}= submit_tag t(".submit"), class: "btn btn-primary"
+            %th.currency{colspan: 3}
+              - if journal_can_reconcile || journal_is_submittable
+                = submit_tag t(".submit"), class: "btn btn-primary", onclick: "this.form.action='#{facility_journal_reconcile_path(current_facility, @journal)}'; return true;"
+              - if journal_can_unreconcile
+                = submit_tag "Unreconcile Orders", class: "btn btn-primary", onclick: "this.form.action='#{facility_journal_unreconcile_path(current_facility, @journal)}'; return true;", style: "margin-left: 5px;"
         %tr
-          - if journal_is_submittable
+          - if show_checkboxes
             %th
           %th= t(".th.order")
           %th= t(".th.fulfilled")
@@ -59,10 +69,11 @@
           %th= t(".th.reconciled")
       %tbody
         - @journal.order_details.each do |order_detail|
-          - disable = order_detail.reconciled? || @journal.open?
           %tr
-            - if journal_is_submittable
-              %td= check_box_tag "order_detail[#{order_detail.id}][reconciled]", "1", order_detail.reconciled?, disabled: order_detail.reconciled?, class: (order_detail.reconciled? ? "" : "toggle")
+            - if show_checkboxes
+              %td
+                - checkbox_checked = journal_is_submittable && !journal_can_unreconcile && order_detail.reconciled?
+                = check_box_tag "order_detail[#{order_detail.id}][selected]", "1", checkbox_checked, class: "toggle"
             %td
               = link_to order_detail, facility_order_path(order_detail.order.facility.url_name, order_detail.order_id)
               - if order_detail.note?
@@ -72,9 +83,13 @@
             %td= order_detail.account
             %td= number_to_currency(order_detail.total)
             %td= order_detail.reconciled? ? t("boolean.true") : t("boolean.false")
-        - if journal_is_submittable
+        - if show_checkboxes
           %tr.borderless
             %td{colspan: 3}
-            %td.currency{colspan: 3}= submit_tag t(".submit"), class: "btn btn-primary"
+            %td.currency{colspan: 3}
+              - if journal_can_reconcile || journal_is_submittable
+                = submit_tag t(".submit"), class: "btn btn-primary", onclick: "this.form.action='#{facility_journal_reconcile_path(current_facility, @journal)}'; return true;"
+              - if journal_can_unreconcile
+                = submit_tag "Unreconcile Orders", class: "btn btn-primary", onclick: "this.form.action='#{facility_journal_unreconcile_path(current_facility, @journal)}'; return true;", style: "margin-left: 5px;"
 - else
   %p.notice= t(".notice")

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -68,13 +68,11 @@ en:
       reconcile:
         success: "%{count} payment(s) successfully reconciled"
         errors:
-          none_selected: "No orders were selected to reconcile"
-          none_eligible: "All selected orders are already reconciled"
+          none_eligible: "No orders were selected or eligible to reconcile"
       unreconcile:
         success: "%{count} payment(s) successfully unreconciled"
         errors:
-          none_selected: "No orders were selected to unreconcile"
-          none_eligible: "No reconciled orders were selected to unreconcile"
+          none_eligible: "No orders were selected or eligible to unreconcile"
 
     facility_order_details:
       destroy:

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -65,6 +65,16 @@ en:
       create:
         notice: "The journal file has been created successfully"
         more_errors: "There are more errors. Please resolve those above to see those that remain."
+      reconcile:
+        success: "%{count} payment(s) successfully reconciled"
+        errors:
+          none_selected: "No orders were selected to reconcile"
+          none_eligible: "All selected orders are already reconciled"
+      unreconcile:
+        success: "%{count} payment(s) successfully unreconciled"
+        errors:
+          none_selected: "No orders were selected to unreconcile"
+          none_eligible: "No reconciled orders were selected to unreconcile"
 
     facility_order_details:
       destroy:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -311,6 +311,7 @@ Rails.application.routes.draw do
 
     resources :journals, controller: "facility_journals", only: [:index, :new, :create, :update, :show] do
       post "reconcile", to: "facility_journals#reconcile"
+      post "unreconcile", to: "facility_journals#unreconcile"
     end
 
     resources :price_groups do

--- a/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
+++ b/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe FacilityAccountsReconciliationController do
                               reconciled_at: formatted_reconciled_at,
                               order_detail: {
                                 order_detail.id.to_s => {
-                                  reconciled: "1",
+                                  selected: "1",
                                   reconciled_note: "A note",
                                 },
                               } }
@@ -70,7 +70,7 @@ RSpec.describe FacilityAccountsReconciliationController do
           page: 2,
           order_detail: {
             order_detail.id.to_s => {
-              reconciled: "1",
+              selected: "1",
               reconciled_note: "A note",
             },
           }

--- a/spec/controllers/facility_journals_controller_spec.rb
+++ b/spec/controllers/facility_journals_controller_spec.rb
@@ -483,7 +483,7 @@ RSpec.describe FacilityJournalsController do
 
       it "sets a flash message" do
         perform
-        expect(flash[:error]).to include("No orders")
+        expect(flash[:error]).to eq("No orders were selected or eligible to reconcile")
       end
     end
   end
@@ -573,9 +573,9 @@ RSpec.describe FacilityJournalsController do
         expect(@order_detail3.reload.state).to eq("complete")
       end
 
-      it "shows appropriate flash notice" do
+      it "shows appropriate flash error" do
         perform
-        expect(flash[:notice]).to eq("No reconciled orders were selected to unreconcile")
+        expect(flash[:error]).to eq("No orders were selected or eligible to unreconcile")
       end
     end
   end

--- a/spec/services/order_details/reconciler_spec.rb
+++ b/spec/services/order_details/reconciler_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe OrderDetails::Reconciler do
       OrderDetail.create!(product: product, quantity: 1, actual_cost: 1, actual_subsidy: 0, state: "complete", statement:, order_id: order.id, created_by_user: user)
     end
   end
-  let(:params) { order_details.each_with_object({}) { |od, h| h[od.id.to_s] = ActionController::Parameters.new(reconciled: "1") } }
+  let(:params) { order_details.each_with_object({}) { |od, h| h[od.id.to_s] = ActionController::Parameters.new(selected: "1", reconciled: "1") } }
   let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current, "reconciled") }
   let(:account) { create(:account, :with_account_owner, type: Account.config.statement_account_types.first) }
   let(:statement) { create(:statement, facility: product.facility, account:, created_by_user: user) }
@@ -71,7 +71,7 @@ RSpec.describe OrderDetails::Reconciler do
     context "with NO bulk note" do
       context "with reconciled note set" do
         let(:reconciler) { described_class.new(OrderDetail.all, params, Time.current, "reconciled") }
-        let(:params) { order_details.each_with_object({}) { |od, h| h[od.id.to_s] = ActionController::Parameters.new(reconciled: "1", reconciled_note: "note #{od.id}") } }
+        let(:params) { order_details.each_with_object({}) { |od, h| h[od.id.to_s] = ActionController::Parameters.new(selected: "1", reconciled: "1", reconciled_note: "note #{od.id}") } }
 
         it "adds the note to the appropriate order details" do
           reconciler.reconcile_all

--- a/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
+++ b/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Account Reconciliation", :js do
       expect(page).to have_content(order_number)
       expect(page).not_to have_content(other_order_number)
 
-      check "order_detail_#{order_detail.id}_reconciled"
+      check "order_detail_#{order_detail.id}_selected"
 
       fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
       fill_in "order_detail_#{order_detail.id}_reconciled_note", with: "this is a note!"
@@ -90,10 +90,10 @@ RSpec.describe "Account Reconciliation", :js do
         expect(page).to have_button("Update Orders", disabled: true)
 
         fill_in "Bulk Note", with: "this is the bulk note"
-        check "order_detail_#{order_detail.id}_reconciled"
+        check "order_detail_#{order_detail.id}_selected"
         expect(page).to have_button("Update Orders", disabled: false)
 
-        check "order_detail_#{orders.last.order_details.first.id}_reconciled"
+        check "order_detail_#{orders.last.order_details.first.id}_selected"
         fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
         click_button "Update Orders", match: :first
 
@@ -112,8 +112,8 @@ RSpec.describe "Account Reconciliation", :js do
         check "Use Bulk Note"
         fill_in "Bulk Note", with: "this is the bulk note"
         uncheck "Use Bulk Note"
-        check "order_detail_#{order_detail.id}_reconciled"
-        check "order_detail_#{orders.last.order_details.first.id}_reconciled"
+        check "order_detail_#{order_detail.id}_selected"
+        check "order_detail_#{orders.last.order_details.first.id}_selected"
         fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
         click_button "Update Orders", match: :first
 
@@ -144,7 +144,7 @@ RSpec.describe "Account Reconciliation", :js do
       expect(page).to have_content(order_number)
       expect(page).not_to have_content(other_order_number)
 
-      check "order_detail_#{order_detail.id}_reconciled"
+      check "order_detail_#{order_detail.id}_selected"
       fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
       fill_in "order_detail_#{order_detail.id}_reconciled_note", with: "this is a note!"
       click_button "Update Orders", match: :first
@@ -166,8 +166,8 @@ RSpec.describe "Account Reconciliation", :js do
 
       check "Use Bulk Note"
       fill_in "Bulk Note", with: "this is the bulk note"
-      check "order_detail_#{order_detail.id}_reconciled"
-      check "order_detail_#{orders.last.order_details.first.id}_reconciled"
+      check "order_detail_#{order_detail.id}_selected"
+      check "order_detail_#{orders.last.order_details.first.id}_selected"
       fill_in "Reconciliation Date", with: I18n.l(1.day.ago.to_date, format: :usa)
       click_button "Update Orders", match: :first
 
@@ -230,10 +230,10 @@ RSpec.describe "Account Reconciliation", :js do
         end
 
         it "allows to add unrecoverable_note individually" do
-          check "order_detail_#{order_detail1.id}_reconciled"
+          check "order_detail_#{order_detail1.id}_selected"
           fill_in "order_detail_#{order_detail1.id}_unrecoverable_note", with: "Unrecoverable note 1"
 
-          check "order_detail_#{order_detail2.id}_reconciled"
+          check "order_detail_#{order_detail2.id}_selected"
           fill_in "order_detail_#{order_detail2.id}_unrecoverable_note", with: "Unrecoverable note 2"
 
           click_button "Update Orders", match: :first
@@ -249,8 +249,8 @@ RSpec.describe "Account Reconciliation", :js do
 
         it "allows to add a unrecoverable_note in bulk" do
           check "Use Bulk Note"
-          check "order_detail_#{order_detail1.id}_reconciled"
-          check "order_detail_#{order_detail2.id}_reconciled"
+          check "order_detail_#{order_detail1.id}_selected"
+          check "order_detail_#{order_detail2.id}_selected"
 
           fill_in "Bulk Note", with: "Unrecoverable note"
 
@@ -268,7 +268,7 @@ RSpec.describe "Account Reconciliation", :js do
         it "clears reconciled_note if then set as unrecoverable" do
           select "Reconciled", from: "order_status"
 
-          check "order_detail_#{order_detail1.id}_reconciled"
+          check "order_detail_#{order_detail1.id}_selected"
           fill_in "order_detail_#{order_detail1.id}_reconciled_note", with: "Reconciled note"
 
           select "Unrecoverable", from: "order_status"


### PR DESCRIPTION
# Release Notes

Add mass unreconciling functionality for journal transactions, allowing facility administrators to efficiently reverse reconciled payment transactions in bulk.

# Screenshots

<img width="881" height="514" alt="Screenshot 2025-09-10 at 10 18 11 AM" src="https://github.com/user-attachments/assets/cbef4b08-7093-4484-93b3-70e61bdbd53f" />

