### PR TITLE
[NU-28] Only global admin can mass unriconcile

### DIFF
--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -145,6 +145,10 @@ class FacilityJournalsController < ApplicationController
       raise CanCan::AccessDenied, I18n.t("controllers.facility_journals.unreconcile.feature_disabled")
     end
 
+    unless current_user.administrator?
+      raise CanCan::AccessDenied, I18n.t("controllers.facility_journals.unreconcile.access_denied")
+    end
+
     process_reconciliation(:unreconcile)
   end
 

--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -170,6 +170,9 @@ class FacilityJournalsController < ApplicationController
 
     if count > 0
       flash[:notice] = I18n.t("controllers.facility_journals.#{action}.success", count: count)
+      if reconciler.full_errors.any?
+        flash[:error] = reconciler.full_errors.join("<br />").html_safe
+      end
     elsif reconciler.full_errors.any?
       flash[:error] = reconciler.full_errors.join("<br />").html_safe
     else

--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -145,9 +145,7 @@ class FacilityJournalsController < ApplicationController
       raise CanCan::AccessDenied
     end
 
-    unless current_user.administrator?
-      raise CanCan::AccessDenied
-    end
+    authorize! :unreconcile, OrderDetail
 
     process_reconciliation(:unreconcile)
   end

--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -142,11 +142,11 @@ class FacilityJournalsController < ApplicationController
 
   def unreconcile
     unless SettingsHelper.feature_on?(:allow_mass_unreconciling)
-      raise CanCan::AccessDenied, I18n.t("controllers.facility_journals.unreconcile.feature_disabled")
+      raise CanCan::AccessDenied
     end
 
     unless current_user.administrator?
-      raise CanCan::AccessDenied, I18n.t("controllers.facility_journals.unreconcile.access_denied")
+      raise CanCan::AccessDenied
     end
 
     process_reconciliation(:unreconcile)

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -391,7 +391,7 @@ class OrderDetail < ApplicationRecord
       transitions to: :reconciled, from: :complete, guard: :actual_total
     end
 
-    event :unreconcile do
+    event :to_complete_from_reconciled do
       transitions to: :complete, from: :reconciled, after: :set_complete_order_status
     end
 

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -391,6 +391,10 @@ class OrderDetail < ApplicationRecord
       transitions to: :reconciled, from: :complete, guard: :actual_total
     end
 
+    event :unreconcile do
+      transitions to: :complete, from: :reconciled, after: :set_complete_order_status
+    end
+
     event :to_unrecoverable do
       transitions to: :unrecoverable, from: :complete, guard: :can_be_marked_as_unrecoverable?
     end
@@ -1007,6 +1011,10 @@ class OrderDetail < ApplicationRecord
   end
 
   private
+
+  def set_complete_order_status
+    self.order_status = OrderStatus.complete
+  end
 
   # Is there enough information to move an associated order to complete/problem?
   def time_data_completeable?

--- a/app/models/order_detail/accessorized.rb
+++ b/app/models/order_detail/accessorized.rb
@@ -43,6 +43,8 @@ module OrderDetail::Accessorized
 
   def update_children
     return unless child_order_details.any?
+    # Skip updating children during unreconciliation to prevent unreconciling orders outside a journal
+    return if saved_change_to_state? && state_before_last_save == "reconciled" && state == "complete"
     accessorizer = Accessories::ChildUpdater.new(self)
     @updated_children = accessorizer.update_children
   end

--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -58,29 +58,25 @@ module OrderDetails
     def unreconcile_all
       @count = 0
       @persist_errors = []
-      rollback_occurred = false
 
-      OrderDetail.transaction do
-        order_details.each do |order_detail|
-          next unless order_detail.reconciled?
+      order_details.each do |order_detail|
+        next unless order_detail.reconciled?
 
-          begin
-            order_detail.update!(
-              state: "complete",
-              order_status: OrderStatus.complete,
-              reconciled_at: nil,
-              deposit_number: nil
-            )
-            @count += 1
-          rescue => e
-            @persist_errors << "Order ##{order_detail.id}: #{e.message}"
-            rollback_occurred = true
-            raise ActiveRecord::Rollback
-          end
+        begin
+          order_detail.update!(
+            state: "complete",
+            order_status: OrderStatus.complete,
+            reconciled_at: nil,
+            deposit_number: nil,
+            reconciled_note: nil
+          )
+          @count += 1
+        rescue => e
+          @persist_errors << "Order ##{order_detail.id}: #{e.message}"
         end
       end
 
-      rollback_occurred ? 0 : @count
+      @count
     end
 
     def full_errors

--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -63,12 +63,13 @@ module OrderDetails
         next unless order_detail.reconciled?
 
         begin
-          order_detail.update!(
+          order_detail.update_columns(
             state: "complete",
-            order_status: OrderStatus.complete,
+            order_status_id: OrderStatus.complete.id,
             reconciled_at: nil,
             deposit_number: nil,
-            reconciled_note: nil
+            reconciled_note: nil,
+            updated_at: Time.current
           )
           @count += 1
         rescue => e

--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -63,14 +63,10 @@ module OrderDetails
         next unless order_detail.reconciled?
 
         begin
-          order_detail.update_columns(
-            state: "complete",
-            order_status_id: OrderStatus.complete.id,
-            reconciled_at: nil,
-            deposit_number: nil,
-            reconciled_note: nil,
-            updated_at: Time.current
-          )
+          order_detail.reconciled_at = nil
+          order_detail.deposit_number = nil
+          order_detail.reconciled_note = nil
+          order_detail.unreconcile!
           @count += 1
         rescue => e
           @persist_errors << "Order ##{order_detail.id}: #{e.message}"

--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -68,7 +68,7 @@ module OrderDetails
           order_detail.reconciled_note = nil
           order_detail.to_complete_from_reconciled!
           @count += 1
-        rescue => e
+        rescue AASM::InvalidTransition, ActiveRecord::RecordInvalid => e
           @persist_errors << "Order ##{order_detail.id}: #{e.message}"
         end
       end

--- a/app/services/order_details/reconciler.rb
+++ b/app/services/order_details/reconciler.rb
@@ -66,7 +66,7 @@ module OrderDetails
           order_detail.reconciled_at = nil
           order_detail.deposit_number = nil
           order_detail.reconciled_note = nil
-          order_detail.unreconcile!
+          order_detail.to_complete_from_reconciled!
           @count += 1
         rescue => e
           @persist_errors << "Order ##{order_detail.id}: #{e.message}"

--- a/app/views/facility_journals/show.html.haml
+++ b/app/views/facility_journals/show.html.haml
@@ -45,7 +45,7 @@
   - has_reconciled = @journal.order_details.where(state: "reconciled").any?
   - has_unreconciled = @journal.order_details.where.not(state: "reconciled").any?
   - journal_can_reconcile = @journal.successful? && has_unreconciled
-  - journal_can_unreconcile = @journal.successful? && has_reconciled && SettingsHelper.feature_on?(:allow_mass_unreconciling)
+  - journal_can_unreconcile = @journal.successful? && has_reconciled && SettingsHelper.feature_on?(:allow_mass_unreconciling) && current_user.administrator?
   - show_checkboxes = journal_is_submittable || journal_can_unreconcile || journal_can_reconcile
   
   = form_tag facility_journal_reconcile_path(current_facility, @journal), method: :post, id: "journal-form" do

--- a/app/views/facility_journals/show.html.haml
+++ b/app/views/facility_journals/show.html.haml
@@ -45,7 +45,7 @@
   - has_reconciled = @journal.order_details.where(state: "reconciled").any?
   - has_unreconciled = @journal.order_details.where.not(state: "reconciled").any?
   - journal_can_reconcile = @journal.successful? && has_unreconciled
-  - journal_can_unreconcile = @journal.successful? && has_reconciled && SettingsHelper.feature_on?(:allow_mass_unreconciling) && current_user.administrator?
+  - journal_can_unreconcile = @journal.successful? && has_reconciled && SettingsHelper.feature_on?(:allow_mass_unreconciling) && can?(:unreconcile, OrderDetail)
   - show_checkboxes = journal_is_submittable || journal_can_unreconcile || journal_can_reconcile
   
   = form_tag facility_journal_reconcile_path(current_facility, @journal), method: :post, id: "journal-form" do

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -74,6 +74,7 @@ en:
         errors:
           none_eligible: "No orders were selected or eligible to unreconcile"
         feature_disabled: "Mass unreconciling is not enabled"
+        access_denied: "Only global administrators can perform mass unreconciling"
 
     facility_order_details:
       destroy:

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -74,7 +74,6 @@ en:
         errors:
           none_eligible: "No orders were selected or eligible to unreconcile"
         feature_disabled: "Mass unreconciling is not enabled"
-        access_denied: "Only global administrators can perform mass unreconciling"
 
     facility_order_details:
       destroy:

--- a/spec/controllers/facility_journals_controller_spec.rb
+++ b/spec/controllers/facility_journals_controller_spec.rb
@@ -620,11 +620,11 @@ RSpec.describe FacilityJournalsController do
             end
           end
 
-          it "rolls back all changes" do
+          it "unreconciles the successful orders but not the failed one" do
             perform
-            expect(@order_detail1.reload.state).to eq("reconciled")
+            expect(@order_detail1.reload.state).to eq("complete")
             expect(@order_detail2.reload.state).to eq("reconciled")
-            expect(@order_detail3.reload.state).to eq("reconciled")
+            expect(@order_detail3.reload.state).to eq("complete")
           end
 
           it "shows error message with the failing order detail" do
@@ -632,9 +632,9 @@ RSpec.describe FacilityJournalsController do
             expect(flash[:error]).to include("Failed to update order detail")
           end
 
-          it "does not show success message" do
+          it "shows partial success message" do
             perform
-            expect(flash[:notice]).to be_nil
+            expect(flash[:notice]).to eq("2 payment(s) successfully unreconciled")
           end
         end
       end

--- a/spec/controllers/facility_journals_controller_spec.rb
+++ b/spec/controllers/facility_journals_controller_spec.rb
@@ -519,107 +519,123 @@ RSpec.describe FacilityJournalsController do
     end
 
     context "when feature flag is enabled", feature_setting: { allow_mass_unreconciling: true } do
-      describe "when all order details are reconciled" do
+      context "when user is not global admin" do
+        let!(:user) { create(:user, :facility_director, facility:) }
+
         before do
-          @order_detail1.update!(state: "reconciled", reconciled_at: 1.day.ago, order_status: OrderStatus.reconciled)
-          @order_detail2.update!(state: "reconciled", reconciled_at: 1.day.ago, order_status: OrderStatus.reconciled)
-          @order_detail3.update!(state: "reconciled", reconciled_at: 1.day.ago, order_status: OrderStatus.reconciled)
+          sign_in user
         end
 
-        it "unreconciles all order details" do
-          perform
-          expect(@order_detail1.reload.state).to eq("complete")
-          expect(@order_detail2.reload.state).to eq("complete")
-          expect(@order_detail3.reload.state).to eq("complete")
-        end
-
-        it "clears reconciled_at for all order details" do
-          perform
-          expect(@order_detail1.reload.reconciled_at).to be_nil
-          expect(@order_detail2.reload.reconciled_at).to be_nil
-          expect(@order_detail3.reload.reconciled_at).to be_nil
-        end
-
-        it "sets flash notice with correct count" do
-          perform
-          expect(flash[:notice]).to eq("3 payment(s) successfully unreconciled")
+        it "denies access with proper error message" do
+          expect { perform }.to raise_error(CanCan::AccessDenied, "Only global administrators can perform mass unreconciling")
         end
       end
 
-      describe "when some order details are not reconciled" do
-        before do
-          @order_detail1.update!(state: "reconciled", reconciled_at: 1.day.ago, order_status: OrderStatus.reconciled)
-          @order_detail2.update!(state: "complete")
-          @order_detail3.update!(state: "reconciled", reconciled_at: 1.day.ago, order_status: OrderStatus.reconciled)
-        end
+      context "when user is global admin" do
+        let!(:user) { create(:user, :administrator) }
 
-        it "only unreconciles the reconciled ones" do
-          perform
-          expect(@order_detail1.reload.state).to eq("complete")
-          expect(@order_detail2.reload.state).to eq("complete")
-          expect(@order_detail3.reload.state).to eq("complete")
-        end
+        describe "when all order details are reconciled" do
+          before do
+            @order_detail1.update!(state: "reconciled", reconciled_at: 1.day.ago, order_status: OrderStatus.reconciled)
+            @order_detail2.update!(state: "reconciled", reconciled_at: 1.day.ago, order_status: OrderStatus.reconciled)
+            @order_detail3.update!(state: "reconciled", reconciled_at: 1.day.ago, order_status: OrderStatus.reconciled)
+          end
 
-        it "shows correct count in flash notice" do
-          perform
-          expect(flash[:notice]).to eq("2 payment(s) successfully unreconciled")
-        end
-      end
+          it "unreconciles all order details" do
+            perform
+            expect(@order_detail1.reload.state).to eq("complete")
+            expect(@order_detail2.reload.state).to eq("complete")
+            expect(@order_detail3.reload.state).to eq("complete")
+          end
 
-      describe "when no order details are reconciled" do
-        before do
-          @order_detail1.update!(state: "complete")
-          @order_detail2.update!(state: "complete")
-          @order_detail3.update!(state: "complete")
-        end
+          it "clears reconciled_at for all order details" do
+            perform
+            expect(@order_detail1.reload.reconciled_at).to be_nil
+            expect(@order_detail2.reload.reconciled_at).to be_nil
+            expect(@order_detail3.reload.reconciled_at).to be_nil
+          end
 
-        it "does not change any states" do
-          perform
-          expect(@order_detail1.reload.state).to eq("complete")
-          expect(@order_detail2.reload.state).to eq("complete")
-          expect(@order_detail3.reload.state).to eq("complete")
-        end
-
-        it "shows appropriate flash error" do
-          perform
-          expect(flash[:error]).to eq("No orders were selected or eligible to unreconcile")
-        end
-      end
-
-      describe "when unreconcile fails for one order detail" do
-        before do
-          @order_detail1.update!(state: "reconciled", reconciled_at: 1.day.ago, order_status: OrderStatus.reconciled)
-          @order_detail2.update!(state: "reconciled", reconciled_at: 1.day.ago, order_status: OrderStatus.reconciled)
-          @order_detail3.update!(state: "reconciled", reconciled_at: 1.day.ago, order_status: OrderStatus.reconciled)
-
-          allow_any_instance_of(OrderDetail).to receive(:update!).and_call_original
-
-          call_count = 0
-          allow_any_instance_of(OrderDetail).to receive(:update!).and_wrap_original do |original, receiver, *args|
-            call_count += 1
-            if call_count == 2 # Fail on the second order detail
-              raise StandardError, "Failed to update order detail"
-            else
-              original.call(receiver, *args)
-            end
+          it "sets flash notice with correct count" do
+            perform
+            expect(flash[:notice]).to eq("3 payment(s) successfully unreconciled")
           end
         end
 
-        it "rolls back all changes" do
-          perform
-          expect(@order_detail1.reload.state).to eq("reconciled")
-          expect(@order_detail2.reload.state).to eq("reconciled")
-          expect(@order_detail3.reload.state).to eq("reconciled")
+        describe "when some order details are not reconciled" do
+          before do
+            @order_detail1.update!(state: "reconciled", reconciled_at: 1.day.ago, order_status: OrderStatus.reconciled)
+            @order_detail2.update!(state: "complete")
+            @order_detail3.update!(state: "reconciled", reconciled_at: 1.day.ago, order_status: OrderStatus.reconciled)
+          end
+
+          it "only unreconciles the reconciled ones" do
+            perform
+            expect(@order_detail1.reload.state).to eq("complete")
+            expect(@order_detail2.reload.state).to eq("complete")
+            expect(@order_detail3.reload.state).to eq("complete")
+          end
+
+          it "shows correct count in flash notice" do
+            perform
+            expect(flash[:notice]).to eq("2 payment(s) successfully unreconciled")
+          end
         end
 
-        it "shows error message with the failing order detail" do
-          perform
-          expect(flash[:error]).to include("Failed to update order detail")
+        describe "when no order details are reconciled" do
+          before do
+            @order_detail1.update!(state: "complete")
+            @order_detail2.update!(state: "complete")
+            @order_detail3.update!(state: "complete")
+          end
+
+          it "does not change any states" do
+            perform
+            expect(@order_detail1.reload.state).to eq("complete")
+            expect(@order_detail2.reload.state).to eq("complete")
+            expect(@order_detail3.reload.state).to eq("complete")
+          end
+
+          it "shows appropriate flash error" do
+            perform
+            expect(flash[:error]).to eq("No orders were selected or eligible to unreconcile")
+          end
         end
 
-        it "does not show success message" do
-          perform
-          expect(flash[:notice]).to be_nil
+        describe "when unreconcile fails for one order detail" do
+          before do
+            @order_detail1.update!(state: "reconciled", reconciled_at: 1.day.ago, order_status: OrderStatus.reconciled)
+            @order_detail2.update!(state: "reconciled", reconciled_at: 1.day.ago, order_status: OrderStatus.reconciled)
+            @order_detail3.update!(state: "reconciled", reconciled_at: 1.day.ago, order_status: OrderStatus.reconciled)
+
+            allow_any_instance_of(OrderDetail).to receive(:update!).and_call_original
+
+            call_count = 0
+            allow_any_instance_of(OrderDetail).to receive(:update!).and_wrap_original do |original, receiver, *args|
+              call_count += 1
+              if call_count == 2 # Fail on the second order detail
+                raise StandardError, "Failed to update order detail"
+              else
+                original.call(receiver, *args)
+              end
+            end
+          end
+
+          it "rolls back all changes" do
+            perform
+            expect(@order_detail1.reload.state).to eq("reconciled")
+            expect(@order_detail2.reload.state).to eq("reconciled")
+            expect(@order_detail3.reload.state).to eq("reconciled")
+          end
+
+          it "shows error message with the failing order detail" do
+            perform
+            expect(flash[:error]).to include("Failed to update order detail")
+          end
+
+          it "does not show success message" do
+            perform
+            expect(flash[:notice]).to be_nil
+          end
         end
       end
     end

--- a/spec/controllers/facility_journals_controller_spec.rb
+++ b/spec/controllers/facility_journals_controller_spec.rb
@@ -526,8 +526,8 @@ RSpec.describe FacilityJournalsController do
           sign_in user
         end
 
-        it "denies access with proper error message" do
-          expect { perform }.to raise_error(CanCan::AccessDenied, "Only global administrators can perform mass unreconciling")
+        it "denies access" do
+          expect { perform }.to raise_error(CanCan::AccessDenied)
         end
       end
 

--- a/spec/controllers/facility_journals_controller_spec.rb
+++ b/spec/controllers/facility_journals_controller_spec.rb
@@ -679,7 +679,7 @@ RSpec.describe FacilityJournalsController do
             allow_any_instance_of(OrderDetail).to receive(:to_complete_from_reconciled!).and_wrap_original do |original, receiver, *args|
               call_count += 1
               if call_count == 2 # Fail on the second order detail
-                raise StandardError, "Failed to update order detail"
+                raise ActiveRecord::RecordInvalid, @order_detail2
               else
                 original.call(receiver, *args)
               end
@@ -695,7 +695,7 @@ RSpec.describe FacilityJournalsController do
 
           it "shows error message with the failing order detail" do
             perform
-            expect(flash[:error]).to include("Failed to update order detail")
+            expect(flash[:error]).to include("Order ##{@order_detail2.id}:")
           end
 
           it "shows partial success message" do

--- a/spec/controllers/facility_journals_controller_spec.rb
+++ b/spec/controllers/facility_journals_controller_spec.rb
@@ -637,17 +637,17 @@ RSpec.describe FacilityJournalsController do
           end
 
           before do
-            @journal.journal_rows.destroy_all
-            @journal.create_journal_rows!([parent_order, accessory_in_journal])
+            journal.journal_rows.destroy_all
+            journal.create_journal_rows!([parent_order, accessory_in_journal])
           end
 
           it "only unreconciles orders that are in the journal" do
-            expect(@journal.order_details.count).to eq(2)
-            expect(@journal.order_details).to include(parent_order, accessory_in_journal)
-            expect(@journal.order_details).not_to include(accessory_not_in_journal)
+            expect(journal.order_details.count).to eq(2)
+            expect(journal.order_details).to include(parent_order, accessory_in_journal)
+            expect(journal.order_details).not_to include(accessory_not_in_journal)
 
             params = {}
-            @journal.order_details.each do |od|
+            journal.order_details.each do |od|
               params[od.id.to_s] = { "selected" => "1" }
             end
 
@@ -665,7 +665,7 @@ RSpec.describe FacilityJournalsController do
             expect(accessory_in_journal.state).to eq("complete")
             expect(accessory_not_in_journal.state).to eq("reconciled") # Should remain reconciled
 
-            expect(flash[:notice]).to include("successfully unreconciled") if flash[:notice]
+            expect(flash[:notice]).to include("successfully unreconciled")
           end
         end
 
@@ -675,10 +675,8 @@ RSpec.describe FacilityJournalsController do
             @order_detail2.update!(state: "reconciled", reconciled_at: 1.day.ago, order_status: OrderStatus.reconciled)
             @order_detail3.update!(state: "reconciled", reconciled_at: 1.day.ago, order_status: OrderStatus.reconciled)
 
-            allow_any_instance_of(OrderDetail).to receive(:update_columns).and_call_original
-
             call_count = 0
-            allow_any_instance_of(OrderDetail).to receive(:update_columns).and_wrap_original do |original, receiver, *args|
+            allow_any_instance_of(OrderDetail).to receive(:unreconcile!).and_wrap_original do |original, receiver, *args|
               call_count += 1
               if call_count == 2 # Fail on the second order detail
                 raise StandardError, "Failed to update order detail"

--- a/spec/controllers/facility_journals_controller_spec.rb
+++ b/spec/controllers/facility_journals_controller_spec.rb
@@ -676,7 +676,7 @@ RSpec.describe FacilityJournalsController do
             @order_detail3.update!(state: "reconciled", reconciled_at: 1.day.ago, order_status: OrderStatus.reconciled)
 
             call_count = 0
-            allow_any_instance_of(OrderDetail).to receive(:unreconcile!).and_wrap_original do |original, receiver, *args|
+            allow_any_instance_of(OrderDetail).to receive(:to_complete_from_reconciled!).and_wrap_original do |original, receiver, *args|
               call_count += 1
               if call_count == 2 # Fail on the second order detail
                 raise StandardError, "Failed to update order detail"


### PR DESCRIPTION
# Notes
  Allow only global administrators to mass unreconcile journal orders, including accessory orders that were previously failing due to state transition conflicts. Only orders within the selected journal are affected - related orders outside the journal remain unchanged.

  ## [NU-28 | Allow mass journal transactions unreconciling](https://universe-of-universities.atlassian.net/browse/NU-28)

  ## Additional Context

  ### Problem
  Previously, mass unreconciling would fail when journals contained parent orders with accessories. When a parent order was unreconciled, it would trigger an `after_save` callback that attempted to update child orders' status, causing invalid state transitions from 'reconciled' to 'complete' using the wrong event.

  ### Solution
  - Restricted mass unreconciling feature to global administrators only
  - Added proper state machine transition `unreconcile` event to OrderDetail model
  - Modified reconciler to use the state machine's `unreconcile!` method instead of bypassing callbacks
  - Added logic to skip child order updates during unreconciliation to prevent state conflicts
  - Each order is processed independently - failures don't affect other orders
  - Added clear error messaging to indicate which specific orders failed and why
