### PR TITLE
[Fix] Failing specs due to user based price groups feature off

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -127,7 +127,7 @@ feature:
   daily_view: true
   split_accounts: true
   print_order_detail: false
-  user_based_price_groups: true
+  user_based_price_groups: false
   my_files: true
   # results file notifications requires that my_files be on as well
   results_file_notifications: true

--- a/spec/factories/nufs_accounts.rb
+++ b/spec/factories/nufs_accounts.rb
@@ -33,5 +33,11 @@ FactoryBot.define do
     after(:build) do |model|
       define_open_account "42345", model.account_number
     end
+
+    after(:create) do |account|
+      unless SettingsHelper.feature_on?(:user_based_price_groups)
+        AccountPriceGroupMember.create(account:, price_group: PriceGroup.base)
+      end
+    end
   end
 end

--- a/spec/system/admin/adding_to_a_cross_core_order_spec.rb
+++ b/spec/system/admin/adding_to_a_cross_core_order_spec.rb
@@ -11,11 +11,12 @@ RSpec.describe "Adding to an existing order for cross core", :js do
   let!(:facility2_credit_card_account) { create(:account, :with_account_owner, type: "CreditCardAccount", owner: order.user, description: "Credit Card Account", facility: facility2) }
   let!(:facility2_account) { create(:nufs_account, :with_account_owner, owner: order.user, description: "Internal Account", facility: facility2) }
   let(:price_group) { PriceGroup.base }
-  let!(:account_price_group_member) { create(:account_price_group_member, account: facility2_account, price_group:) }
   let(:external_price_group) { PriceGroup.external }
-  let!(:account_price_group_member) { create(:account_price_group_member, account: facility2_account, price_group: external_price_group) }
 
   before do
+    create(:account_price_group_member, account: facility2_account, price_group: external_price_group)
+    create(:account_price_group_member, account: facility2_account, price_group:)
+
     login_as user
   end
 
@@ -162,6 +163,7 @@ RSpec.describe "Adding to an existing order for cross core", :js do
             price_group:,
             start_date: 1.day.ago,
           )
+
           visit facility_order_path(facility, order)
           select_from_chosen facility2.name, from: "add_to_order_form[facility_id]"
           select_from_chosen product2.name, from: "add_to_order_form[product_id]", scroll_to: :center

--- a/spec/system/holiday_reservation_access_spec.rb
+++ b/spec/system/holiday_reservation_access_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe "Reserving an instrument on a holiday" do
   let!(:instrument) { create(:setup_instrument, restrict_holiday_access: true) }
   let(:facility) { instrument.facility }
   let!(:account) { create(:nufs_account, :with_account_owner, owner: user) }
+  let!(:account_price_group_member) do
+    create(:account_price_group_member, account:, price_group: PriceGroup.base)
+  end
   let!(:price_policy) { create(:instrument_price_policy, price_group: PriceGroup.base, product: instrument) }
   let!(:holiday) { Holiday.create(date: 2.days.from_now) }
 

--- a/spec/system/purchasing_a_reservation_spec.rb
+++ b/spec/system/purchasing_a_reservation_spec.rb
@@ -60,7 +60,13 @@ RSpec.describe "Purchasing a reservation" do
       end
     end
 
-    context "when feature flag is enabled", feature_setting: { user_based_price_groups_exclude_purchaser: true } do
+    context(
+      "when feature flag is enabled",
+      feature_setting: {
+        user_based_price_groups: true,
+        user_based_price_groups_exclude_purchaser: true,
+      }
+    ) do
       context "when account HAS price groups configured" do
         before do
           instrument.price_group_products.update_all(reservation_window: 7)

--- a/spec/system/quick_reservations_spec.rb
+++ b/spec/system/quick_reservations_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe "Reserving an instrument using quick reservations", feature_setti
   let!(:reservation) {}
 
   before do
+    if account.present?
+      create(:account_price_group_member, account:, price_group: price_policy.price_group)
+    end
+
     login_as user
     visit new_facility_instrument_quick_reservation_path(facility, instrument)
   end

--- a/spec/system/training_requests_spec.rb
+++ b/spec/system/training_requests_spec.rb
@@ -2,11 +2,11 @@ require "rails_helper"
 
 RSpec.describe "Training Requests", feature_setting: { training_requests: true, reload_routes: true } do
   let(:facility) { create(:setup_facility) }
-
   let(:user) { create(:user) }
   let!(:account) { FactoryBot.create(:nufs_account, :with_account_owner, owner: user) }
 
   before do
+    create(:account_price_group_member, account:, price_group: PriceGroup.base)
     login_as user
   end
 


### PR DESCRIPTION
# Notes

Test fail due mainly these two reasons when user based price groups are ignored:
- There's no price group matching for a purchase
- The price group used for a purchase yields a reservation window that is too short
