### PR TITLE
[NUOPEN-24] Improve billing transactions page load

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -111,7 +111,13 @@ class ApplicationController < ActionController::Base
   end
 
   def acting_user
-    @acting_user ||= User.find_by(id: session[:acting_user_id]) || session_user
+    @acting_user ||= fetch_acting_user || session_user
+  end
+
+  def fetch_acting_user
+    return if (acting_user_id = session[:acting_user_id]).blank?
+
+    User.find_by(id: acting_user_id)
   end
 
   def acting_as?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -113,7 +113,13 @@ class ApplicationController < ActionController::Base
   end
 
   def acting_user
-    @acting_user ||= User.find_by(id: session[:acting_user_id]) || session_user
+    @acting_user ||= fetch_acting_user || session_user
+  end
+
+  def fetch_acting_user
+    return if (acting_user_id = session[:acting_user_id]).blank?
+
+    User.find_by(id: acting_user_id)
   end
 
   def acting_as?

--- a/app/controllers/concerns/movable_transactions.rb
+++ b/app/controllers/concerns/movable_transactions.rb
@@ -38,7 +38,7 @@ module MovableTransactions
     @search_form = TransactionSearch::SearchForm.new(params[:search])
     @search =
       TransactionSearch::Searcher
-      .new(facilities: include_facilities?)
+      .new(current_facility, facilities: include_facilities?)
       .search(movable_transactions_order_details, @search_form)
 
     @date_range_field = @search_form.date_params[:field]

--- a/app/controllers/concerns/new_inprocess_controller.rb
+++ b/app/controllers/concerns/new_inprocess_controller.rb
@@ -16,7 +16,11 @@ module NewInprocessController
       TransactionSearch::CrossCoreSearcher,
     ]
 
-    @search = TransactionSearch::Searcher.new(*searchers).search(order_details, @search_form)
+    @search =
+      TransactionSearch::Searcher
+      .new(current_facility, *searchers)
+      .search(order_details, @search_form)
+
     @order_details = @search.order_details.includes(:order_status).joins_assigned_users.reorder(sort_clause)
     @date_range_field = @search_form.date_params[:field]
     @label_key_prefix = "estimated"

--- a/app/controllers/concerns/problem_order_details_controller.rb
+++ b/app/controllers/concerns/problem_order_details_controller.rb
@@ -56,7 +56,10 @@ module ProblemOrderDetailsController
       TransactionSearch::CrossCoreSearcher,
     ]
 
-    @search = TransactionSearch::Searcher.new(*searchers).search(order_details, @search_form)
+    @search =
+      TransactionSearch::Searcher
+      .new(current_facility, *searchers)
+      .search(order_details, @search_form)
     @order_details = @search.order_details.preload(:order_status, :assigned_user)
 
     respond_to do |format|

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -142,7 +142,7 @@ class FacilitiesController < ApplicationController
 
     @search =
       TransactionSearch::Searcher
-      .new(facilities: current_facility.cross_facility?)
+      .new(current_facility, facilities: current_facility.cross_facility?)
       .search(order_details, @search_form)
 
     @date_range_field = @search_form.date_params[:field]
@@ -169,7 +169,7 @@ class FacilitiesController < ApplicationController
     @search_form = TransactionSearch::SearchForm.new(params[:search])
     @search =
       TransactionSearch::Searcher
-      .new(facilities: current_facility.cross_facility?)
+      .new(current_facility, facilities: current_facility.cross_facility?)
       .search(order_details, @search_form)
 
     @date_range_field = @search_form.date_params[:field]

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -134,7 +134,7 @@ class FacilitiesController < ApplicationController
 
     @search =
       TransactionSearch::Searcher
-      .new(facilities: current_facility.cross_facility?)
+      .new(current_facility, facilities: current_facility.cross_facility?)
       .search(order_details, @search_form)
 
     @date_range_field = @search_form.date_params[:field]
@@ -161,7 +161,7 @@ class FacilitiesController < ApplicationController
     @search_form = TransactionSearch::SearchForm.new(params[:search])
     @search =
       TransactionSearch::Searcher
-      .new(facilities: current_facility.cross_facility?)
+      .new(current_facility, facilities: current_facility.cross_facility?)
       .search(order_details, @search_form)
 
     @date_range_field = @search_form.date_params[:field]

--- a/app/controllers/facility_accounts_reconciliation_controller.rb
+++ b/app/controllers/facility_accounts_reconciliation_controller.rb
@@ -22,6 +22,7 @@ class FacilityAccountsReconciliationController < ApplicationController
     @search_form = TransactionSearch::SearchForm.new(params[:search])
 
     @search = TransactionSearch::Searcher.new(
+      current_facility,
       TransactionSearch::AccountSearcher,
       TransactionSearch::AccountOwnerSearcher,
       TransactionSearch::StatementSearcher,

--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -39,7 +39,7 @@ class FacilityJournalsController < ApplicationController
     @search_form = TransactionSearch::SearchForm.new(params[:search])
     @search =
       TransactionSearch::Searcher
-      .new(facilities: current_facility.cross_facility?)
+      .new(current_facility, facilities: current_facility.cross_facility?)
       .search(order_details, @search_form)
 
     @date_range_field = @search_form.date_params[:field]

--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -38,7 +38,11 @@ class FacilityJournalsController < ApplicationController
     @search_form = TransactionSearch::SearchForm.new(params[:search])
     @search =
       TransactionSearch::Searcher
-      .new(facilities: current_facility.cross_facility?, suspended_accounts: true)
+      .new(
+        current_facility,
+        facilities: current_facility.cross_facility?,
+        suspended_accounts: true,
+      )
       .search(order_details, @search_form)
 
     @date_range_field = @search_form.date_params[:field]

--- a/app/controllers/facility_notifications_controller.rb
+++ b/app/controllers/facility_notifications_controller.rb
@@ -31,7 +31,7 @@ class FacilityNotificationsController < ApplicationController
     @search_form = TransactionSearch::SearchForm.new(params[:search])
     @search =
       TransactionSearch::Searcher
-      .new(facilities: current_facility.cross_facility?)
+      .new(current_facility, facilities: current_facility.cross_facility?)
       .search(order_details, @search_form)
 
     @date_range_field = @search_form.date_params[:field]
@@ -71,7 +71,7 @@ class FacilityNotificationsController < ApplicationController
     @search_form = TransactionSearch::SearchForm.new(params[:search])
     @search =
       TransactionSearch::Searcher
-      .new(facilities: current_facility.cross_facility?)
+      .new(current_facility, facilities: current_facility.cross_facility?)
       .search(order_details, @search_form)
 
     @date_range_field = @search_form.date_params[:field]

--- a/app/controllers/facility_statements_controller.rb
+++ b/app/controllers/facility_statements_controller.rb
@@ -56,7 +56,7 @@ class FacilityStatementsController < ApplicationController
     @search_form = TransactionSearch::SearchForm.new(params[:search], defaults:)
     @search =
       TransactionSearch::Searcher
-      .new(facilities: current_facility.cross_facility?)
+      .new(current_facility, facilities: current_facility.cross_facility?)
       .search(order_details, @search_form)
 
     @date_range_field = @search_form.date_params[:field]

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -53,7 +53,11 @@ class ProjectsController < ApplicationController
       ProjectsSearch::CrossCoreFacilitySearcher,
     ]
 
-    @search = TransactionSearch::Searcher.new(*searchers).search(order_details, @search_form)
+    @search =
+      TransactionSearch::Searcher
+      .new(current_facility, *searchers)
+      .search(order_details, @search_form)
+
     @order_details = @search.order_details.includes(:order_status).reorder(sort_clause)
 
     respond_to do |format|

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -52,7 +52,7 @@ class TransactionsController < ApplicationController
     @search_form = TransactionSearch::SearchForm.new(params[:search])
     @search =
       TransactionSearch::Searcher
-      .new(current_facility, facility: true)
+      .new(current_facility, facilities: true)
       .search(order_details, @search_form)
 
     @date_range_field = @search_form.date_params[:field]

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -31,7 +31,7 @@ class TransactionsController < ApplicationController
     account_ids = params.dig(:search, :accounts)
     @search =
       TransactionSearch::Searcher
-      .new(facilities: true, accounts: { account_ids: })
+      .new(current_facility, facilities: true, accounts: { account_ids: })
       .search(order_details, @search_form)
 
     @date_range_field = @search_form.date_params[:field]
@@ -52,7 +52,7 @@ class TransactionsController < ApplicationController
     @search_form = TransactionSearch::SearchForm.new(params[:search])
     @search =
       TransactionSearch::Searcher
-      .new(facility: true)
+      .new(current_facility, facility: true)
       .search(order_details, @search_form)
 
     @date_range_field = @search_form.date_params[:field]

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -8,7 +8,7 @@ class Order < ApplicationRecord
   belongs_to :account, optional: true
   belongs_to :facility, optional: true
   belongs_to :order_import, optional: true
-  belongs_to :cross_core_project, class_name: "Project", optional: true
+  belongs_to :cross_core_project, class_name: "Project", optional: true, counter_cache: true
   has_many   :order_details, inverse_of: :order, dependent: :destroy
   has_many :products, through: :order_details
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -43,7 +43,7 @@ class Project < ApplicationRecord
   end
 
   def cross_core?
-    orders.any?
+    orders_count > 0
   end
 
   def name

--- a/app/services/projects_search/cross_core_facility_searcher.rb
+++ b/app/services/projects_search/cross_core_facility_searcher.rb
@@ -19,9 +19,9 @@ module ProjectsSearch
       selected_value = params.first
 
       if selected_value == "other"
-        order_details.where.not(orders: { facility_id: @current_facility_id })
+        order_details.where.not(orders: { facility_id: current_facility.id })
       elsif selected_value == "current"
-        order_details.where(orders: { facility_id: @current_facility_id })
+        order_details.where(orders: { facility_id: current_facility.id })
       else
         order_details
       end

--- a/app/services/projects_search/cross_core_searcher.rb
+++ b/app/services/projects_search/cross_core_searcher.rb
@@ -30,11 +30,11 @@ module ProjectsSearch
     private
 
     def cross_core_projects
-      Project.cross_core.for_facility(@current_facility_id).distinct
+      Project.cross_core.for_facility(current_facility.id).distinct
     end
 
     def single_facility_projects
-      Project.for_single_facility(@current_facility_id)
+      Project.for_single_facility(current_facility.id)
     end
 
   end

--- a/app/services/projects_search/cross_core_searcher.rb
+++ b/app/services/projects_search/cross_core_searcher.rb
@@ -30,11 +30,11 @@ module ProjectsSearch
     private
 
     def cross_core_projects
-      Project.cross_core.for_facility(current_facility.id).distinct
+      Project.cross_core.for_facility(@current_facility_id).distinct
     end
 
     def single_facility_projects
-      Project.for_single_facility(current_facility.id)
+      Project.for_single_facility(@current_facility_id)
     end
 
   end

--- a/app/services/projects_search/project_searcher.rb
+++ b/app/services/projects_search/project_searcher.rb
@@ -5,11 +5,24 @@ module ProjectsSearch
   class ProjectSearcher < TransactionSearch::BaseSearcher
 
     def self.key
-      :projects
+      "projects"
     end
 
     def options
-      Project.where(id: order_details.select("distinct project_id")).order(:name)
+      projects =
+        if current_facility.cross_facility?
+          Project.all
+        else
+          project_ids =
+            current_facility
+            .order_details
+            .where.not(project_id: nil)
+            .select(:project_id)
+
+          Project.where(id: project_ids)
+        end
+
+      projects.order(:name)
     end
 
     def search(params)

--- a/app/services/projects_search/project_searcher.rb
+++ b/app/services/projects_search/project_searcher.rb
@@ -5,7 +5,7 @@ module ProjectsSearch
   class ProjectSearcher < TransactionSearch::BaseSearcher
 
     def self.key
-      "projects"
+      :projects
     end
 
     def options

--- a/app/services/projects_search/project_searcher.rb
+++ b/app/services/projects_search/project_searcher.rb
@@ -22,7 +22,7 @@ module ProjectsSearch
           Project.where(id: project_ids)
         end
 
-      projects.order(:name)
+      projects.includes(:facility).order(:name)
     end
 
     def search(params)

--- a/app/services/projects_search/project_searcher.rb
+++ b/app/services/projects_search/project_searcher.rb
@@ -11,7 +11,7 @@ module ProjectsSearch
     def options
       projects =
         if current_facility.cross_facility?
-          Project.all
+          Project.where(id: order_details.select("distinct project_id")).order(:name)
         else
           project_ids =
             current_facility

--- a/app/services/transaction_search/base_searcher.rb
+++ b/app/services/transaction_search/base_searcher.rb
@@ -4,15 +4,15 @@ module TransactionSearch
 
   class BaseSearcher
 
-    attr_reader :order_details, :config
+    attr_reader :order_details, :current_facility, :config
 
     def self.key
       to_s.sub(/\ATransactionSearch::/, "").sub(/Searcher\z/, "").pluralize.underscore
     end
 
-    def initialize(order_details, current_facility_id = nil, **config)
+    def initialize(order_details, **config)
       @order_details = order_details
-      @current_facility_id = current_facility_id
+      @current_facility = config[:current_facility] || Facility.cross_facility
       @config = config
     end
 

--- a/app/services/transaction_search/searcher.rb
+++ b/app/services/transaction_search/searcher.rb
@@ -46,9 +46,10 @@ module TransactionSearch
     end
 
     # Expects an array of `TransactionSearch::BaseSearcher`s
-    def initialize(*searchers, **kwargs)
+    def initialize(facility, *searchers, **kwargs)
       searchers_config = default_config.merge(kwargs)
 
+      @facility = facility
       @searchers_config = searchers_config
       @searchers =
         searchers.presence ||
@@ -61,17 +62,22 @@ module TransactionSearch
       order_details = add_global_optimizations(order_details)
 
       @searchers.reduce(Results.new(order_details)) do |results, searcher_class|
-        searcher_config = searcher_config(searcher_class.key.to_sym)
+        searcher_config =
+          searcher_config(searcher_class.key.to_sym)
+          .merge(current_facility: @facility)
+
         searcher = searcher_class.new(
           results.order_details,
-          params[:current_facility_id],
           **searcher_config,
         )
         search_params = params[searcher_class.key.to_sym]
         search_params = Array(search_params).reject(&:blank?) unless searcher.multipart?
 
         # Options should not be restricted, they should search over the full order details
-        option_searcher = searcher_class.new(order_details, **searcher_config)
+        option_searcher = searcher_class.new(
+          order_details,
+          **searcher_config,
+        )
 
         Results.new(
           searcher.search(search_params),
@@ -116,7 +122,7 @@ module TransactionSearch
       def to_options_by_searcher
         @to_h ||= options.to_h do |searcher|
           [searcher.key, searcher.options]
-        end
+        end.with_indifferent_access
       end
 
     end

--- a/app/services/transaction_search/searcher.rb
+++ b/app/services/transaction_search/searcher.rb
@@ -42,11 +42,6 @@ module TransactionSearch
       }
     end
 
-    # Shorthand method if you only want the default searchers
-    def self.search(order_details, params)
-      new.search(order_details, params)
-    end
-
     # Expects an array of `TransactionSearch::BaseSearcher`s
     def initialize(facility, *searchers, **kwargs)
       searchers_config = default_config.merge(kwargs)

--- a/app/services/transaction_search/searcher.rb
+++ b/app/services/transaction_search/searcher.rb
@@ -48,9 +48,10 @@ module TransactionSearch
     end
 
     # Expects an array of `TransactionSearch::BaseSearcher`s
-    def initialize(*searchers, **kwargs)
+    def initialize(facility, *searchers, **kwargs)
       searchers_config = default_config.merge(kwargs)
 
+      @facility = facility
       @searchers_config = searchers_config
       @searchers =
         searchers.presence ||
@@ -63,17 +64,22 @@ module TransactionSearch
       order_details = add_global_optimizations(order_details)
 
       @searchers.reduce(Results.new(order_details)) do |results, searcher_class|
-        searcher_config = searcher_config(searcher_class.key.to_sym)
+        searcher_config =
+          searcher_config(searcher_class.key.to_sym)
+          .merge(current_facility: @facility)
+
         searcher = searcher_class.new(
           results.order_details,
-          params[:current_facility_id],
           **searcher_config,
         )
         search_params = params[searcher_class.key.to_sym]
         search_params = Array(search_params).reject(&:blank?) unless searcher.multipart?
 
         # Options should not be restricted, they should search over the full order details
-        option_searcher = searcher_class.new(order_details, **searcher_config)
+        option_searcher = searcher_class.new(
+          order_details,
+          **searcher_config,
+        )
 
         Results.new(
           searcher.search(search_params),
@@ -118,7 +124,7 @@ module TransactionSearch
       def to_options_by_searcher
         @to_h ||= options.to_h do |searcher|
           [searcher.key, searcher.options]
-        end
+        end.with_indifferent_access
       end
 
     end

--- a/db/migrate/20260819140538_add_orders_count_to_projects.rb
+++ b/db/migrate/20260819140538_add_orders_count_to_projects.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrdersCountToProjects < ActiveRecord::Migration[8.0]
+  def change
+    add_column :projects, :orders_count, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_14_194847) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_19_140538) do
   create_table "account_facility_joins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "facility_id", null: false
     t.integer "account_id", null: false
@@ -794,6 +794,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_14_194847) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "active", default: true, null: false
+    t.integer "orders_count", default: 0, null: false
     t.index ["facility_id", "name"], name: "index_projects_on_facility_id_and_name", unique: true
     t.index ["facility_id"], name: "index_projects_on_facility_id"
   end

--- a/spec/services/transaction_search/searcher_spec.rb
+++ b/spec/services/transaction_search/searcher_spec.rb
@@ -5,10 +5,11 @@ require "rails_helper"
 RSpec.describe TransactionSearch::Searcher, type: :service do
   describe "a basic searcher" do
     let(:item) { create(:setup_item) }
+    let(:facility) { item.facility }
     let(:order) { create(:purchased_order, product: item) }
     let(:order_detail) { order.order_details.first }
     let(:account) { order.account }
-    let(:searcher) { described_class.new(*searchers) }
+    let(:searcher) { described_class.new(facility, *searchers) }
     let(:searchers) do
       [
         TransactionSearch::AccountSearcher,
@@ -107,10 +108,12 @@ RSpec.describe TransactionSearch::Searcher, type: :service do
   end
 
   describe "can toggle default searchers by key" do
+    let(:facility) { create(:facility) }
+
     it "can disable some searcher" do
       searcher_key = described_class.default_searchers.sample.key
 
-      searcher = described_class.new(searcher_key.to_sym => false)
+      searcher = described_class.new(facility, searcher_key.to_sym => false)
 
       expect(searcher.instance_eval { @searchers.map(&:key) }).not_to(
         include(searcher_key)
@@ -118,7 +121,7 @@ RSpec.describe TransactionSearch::Searcher, type: :service do
     end
 
     it "can enable facilities searcher" do
-      searcher = described_class.new(facilities: true)
+      searcher = described_class.new(facility, facilities: true)
 
       expect(searcher.instance_eval { @searchers.map(&:key) }).to(
         include("facilities")
@@ -126,7 +129,7 @@ RSpec.describe TransactionSearch::Searcher, type: :service do
     end
 
     it "disables facility searcher by default" do
-      searcher = described_class.new
+      searcher = described_class.new(facility)
 
       expect(searcher.instance_eval { @searchers.map(&:key) }).not_to(
         include("facilities")

--- a/spec/services/transaction_search/suspended_account_searcher_spec.rb
+++ b/spec/services/transaction_search/suspended_account_searcher_spec.rb
@@ -3,7 +3,6 @@
 require "rails_helper"
 
 RSpec.describe TransactionSearch::Searcher, :use_test_account do
-
   describe "suspended accounts filter" do
     let(:facility) { create(:setup_facility) }
     let(:user) { create(:user) }
@@ -19,7 +18,7 @@ RSpec.describe TransactionSearch::Searcher, :use_test_account do
       )
     end
     let(:searcher) do
-      described_class.new(suspended_accounts: true)
+      described_class.new(facility, suspended_accounts: true)
     end
     let(:searched_order_details) do
       searcher.search(

--- a/vendor/engines/secure_rooms/app/controllers/secure_rooms/facility_occupancies_controller.rb
+++ b/vendor/engines/secure_rooms/app/controllers/secure_rooms/facility_occupancies_controller.rb
@@ -26,7 +26,11 @@ module SecureRooms
       order_details = new_or_in_process_orders.joins(:order)
 
       @search_form = TransactionSearch::SearchForm.new(params[:search], defaults: { date_range_field: "ordered_at" })
-      @search = TransactionSearch::Searcher.new(TransactionSearch::ProductSearcher).search(order_details, @search_form)
+      @search =
+        TransactionSearch::Searcher
+        .new(current_facility, TransactionSearch::ProductSearcher)
+        .search(order_details, @search_form)
+
       @order_details = @search.order_details.includes(:order_status).joins_assigned_users.reorder(sort_clause)
 
       respond_to do |format|


### PR DESCRIPTION
# Notes

- General improvement: don't try to find acting user by nil id
- Transactions Project filter options: the query can take a large amount of time even though there are a handful of Projects. Simplify query to use projects from all facility orders instead of the filtered subset of orders. When the facility is cross facility then use the existing logic
- Add `orders_count` counter cache on Projects

Part of [NUOPEN-24 - Transactions page load times](https://universe-of-universities.atlassian.net/browse/NUOPEN-24)

## Project counter cache backfill

```ruby
Project.all.pluck(:id).each do |proj_id| Project.reset_counters(proj_id, :orders_count) end
```
