### PR TITLE
[NU-26] Use correct account for the non-billable reservation spec

### DIFF
--- a/spec/services/auto_expire_reservation_spec.rb
+++ b/spec/services/auto_expire_reservation_spec.rb
@@ -59,6 +59,11 @@ RSpec.describe AutoExpireReservation, :time_travel do
                                                    product: instrument)
       end
 
+      before do
+        reservation.order.account = NonbillableAccount.singleton_instance
+        reservation.order.save!
+      end
+
       it "completes the reservation" do
         expect { action.perform }.to change { order_detail.reload.state }.from("new").to("complete")
       end


### PR DESCRIPTION
# Notes
* Use correct account for the non-billable reservation spec

[#NU-26](https://universe-of-universities.atlassian.net/browse/NU-26)

# Additional Context
When user goes through the reservation flow, they can only select the NonBillable account, so it makes sense to set it in the spec.
