### PR TITLE
[NU-26] Use payment source price group when assigned

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -8,13 +8,7 @@ class Account < ApplicationRecord
     # set to `false`. Currently Dartmouth is the only school with this feature
     # flag set to false, and they do this in their account_extension.rb
     def price_groups
-      account_price_groups = price_group_members.collect(&:price_group)
-
-      if SettingsHelper.feature_on?(:user_based_price_groups_exclude_purchaser) && account_price_groups.present?
-        account_price_groups
-      else
-        (account_price_groups + (owner_user ? owner_user.price_groups : [])).uniq
-      end
+      (price_group_members.collect(&:price_group) + (owner_user ? owner_user.price_groups : [])).uniq
     end
 
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -8,7 +8,13 @@ class Account < ApplicationRecord
     # set to `false`. Currently Dartmouth is the only school with this feature
     # flag set to false, and they do this in their account_extension.rb
     def price_groups
-      (price_group_members.collect(&:price_group) + (owner_user ? owner_user.price_groups : [])).uniq
+      account_price_groups = price_group_members.collect(&:price_group)
+
+      if SettingsHelper.feature_on?(:user_based_price_groups_exclude_purchaser) && account_price_groups.present?
+        account_price_groups
+      else
+        (account_price_groups + (owner_user ? owner_user.price_groups : [])).uniq
+      end
     end
 
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -8,7 +8,11 @@ class Account < ApplicationRecord
     # set to `false`. Currently Dartmouth is the only school with this feature
     # flag set to false, and they do this in their account_extension.rb
     def price_groups
-      (price_group_members.collect(&:price_group) + (owner_user ? owner_user.price_groups : [])).uniq
+      (account_price_groups + (owner_user ? owner_user.price_groups : [])).uniq
+    end
+
+    def account_price_groups
+      price_group_members.collect(&:price_group)
     end
 
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -267,7 +267,7 @@ class Product < ApplicationRecord
 
     # When feature flag is enabled, try account price groups first, then fallback to all groups
     if detail.is_a?(OrderDetail) && detail.account && SettingsHelper.feature_on?(:user_based_price_groups_exclude_purchaser)
-      account_price_groups = detail.account.price_group_members.collect(&:price_group)
+      account_price_groups = detail.account.account_price_groups
 
       if account_price_groups.present?
         policy = find_cheapest_price_policy_for_groups(detail, date, account_price_groups)
@@ -394,7 +394,6 @@ class Product < ApplicationRecord
 
   def find_cheapest_price_policy_for_groups(detail, date, groups)
     price_policies = current_price_policies(date).newest.to_a.delete_if { |pp| pp.restrict_purchase? || groups.exclude?(pp.price_group) }
-    return nil if price_policies.empty?
 
     # provide a predictable ordering of price groups so that equal unit costs
     # are always handled the same way. Put the base group at the front of the

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -426,58 +426,6 @@ RSpec.describe Account do
     end
   end
 
-  describe "#price_groups" do
-    let(:facility) { create(:facility) }
-    let(:owner_user) { create(:user) }
-    let(:account) { create(:nufs_account, :with_account_owner, owner: owner_user) }
-    let(:owner_price_group) { create(:price_group, facility:) }
-    let(:account_price_group) { create(:price_group, facility:) }
-
-    before do
-      owner_user.price_groups << owner_price_group
-    end
-
-    context "when user_based_price_groups_exclude_purchaser is disabled", feature_setting: { user_based_price_groups_exclude_purchaser: false } do
-      context "when account has no price groups assigned" do
-        it "returns only the owner's price groups" do
-          expect(account.price_groups).to include(owner_price_group)
-        end
-      end
-
-      context "when account has price groups assigned" do
-        before do
-          account.price_group_members.create!(price_group: account_price_group)
-        end
-
-        it "returns both account and owner price groups" do
-          expect(account.price_groups).to include(account_price_group, owner_price_group)
-        end
-      end
-    end
-
-    context "when user_based_price_groups_exclude_purchaser is enabled", feature_setting: { user_based_price_groups_exclude_purchaser: true } do
-      context "when account has no price groups assigned" do
-        it "returns the owner's price groups" do
-          expect(account.price_groups).to include(owner_price_group)
-        end
-      end
-
-      context "when account has price groups assigned directly" do
-        before do
-          account.price_group_members.create!(price_group: account_price_group)
-        end
-
-        it "returns only the account's price groups" do
-          expect(account.price_groups).to contain_exactly(account_price_group)
-        end
-
-        it "does not include the owner's price groups" do
-          expect(account.price_groups).not_to include(owner_price_group)
-        end
-      end
-    end
-  end
-
   describe "#expired?" do
     it "returns true if the account is expired" do
       account.expires_at = 1.day.ago

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -426,6 +426,58 @@ RSpec.describe Account do
     end
   end
 
+  describe "#price_groups" do
+    let(:facility) { create(:facility) }
+    let(:owner_user) { create(:user) }
+    let(:account) { create(:nufs_account, :with_account_owner, owner: owner_user) }
+    let(:owner_price_group) { create(:price_group, facility:) }
+    let(:account_price_group) { create(:price_group, facility:) }
+
+    before do
+      owner_user.price_groups << owner_price_group
+    end
+
+    context "when user_based_price_groups_exclude_purchaser is disabled", feature_setting: { user_based_price_groups_exclude_purchaser: false } do
+      context "when account has no price groups assigned" do
+        it "returns only the owner's price groups" do
+          expect(account.price_groups).to include(owner_price_group)
+        end
+      end
+
+      context "when account has price groups assigned" do
+        before do
+          account.price_group_members.create!(price_group: account_price_group)
+        end
+
+        it "returns both account and owner price groups" do
+          expect(account.price_groups).to include(account_price_group, owner_price_group)
+        end
+      end
+    end
+
+    context "when user_based_price_groups_exclude_purchaser is enabled", feature_setting: { user_based_price_groups_exclude_purchaser: true } do
+      context "when account has no price groups assigned" do
+        it "returns the owner's price groups" do
+          expect(account.price_groups).to include(owner_price_group)
+        end
+      end
+
+      context "when account has price groups assigned directly" do
+        before do
+          account.price_group_members.create!(price_group: account_price_group)
+        end
+
+        it "returns only the account's price groups" do
+          expect(account.price_groups).to contain_exactly(account_price_group)
+        end
+
+        it "does not include the owner's price groups" do
+          expect(account.price_groups).not_to include(owner_price_group)
+        end
+      end
+    end
+  end
+
   describe "#expired?" do
     it "returns true if the account is expired" do
       account.expires_at = 1.day.ago

--- a/spec/models/order_detail_price_groups_spec.rb
+++ b/spec/models/order_detail_price_groups_spec.rb
@@ -48,14 +48,48 @@ RSpec.describe OrderDetail do
           account.price_group_members.create!(price_group: account_price_group)
         end
 
-        it "uses account's assigned price groups instead of owner's price groups" do
+        it "includes both account and owner price groups for fallback" do
           expect(order_detail.price_groups).to include(account_price_group)
-          expect(order_detail.price_groups).not_to include(owner_price_group)
+          expect(order_detail.price_groups).to include(owner_price_group)
           expect(order_detail.price_groups).not_to include(purchaser_price_group)
         end
 
-        it "only includes the account's directly assigned price groups" do
-          expect(order_detail.price_groups).to eq([account_price_group])
+        context "when product has prices for account price groups" do
+          before do
+            create(:item_price_policy, product:, price_group: account_price_group, unit_cost: 10)
+            create(:item_price_policy, product:, price_group: owner_price_group, unit_cost: 20)
+          end
+
+          it "prioritizes account price group over owner price group" do
+            order_detail.assign_estimated_price
+            expect(order_detail.estimated_price_group).to eq(account_price_group)
+          end
+        end
+
+        context "when product only has prices for owner price groups" do
+          before do
+            create(:item_price_policy, product:, price_group: owner_price_group, unit_cost: 20)
+          end
+
+          it "falls back to owner price group" do
+            order_detail.assign_estimated_price
+            expect(order_detail.estimated_price_group).to eq(owner_price_group)
+          end
+        end
+
+        context "when account has price groups but product has no prices for them" do
+          let(:unpriced_account_group) { create(:price_group, name: "Unpriced Account Group", facility:) }
+
+          before do
+            account.price_group_members.create!(price_group: unpriced_account_group)
+            create(:item_price_policy, product:, price_group: owner_price_group, unit_cost: 15)
+          end
+
+          it "falls back to owner price group when account group has no valid prices" do
+            order_detail.assign_estimated_price
+            expect(order_detail.estimated_price_group).to eq(owner_price_group)
+            expect(order_detail.estimated_cost).to eq(15)
+          end
         end
       end
     end

--- a/spec/models/order_detail_price_groups_spec.rb
+++ b/spec/models/order_detail_price_groups_spec.rb
@@ -40,6 +40,24 @@ RSpec.describe OrderDetail do
         order_detail.account = nil
         expect(order_detail.price_groups).to eq([])
       end
+
+      context "when account has price groups assigned directly" do
+        let(:account_price_group) { create(:price_group, facility:) }
+
+        before do
+          account.price_group_members.create!(price_group: account_price_group)
+        end
+
+        it "uses account's assigned price groups instead of owner's price groups" do
+          expect(order_detail.price_groups).to include(account_price_group)
+          expect(order_detail.price_groups).not_to include(owner_price_group)
+          expect(order_detail.price_groups).not_to include(purchaser_price_group)
+        end
+
+        it "only includes the account's directly assigned price groups" do
+          expect(order_detail.price_groups).to eq([account_price_group])
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# Notes

When user_based_price_groups_exclude_purchaser FF is on and a payment source has a price group assigned, use that price group directly instead of comparing it with the owner's price groups.

[#NU-26 | Pricing flowing from payment source/payment source owner ](https://universe-of-universities.atlassian.net/browse/NU-26)

