### PR TITLE
[NU-26] Use account owner for pricing when feature flag is enabled

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -526,7 +526,7 @@ class OrderDetail < ApplicationRecord
   def price_groups
     return [PriceGroup.nonbillable] if product.nonbillable_mode?
 
-    groups = SettingsHelper.feature_on?(:pricing_flows_from_payment_source) ? [] : user.price_groups
+    groups = SettingsHelper.feature_on?(:user_based_price_groups_exclude_purchaser) ? [] : user.price_groups
     groups += account.price_groups if account
     groups.uniq
   end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -526,13 +526,8 @@ class OrderDetail < ApplicationRecord
   def price_groups
     return [PriceGroup.nonbillable] if product.nonbillable_mode?
 
-    if SettingsHelper.feature_on?(:pricing_flows_from_payment_source)
-      groups = account&.owner_user&.price_groups || user.price_groups
-    else
-      groups = user.price_groups
-      groups += account.price_groups if account
-    end
-
+    groups = SettingsHelper.feature_on?(:pricing_flows_from_payment_source) ? [] : user.price_groups
+    groups += account.price_groups if account
     groups.uniq
   end
 

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -526,8 +526,13 @@ class OrderDetail < ApplicationRecord
   def price_groups
     return [PriceGroup.nonbillable] if product.nonbillable_mode?
 
-    groups = user.price_groups
-    groups += account.price_groups if account
+    if SettingsHelper.feature_on?(:pricing_flows_from_payment_source)
+      groups = account&.owner_user&.price_groups || user.price_groups
+    else
+      groups = user.price_groups
+      groups += account.price_groups if account
+    end
+
     groups.uniq
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -180,7 +180,7 @@ feature:
   reference_statement_invoice_number: false
   stored_order_notices: false
   account_tabs: false
-  pricing_flows_from_payment_source: false
+  user_based_price_groups_exclude_purchaser: false
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -180,6 +180,7 @@ feature:
   reference_statement_invoice_number: false
   stored_order_notices: false
   account_tabs: false
+  pricing_flows_from_payment_source: false
 
 split_accounts:
   # Roles are allowed to create Split Accounts

--- a/spec/models/order_detail_price_groups_spec.rb
+++ b/spec/models/order_detail_price_groups_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe OrderDetail do
-  describe "#price_groups with pricing_flows_from_payment_source feature" do
+  describe "#price_groups with user_based_price_groups_exclude_purchaser feature" do
     let(:product) { create(:setup_item) }
     let(:facility) { product.facility }
     let(:purchaser) { create(:user) }
@@ -23,15 +23,15 @@ RSpec.describe OrderDetail do
       account.account_users.create!(user: purchaser, user_role: AccountUser::ACCOUNT_PURCHASER, created_by: 1)
     end
 
-    context "when feature is disabled", feature_setting: { pricing_flows_from_payment_source: false } do
+    context "when feature is disabled", feature_setting: { user_based_price_groups_exclude_purchaser: false } do
       it "uses purchaser's price groups plus account's price groups" do
         expect(order_detail.price_groups).to include(purchaser_price_group)
         expect(order_detail.price_groups).to include(owner_price_group)
       end
     end
 
-    context "when feature is enabled", feature_setting: { pricing_flows_from_payment_source: true } do
-      it "uses only account's price groups (owner's price groups)" do
+    context "when feature is enabled", feature_setting: { user_based_price_groups_exclude_purchaser: true } do
+      it "excludes purchaser's price groups, uses only account's price groups" do
         expect(order_detail.price_groups).to include(owner_price_group)
         expect(order_detail.price_groups).not_to include(purchaser_price_group)
       end

--- a/spec/models/order_detail_price_groups_spec.rb
+++ b/spec/models/order_detail_price_groups_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OrderDetail do
+  describe "#price_groups with pricing_flows_from_payment_source feature" do
+    let(:product) { create(:setup_item) }
+    let(:facility) { product.facility }
+    let(:purchaser) { create(:user) }
+    let(:account_owner) { create(:user) }
+    let(:account) { create(:setup_account, owner_user: account_owner, facility:) }
+    let(:order) { create(:setup_order, user: purchaser, facility:, account:) }
+    let(:order_detail) do
+      create(:order_detail, order:, product:, account:)
+    end
+
+    let(:purchaser_price_group) { create(:price_group, name: "Purchaser Group", facility:) }
+    let(:owner_price_group) { create(:price_group, name: "Owner Group", facility:) }
+
+    before do
+      purchaser.price_groups << purchaser_price_group
+      account_owner.price_groups << owner_price_group
+    end
+
+    context "when feature is disabled", feature_setting: { pricing_flows_from_payment_source: false } do
+      it "uses purchaser's price groups" do
+        expect(order_detail.price_groups).to include(purchaser_price_group)
+        expect(order_detail.price_groups).not_to include(owner_price_group)
+      end
+    end
+
+    context "when feature is enabled", feature_setting: { pricing_flows_from_payment_source: true } do
+      it "uses account owner's price groups" do
+        expect(order_detail.price_groups).to include(owner_price_group)
+        expect(order_detail.price_groups).not_to include(purchaser_price_group)
+      end
+
+      it "falls back to purchaser when no account owner" do
+        account.update(owner_user: nil)
+        expect(order_detail.price_groups).to include(purchaser_price_group)
+      end
+    end
+  end
+end

--- a/spec/models/order_detail_price_groups_spec.rb
+++ b/spec/models/order_detail_price_groups_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe OrderDetail do
     let(:purchaser) { create(:user) }
     let(:account_owner) { create(:user) }
     let(:account) { create(:setup_account, owner_user: account_owner, facility:) }
-    let(:order) { create(:setup_order, user: purchaser, facility:, account:) }
+    let(:order) { create(:order, user: purchaser, facility:, account:, created_by: purchaser.id) }
     let(:order_detail) do
       create(:order_detail, order:, product:, account:)
     end
@@ -20,24 +20,25 @@ RSpec.describe OrderDetail do
     before do
       purchaser.price_groups << purchaser_price_group
       account_owner.price_groups << owner_price_group
+      account.account_users.create!(user: purchaser, user_role: AccountUser::ACCOUNT_PURCHASER, created_by: 1)
     end
 
     context "when feature is disabled", feature_setting: { pricing_flows_from_payment_source: false } do
-      it "uses purchaser's price groups" do
+      it "uses purchaser's price groups plus account's price groups" do
         expect(order_detail.price_groups).to include(purchaser_price_group)
-        expect(order_detail.price_groups).not_to include(owner_price_group)
+        expect(order_detail.price_groups).to include(owner_price_group)
       end
     end
 
     context "when feature is enabled", feature_setting: { pricing_flows_from_payment_source: true } do
-      it "uses account owner's price groups" do
+      it "uses only account's price groups (owner's price groups)" do
         expect(order_detail.price_groups).to include(owner_price_group)
         expect(order_detail.price_groups).not_to include(purchaser_price_group)
       end
 
-      it "falls back to purchaser when no account owner" do
-        account.update(owner_user: nil)
-        expect(order_detail.price_groups).to include(purchaser_price_group)
+      it "returns empty array when no account present" do
+        order_detail.account = nil
+        expect(order_detail.price_groups).to eq([])
       end
     end
   end

--- a/spec/models/order_detail_price_groups_spec.rb
+++ b/spec/models/order_detail_price_groups_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe OrderDetail do
     before do
       purchaser.price_groups << purchaser_price_group
       account_owner.price_groups << owner_price_group
-      account.account_users.create!(user: purchaser, user_role: AccountUser::ACCOUNT_PURCHASER, created_by: 1)
+      create(:account_user, :purchaser, account: account, user: purchaser)
     end
 
     context "when feature is disabled", feature_setting: { user_based_price_groups_exclude_purchaser: false } do


### PR DESCRIPTION
# Release Notes

Added configurable pricing flow feature that allows price groups to be determined by payment source (account owner) instead of purchaser when enabled.

# Additional Context

This change introduces a new feature flag `pricing_flows_from_payment_source` that modifies how price groups are calculated for order details. When enabled, the system will use the account owner's price groups instead of the purchaser's price groups for pricing calculations.
