### PR TITLE
[Chore] Active storage direct upload require authentication

### DIFF
--- a/app/controllers/concerns/requires_authentication.rb
+++ b/app/controllers/concerns/requires_authentication.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module RequiresAuthentication
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authenticate_user!
+  end
+end

--- a/config/initializers/active_storage_controllers.rb
+++ b/config/initializers/active_storage_controllers.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.config.after_initialize do
+  ActiveStorage::DirectUploadsController.include RequiresAuthentication
+end

--- a/spec/requests/active_storage/direct_uploads_spec.rb
+++ b/spec/requests/active_storage/direct_uploads_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "direct uploads" do
+  let(:action) { -> { post rails_direct_uploads_path } }
+
+  it "requires login" do
+    action.call
+
+    expect(response).to have_http_status(:found)
+    expect(response.location).to eq(new_user_session_url)
+  end
+
+  context "with logged in user" do
+    before { login_as create(:user) }
+
+    it "does not return unauthorized" do
+      action.call
+
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+end

--- a/spec/requests/active_storage/direct_uploads_spec.rb
+++ b/spec/requests/active_storage/direct_uploads_spec.rb
@@ -3,13 +3,12 @@
 require "rails_helper"
 
 RSpec.describe "direct uploads" do
-  let(:action) { -> { post rails_direct_uploads_path } }
+  let(:action) { -> { post rails_direct_uploads_path, xhr: true } }
 
-  it "requires login" do
+  it "returns unauthorized" do
     action.call
 
-    expect(response).to have_http_status(:found)
-    expect(response.location).to eq(new_user_session_url)
+    expect(response).to have_http_status(:unauthorized)
   end
 
   context "with logged in user" do


### PR DESCRIPTION
# Notes

Require authentication for the direct uploads endpoint.

Given the recent active storage vulnerability https://github.com/rails/rails/security/advisories/GHSA-xr9x-r78c-5hrm, restrict direct uploads endpoint to reduce the vips errors flooding.
