### PR TITLE
[NU-488] Add account owner search `before_form` view hook

### DIFF
--- a/app/views/facility_accounts/new_account_user_search.html.haml
+++ b/app/views/facility_accounts/new_account_user_search.html.haml
@@ -6,6 +6,9 @@
 -# TODO: The following is very similar to app/views/users/_search_form.html.haml
 %h2= t(".head")
 %p= t(".instruct")
+
+= render_view_hook("before_form")
+
 = form_tag user_search_results_path, id: "ajax_form", method: :get do
   = label_tag :search_term, text("facility_accounts.new_account_user_search.label.search_term")
   %br


### PR DESCRIPTION
# Notes

Add view hook to support account owner search page extension.
