### PR TITLE
[OSU-173] Account styles fixes

### DIFF
--- a/app/assets/stylesheets/app/facility_accounts.scss
+++ b/app/assets/stylesheets/app/facility_accounts.scss
@@ -19,7 +19,7 @@
 }
 
 .account-form {
-  input {
+  .form-control {
     max-width: 240px;
   }
 }

--- a/app/inputs/date_picker_input.rb
+++ b/app/inputs/date_picker_input.rb
@@ -11,7 +11,9 @@ class DatePickerInput < SimpleForm::Inputs::Base
 
     min_date = options[:min_date]
 
-    html_options = input_html_options.merge(value: value, class: "datepicker__data")
+    html_options = input_html_options.merge(
+      value:, class: "datepicker__data form-control",
+    )
     html_options[:data] = { min_date: min_date } if min_date
 
     @builder.text_field attribute_name, html_options


### PR DESCRIPTION
# Notes

- Set account form max-width to form-control instead of inputs so it applies to select elements as well
- Use bootstrap input styles for date picker. This applies to all date pickers in the app

> These changes are needed for school specific changes

# Screenshot

Before

<img width="898" height="493" alt="Captura de pantalla 2025-09-15 a la(s) 10 29 05" src="https://github.com/user-attachments/assets/bba7be95-a2ae-471b-9bac-fc50ed76e206" />

After

<img width="898" height="493" alt="Captura de pantalla 2025-09-15 a la(s) 10 40 14" src="https://github.com/user-attachments/assets/c6a113aa-6aeb-4c9e-bffb-0fe3108dcf9a" />

# Additional Context

When the account form has a select box it spans the full width of the page since the max width style was only applied to inputs.
The date picker is rendered for the account `expires_at` field and was not using bootstrap styles.
