### PR TITLE
[NU-491] Fix account listing filters

### DIFF
--- a/app/assets/javascripts/user_accounts.js.erb
+++ b/app/assets/javascripts/user_accounts.js.erb
@@ -3,6 +3,11 @@
  */
 window.addEventListener("DOMContentLoaded", () => {
   const toggleExpiredAcctsBtn = document.querySelector(".toggle_expired_accts_btn--js");
+
+  if (!toggleExpiredAcctsBtn) {
+    return;
+  }
+
   const expiredAccts = document.querySelectorAll("tr.expired--js");
   let hideAccounts = true;
 

--- a/app/assets/javascripts/user_accounts.js.erb
+++ b/app/assets/javascripts/user_accounts.js.erb
@@ -11,7 +11,7 @@ window.addEventListener("DOMContentLoaded", () => {
   const expiredAccts = document.querySelectorAll("tr.expired--js");
   let hideAccounts = true;
 
-  if (toggleExpiredAcctsBtn) { toggleExpiredAcctsBtn.addEventListener("click", toggleExpiredAccounts); }
+  toggleExpiredAcctsBtn.addEventListener("click", toggleExpiredAccounts);
 
   toggleRowVisibility();
 
@@ -36,9 +36,7 @@ window.addEventListener("DOMContentLoaded", () => {
       acctEle.style.display = displayStyle;
     });
 
-    if (toggleExpiredAcctsBtn) {
-      toggleExpiredAcctsBtn.textContent = buttonText;
-    }
+    toggleExpiredAcctsBtn.textContent = buttonText;
   }
 
 });

--- a/app/assets/stylesheets/app/facility_accounts.scss
+++ b/app/assets/stylesheets/app/facility_accounts.scss
@@ -24,8 +24,6 @@
   }
 }
 
-.js--searchForm {
-  .row {
-    margin-bottom: 10px;
-  }
+.account-search-form {
+  .row { margin-bottom: 10px; }
 }

--- a/app/controllers/facility_accounts_controller.rb
+++ b/app/controllers/facility_accounts_controller.rb
@@ -197,10 +197,13 @@ class FacilityAccountsController < ApplicationController
   end
 
   def filter_params
-    params
+    @filter_params ||=
+      params
       .permit(:search_term, :account_type, :suspended, :account_status)
       .to_h
       .symbolize_keys
+      .compact_blank
+      .reverse_merge(default_filters)
   end
 
   # Filter active if it's a form submission
@@ -209,5 +212,13 @@ class FacilityAccountsController < ApplicationController
   end
 
   helper_method :filters_active?
+
+  def default_filters
+    if SettingsHelper.feature_on?("accounts.account_tabs")
+      { suspended: "false" }
+    else
+      { account_status: "active" }
+    end
+  end
 
 end

--- a/app/controllers/facility_accounts_controller.rb
+++ b/app/controllers/facility_accounts_controller.rb
@@ -9,31 +9,35 @@ class FacilityAccountsController < ApplicationController
   admin_tab     :all
   before_action :check_acting_as
   before_action :init_current_facility
-  before_action :init_account, except: :search_results
+  before_action :init_account, except: :index
   before_action :build_account, only: [:new, :create]
   before_action :set_facility_accounts_for_user, only: [:accounts_available_for_order]
-  before_action :set_account_types, only: [:index, :search_results]
+  before_action :set_account_types, only: :index
 
   authorize_resource :account, except: [:accounts_available_for_order]
 
-  layout "two_column"
   before_action { @active_tab = "admin_users" }
+  layout "two_column"
 
   # GET /facilties/:facility_id/accounts
   def index
-    accounts = Account.with_orders_for_facility(current_facility)
+    searcher = AccountSearcher.new(
+      filter_params[:search_term],
+      scope: account_scope,
+      filter_params:,
+    )
 
-    if SettingsHelper.feature_on?("accounts.account_tabs")
-      accounts = if params[:suspended] == "true"
-                   accounts.suspended
-                 else
-                   accounts.not_suspended
-                 end
+    if searcher.valid?
+      respond_to do |format|
+        format.html do
+          @accounts = searcher.results.includes(:owner_user)
+          @accounts = @accounts.paginate(page: params[:page])
+        end
+        format.csv { export_accounts_csv }
+      end
+    else
+      flash.now[:error] = "Search terms must be 3 or more characters."
     end
-
-    @accounts = accounts.includes(:owner, :owner_user).paginate(page: params[:page])
-
-    render("search_results", layout: false) if request.xhr?
   end
 
   # GET /facilties/:facility_id/accounts/:id
@@ -80,46 +84,6 @@ class FacilityAccountsController < ApplicationController
   end
 
   def new_account_user_search
-  end
-
-  # GET/POST /facilities/:facility_id/accounts/search_results
-  def search_results
-    account_scope = Account.for_facility(current_facility)
-    filter_params = {
-      account_type: params[:account_type],
-      suspended: params[:suspended],
-      account_status: params[:account_status],
-    }
-
-    if SettingsHelper.feature_on?("accounts.account_tabs") && params[:search_term].blank?
-      account_scope = AccountSearcher.new("", scope: account_scope, filter_params:).filtered_scope
-      respond_to do |format|
-        format.html do
-          @accounts = account_scope.paginate(page: params[:page])
-          render layout: false
-        end
-        format.csv { export_accounts_csv("") }
-      end
-
-      return
-    end
-
-    searcher = AccountSearcher.new(params[:search_term], scope: account_scope, filter_params:)
-
-    if searcher.valid?
-      @accounts = searcher.results
-
-      respond_to do |format|
-        format.html do
-          @accounts = @accounts.paginate(page: params[:page])
-          render layout: false
-        end
-        format.csv { export_accounts_csv(params[:search_term]) }
-      end
-    else
-      flash.now[:errors] = "Search terms must be 3 or more characters."
-      render layout: false
-    end
   end
 
   # GET /facilities/:facility_id/accounts/:account_id/members
@@ -212,22 +176,38 @@ class FacilityAccountsController < ApplicationController
     end
   end
 
-  def export_accounts_csv(search_term)
-    filter_params = if SettingsHelper.feature_on?("accounts.account_tabs")
-                      {
-                        account_type: params[:account_type],
-                        suspended: params[:suspended],
-                        account_status: params[:account_status],
-                      }
-                    else
-                      {}
-                    end
+  def export_accounts_csv
     queue_csv_report_email(
       Reports::AccountSearchReport,
-      search_term:,
+      search_term: filter_params[:search_term],
       facility: SerializableFacility.new(current_facility),
       filter_params:,
     )
   end
+
+  # Default scope is to show latest accounts used.
+  #
+  # If we are filtering then return all accounts for facility.
+  def account_scope
+    if filters_active?
+      Account.for_facility(current_facility)
+    else
+      Account.with_orders_for_facility(current_facility)
+    end
+  end
+
+  def filter_params
+    params
+      .permit(:search_term, :account_type, :suspended, :account_status)
+      .to_h
+      .symbolize_keys
+  end
+
+  # Filter active if it's a form submission
+  def filters_active?
+    params[:commit].present?
+  end
+
+  helper_method :filters_active?
 
 end

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -3,13 +3,13 @@
 module AccountsHelper
 
   def toggle_expired_account_btn
-    toggle_params = request.query_parameters.dup
+    toggle_params = request.query_parameters.dup.except(:page)
 
-    if params[:account_status] == "active"
-      toggle_params.delete :account_status
+    if params[:account_status].blank?
+      toggle_params[:account_status] = "all"
       label = t("views.facility_accounts.account_table.show_text")
     else
-      toggle_params[:account_status] = "active"
+      toggle_params.delete :account_status
       label = t("views.facility_accounts.account_table.hide_text")
     end
 

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -6,6 +6,8 @@ module AccountsHelper
     toggle_params = request.query_parameters.dup.except(:page)
 
     if params[:account_status].blank?
+      # `all` is only used to override the default account_status filter.
+      # It does not really filter anything
       toggle_params[:account_status] = "all"
       label = t("views.facility_accounts.account_table.show_text")
     else

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -2,6 +2,24 @@
 
 module AccountsHelper
 
+  def toggle_expired_account_btn
+    toggle_params = request.query_parameters.dup
+
+    if params[:account_status] == "active"
+      toggle_params.delete :account_status
+      label = t("views.facility_accounts.account_table.show_text")
+    else
+      toggle_params[:account_status] = "active"
+      label = t("views.facility_accounts.account_table.hide_text")
+    end
+
+    link_to(
+      label,
+      facility_accounts_path(current_facility, toggle_params),
+      class: "btn btn-primary",
+    )
+  end
+
   def account_input(form, disabled: false)
     form.input :account_id,
       as: :select,

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -54,8 +54,8 @@ class Account < ApplicationRecord
   scope :active_at, ->(time) { where("expires_at >= ?", time&.beginning_of_day).where(suspended_at: nil) }
   scope :suspended, -> { where.not(suspended_at: nil) }
   scope :not_suspended, -> { where(suspended_at: nil) }
-  scope :expired, -> { where("expires_at < ?", Time.current.beginning_of_day) }
-  scope :not_expired, -> { where("expires_at > ?", Time.current.beginning_of_day) }
+  scope :expired, -> { where(expires_at: ...Time.current.beginning_of_day) }
+  scope :not_expired, -> { where(expires_at: Time.current.beginning_of_day..) }
 
   scope :administered_by, lambda { |user|
     for_user(user).where("account_users.user_role" => AccountUser.admin_user_roles)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -50,11 +50,12 @@ class Account < ApplicationRecord
   accepts_nested_attributes_for :account_users
   has_many :log_events, as: :loggable
 
-  scope :active, -> { where("expires_at > ?", Time.current.beginning_of_day).where(suspended_at: nil) }
+  scope :active, -> { not_expired.not_suspended }
   scope :active_at, ->(time) { where("expires_at >= ?", time&.beginning_of_day).where(suspended_at: nil) }
   scope :suspended, -> { where.not(suspended_at: nil) }
   scope :not_suspended, -> { where(suspended_at: nil) }
   scope :expired, -> { where("expires_at < ?", Time.current.beginning_of_day) }
+  scope :not_expired, -> { where("expires_at > ?", Time.current.beginning_of_day) }
 
   scope :administered_by, lambda { |user|
     for_user(user).where("account_users.user_role" => AccountUser.admin_user_roles)

--- a/app/services/account_searcher.rb
+++ b/app/services/account_searcher.rb
@@ -23,10 +23,6 @@ class AccountSearcher
     scope.or(matches_field(:account_number, :description, :ar_number))
   end
 
-  def filtered_scope
-    @scope
-  end
-
   def apply_account_filters(scope, filter_params)
     if filter_params[:account_type].present?
       scope = scope.where(type: filter_params[:account_type])
@@ -35,7 +31,7 @@ class AccountSearcher
     scope =
       if filter_params[:suspended] == "true"
         scope.suspended
-      elsif filter_params[:suspended] == "false" || SettingsHelper.feature_on?("accounts.account_tabs")
+      elsif filter_params[:suspended] == "false"
         scope.not_suspended
       else
         scope

--- a/app/services/account_searcher.rb
+++ b/app/services/account_searcher.rb
@@ -12,7 +12,7 @@ class AccountSearcher
   end
 
   def valid?
-    @query.to_s.length >= MINIMUM_SEARCH_LENGTH
+    @query.blank? || @query.to_s.length >= MINIMUM_SEARCH_LENGTH
   end
 
   def results
@@ -28,20 +28,25 @@ class AccountSearcher
   end
 
   def apply_account_filters(scope, filter_params)
-    return scope if SettingsHelper.feature_off?("accounts.account_tabs")
-
     if filter_params[:account_type].present?
       scope = scope.where(type: filter_params[:account_type])
     end
 
-    if filter_params[:suspended] == "true"
-      scope.suspended
-    elsif filter_params[:account_status] == "active"
-      scope.active
+    scope =
+      if filter_params[:suspended] == "true"
+        scope.suspended
+      elsif filter_params[:suspended] == "false" || SettingsHelper.feature_on?("accounts.account_tabs")
+        scope.not_suspended
+      else
+        scope
+      end
+
+    if filter_params[:account_status] == "active"
+      scope.not_expired
     elsif filter_params[:account_status] == "expired"
-      scope.expired.not_suspended
+      scope.expired
     else
-      scope.not_suspended
+      scope
     end
   end
 

--- a/app/views/facility_accounts/_account_table.html.haml
+++ b/app/views/facility_accounts/_account_table.html.haml
@@ -22,16 +22,6 @@
           - if current_facility.cross_facility?
             %td= account.per_facility? ? account.facilities.alphabetized.join(", ") : html("all", inline: true)
 
-  - pagination_params = {}
-  - if params[:search_term].present?
-    - pagination_params = { search_term: params[:search_term] }
-  - elsif SettingsHelper.feature_on?("accounts.account_tabs")
-    - filter_params = params.slice(:account_type, :suspended, :account_status).compact_blank
-    - pagination_params = filter_params if filter_params.present?
-
-  - if pagination_params.present?
-    = will_paginate(@accounts, class: "ajax_links", params: pagination_params)
-  - else
-    = will_paginate(@accounts)
+  = will_paginate(@accounts)
 
   %p.footnote= text("facility_accounts.account_table.foot")

--- a/app/views/facility_accounts/_account_table.html.haml
+++ b/app/views/facility_accounts/_account_table.html.haml
@@ -13,7 +13,7 @@
           %th= Facility.model_name.human
     %tbody
       - @accounts.each do |account|
-        %tr{ class: account.expired? ? "expired--js" : "" }
+        %tr
           %td= payment_source_link_or_text(account)
           %td= account.type_string
           %td= account.owner_user.full_name if account.owner_user

--- a/app/views/facility_accounts/index.html.haml
+++ b/app/views/facility_accounts/index.html.haml
@@ -41,10 +41,10 @@
 %ul.list-inline
   - if SettingsHelper.feature_on?("accounts.edit_accounts") && current_ability.can?(:create, Account)
     %li= link_to t(".add_account"), new_account_user_search_facility_accounts_path, class: "btn-add"
-  - if @accounts.present? && SettingsHelper.feature_off?("accounts.account_tabs")
+  - if SettingsHelper.feature_off?("accounts.account_tabs")
     %li.pull-right= toggle_expired_account_btn
 
-= turbo_frame_tag("account-search-result") do
+%div
   - if filters_active? && @accounts.present?
     = link_to text("reports.export_as_csv"), url_for(format: :csv), class: "js--exportSearchResults pull-right", data: { form: ".account-search-form" }
 

--- a/app/views/facility_accounts/index.html.haml
+++ b/app/views/facility_accounts/index.html.haml
@@ -8,16 +8,17 @@
 - if SettingsHelper.feature_on?("accounts.account_tabs")
   = render "shared/accounts_tab_nav"
 
-= form_tag search_results_facility_accounts_path, id: "ajax_form", method: :get, class: "js--searchForm" do
+= form_tag facility_accounts_path, method: :get, class: "account-search-form" do
   = label_tag :search_term, text("facility_accounts.index.label.search_term")
   = hidden_field_tag :email, current_user.email, disabled: true
   = hidden_field_tag :format, params[:format], disabled: true
+  = hidden_field_tag :account_status, params[:account_status]
   - if SettingsHelper.feature_on?("accounts.account_tabs")
     = hidden_field_tag :suspended, params[:suspended]
-  %br
+
   .row
-    .col-md-4
-      = text_field_tag :search_term, nil, size: 30, class: "form-control"
+    .col-md-12
+      = text_field_tag :search_term, nil, size: 30, class: "form-control", value: params[:search_term]
 
   - if SettingsHelper.feature_on?("accounts.account_tabs")
     .row
@@ -32,16 +33,19 @@
           = select_tag :account_status,
           options_for_select([[I18n.t("account.statuses.active"), "active"], [I18n.t("account.statuses.expired"), "expired"]], params[:account_status]),
           { class: "form-control mb-2", include_blank: "" }
-  .row
-    .col-md-2
-      = submit_tag t(".search"), class: "btn btn-default", data: { test_id: "account_search_button" }
+  %div
+    = submit_tag t(".search"), class: "btn btn-default", data: { disable_with: t("shared.loading") }
 
 %hr
 
 %ul.list-inline
   - if SettingsHelper.feature_on?("accounts.edit_accounts") && current_ability.can?(:create, Account)
     %li= link_to t(".add_account"), new_account_user_search_facility_accounts_path, class: "btn-add"
-  - if !@accounts.blank? && SettingsHelper.feature_off?("accounts.account_tabs")
-    %li.toggle_expired_accts_btn--js.toggle_expired_btn.btn.btn-primary= t("views.facility_accounts.account_table.hide_text")
-#result
+  - if @accounts.present? && SettingsHelper.feature_off?("accounts.account_tabs")
+    %li.pull-right= toggle_expired_account_btn
+
+= turbo_frame_tag("account-search-result") do
+  - if filters_active? && @accounts.present?
+    = link_to text("reports.export_as_csv"), url_for(format: :csv), class: "js--exportSearchResults pull-right", data: { form: ".account-search-form" }
+
   = render "account_table"

--- a/app/views/facility_accounts/index.html.haml
+++ b/app/views/facility_accounts/index.html.haml
@@ -12,6 +12,7 @@
   = label_tag :search_term, text("facility_accounts.index.label.search_term")
   = hidden_field_tag :email, current_user.email, disabled: true
   = hidden_field_tag :format, params[:format], disabled: true
+  = hidden_field_tag :account_status, params[:account_status]
   - if SettingsHelper.feature_on?("accounts.account_tabs")
     = hidden_field_tag :suspended, params[:suspended]
 

--- a/app/views/facility_accounts/index.html.haml
+++ b/app/views/facility_accounts/index.html.haml
@@ -12,7 +12,6 @@
   = label_tag :search_term, text("facility_accounts.index.label.search_term")
   = hidden_field_tag :email, current_user.email, disabled: true
   = hidden_field_tag :format, params[:format], disabled: true
-  = hidden_field_tag :account_status, params[:account_status]
   - if SettingsHelper.feature_on?("accounts.account_tabs")
     = hidden_field_tag :suspended, params[:suspended]
 

--- a/app/views/facility_accounts/search_results.html.haml
+++ b/app/views/facility_accounts/search_results.html.haml
@@ -1,7 +1,0 @@
-- if flash[:errors]
-  %p.alert.alert-danger= flash[:errors]
-
-- else
-  .pull-right
-    = link_to text("reports.export_as_csv"), url_for(format: :csv), class: "js--exportSearchResults pull-right", data: { form: ".js--searchForm" }
-  = render "account_table"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,6 +141,7 @@ en:
     remove: Remove
     save: Save
     search: Search
+    loading: Please wait...
     view: View
     filter: Filter
     select_all: Select All

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -293,8 +293,6 @@ Rails.application.routes.draw do
     end
 
     resources :accounts, controller: "facility_accounts", only: [:index, :show] do
-      get "search_results", via: [:post], on: :collection
-
       if SettingsHelper.feature_on?("accounts.suspend_accounts")
         get "suspend",   to: "facility_accounts#suspend",   as: "suspend"
         get "unsuspend", to: "facility_accounts#unsuspend", as: "unsuspend"

--- a/spec/controllers/facility_accounts_controller_spec.rb
+++ b/spec/controllers/facility_accounts_controller_spec.rb
@@ -40,6 +40,34 @@ RSpec.describe FacilityAccountsController, feature_setting: { "accounts.edit_acc
       expect(assigns(:accounts).first).to eq(@account)
       is_expected.to render_template("index")
     end
+
+    describe "default filters" do
+      before { sign_in create(:user, :administrator) }
+
+      context "when account_tab is off", feature_setting: { "accounts.account_tabs" => false } do
+        it "list active accounts" do
+          expect(AccountSearcher).to receive(:new).with(
+            nil,
+            scope: anything,
+            filter_params: { account_status: "active" }
+          ).and_call_original
+
+          do_request
+        end
+      end
+
+      context "when account_tab is on", feature_setting: { "accounts.account_tabs" => true } do
+        it "list non suspended accounts" do
+          expect(AccountSearcher).to receive(:new).with(
+            nil,
+            scope: anything,
+            filter_params: { suspended: "false" }
+          ).and_call_original
+
+          do_request
+        end
+      end
+    end
   end
 
   context "show" do

--- a/spec/controllers/facility_accounts_controller_spec.rb
+++ b/spec/controllers/facility_accounts_controller_spec.rb
@@ -193,15 +193,15 @@ RSpec.describe FacilityAccountsController, feature_setting: { "accounts.edit_acc
     end
   end
 
-  context "search_results" do
+  context "index search" do
     it "requires login" do
-      get :search_results, params: { facility_id: facility.url_name }
+      get :index, params: { facility_id: facility.url_name }
       expect(response).to redirect_to(new_user_session_path)
     end
 
     it "denies senior staff" do
       sign_in create(:user, :senior_staff, facility: facility)
-      expect { get :search_results, params: { facility_id: facility.url_name } }.to raise_error(CanCan::AccessDenied)
+      expect { get :index, params: { facility_id: facility.url_name } }.to raise_error(CanCan::AccessDenied)
     end
 
     describe "as the director" do
@@ -213,41 +213,41 @@ RSpec.describe FacilityAccountsController, feature_setting: { "accounts.edit_acc
       end
 
       it "finds an account by a partial account number" do
-        get :search_results, params: { facility_id: facility.url_name, search_term: account.account_number.first(3) }
+        get :index, params: { facility_id: facility.url_name, search_term: account.account_number.first(3) }
         expect(assigns(:accounts)).to include(account)
       end
 
       it "finds the account by the owner first name" do
-        get :search_results, params: { facility_id: facility.url_name, search_term: owner.first_name }
+        get :index, params: { facility_id: facility.url_name, search_term: owner.first_name }
         expect(assigns(:accounts)).to include(account)
       end
 
       it "finds the account by the owner last name" do
-        get :search_results, params: { facility_id: facility.url_name, search_term: owner.last_name }
+        get :index, params: { facility_id: facility.url_name, search_term: owner.last_name }
         expect(assigns(:accounts)).to include(account)
       end
 
       it "doesn't find anything with gibberish" do
-        get :search_results, params: { facility_id: facility.url_name, search_term: "GOBBLEDEGOOK" }
+        get :index, params: { facility_id: facility.url_name, search_term: "GOBBLEDEGOOK" }
         expect(assigns(:accounts)).to be_empty
       end
 
       it "returns a warning an no results if less than three characters" do
-        get :search_results, params: { facility_id: facility.url_name, search_term: "A" }
+        get :index, params: { facility_id: facility.url_name, search_term: "A" }
         expect(assigns(:accounts)).to be_nil
-        expect(flash.now[:errors]).to be_present
+        expect(flash.now[:error]).to be_present
       end
 
       context "with CSV format" do
         it "enqueues CsvReportEmailJob with search term" do
           expect do
-            get :search_results, params: { facility_id: facility.url_name, search_term: account.account_number.first(3), format: :csv }
+            get :index, params: { facility_id: facility.url_name, search_term: account.account_number.first(3), format: :csv }
           end.to have_enqueued_job(CsvReportEmailJob)
         end
 
         it "sends an email" do
           perform_enqueued_jobs do
-            get :search_results, params: { facility_id: facility.url_name, search_term: account.account_number.first(3), format: :csv }
+            get :index, params: { facility_id: facility.url_name, search_term: account.account_number.first(3), format: :csv }
           end
 
           expect(ActionMailer::Base.deliveries.length).to eq(1)
@@ -273,18 +273,14 @@ RSpec.describe FacilityAccountsController, feature_setting: { "accounts.edit_acc
       context "with CSV format and no search term" do
         it "enqueues CsvReportEmailJob with blank search term" do
           expect do
-            get :search_results, params: { facility_id: facility.url_name, format: :csv }
+            get :index, params: { facility_id: facility.url_name, format: :csv }
           end.to(
             have_enqueued_job(CsvReportEmailJob).with(
               Reports::AccountSearchReport.to_s,
               anything,
               hash_including(
-                search_term: "",
-                filter_params: hash_including(
-                  account_type: nil,
-                  suspended: nil,
-                  account_status: nil,
-                )
+                search_term: nil,
+                filter_params: {},
               )
             )
           )
@@ -292,13 +288,13 @@ RSpec.describe FacilityAccountsController, feature_setting: { "accounts.edit_acc
 
         it "respects suspended filter" do
           expect do
-            get :search_results, params: { facility_id: facility.url_name, suspended: "true", format: :csv }
+            get :index, params: { facility_id: facility.url_name, suspended: "true", format: :csv }
           end.to(
             have_enqueued_job(CsvReportEmailJob).with(
               Reports::AccountSearchReport.to_s,
               anything,
               hash_including(
-                search_term: "",
+                search_term: nil,
                 filter_params: hash_including(suspended: "true"),
               )
             )
@@ -307,13 +303,13 @@ RSpec.describe FacilityAccountsController, feature_setting: { "accounts.edit_acc
 
         it "respects account_status filter" do
           expect do
-            get :search_results, params: { facility_id: facility.url_name, account_status: "active", format: :csv }
+            get :index, params: { facility_id: facility.url_name, account_status: "active", format: :csv }
           end.to(
             have_enqueued_job(CsvReportEmailJob).with(
               Reports::AccountSearchReport.to_s,
               anything,
               hash_including(
-                search_term: "",
+                search_term: nil,
                 filter_params: hash_including(account_status: "active"),
               )
             )
@@ -322,13 +318,13 @@ RSpec.describe FacilityAccountsController, feature_setting: { "accounts.edit_acc
 
         it "respects account_type filter" do
           expect do
-            get :search_results, params: { facility_id: facility.url_name, account_type: "NufsAccount", format: :csv }
+            get :index, params: { facility_id: facility.url_name, account_type: "NufsAccount", format: :csv }
           end.to(
             have_enqueued_job(CsvReportEmailJob).with(
               Reports::AccountSearchReport.to_s,
               anything,
               hash_including(
-                search_term: "",
+                search_term: nil,
                 filter_params: hash_including(account_type: "NufsAccount"),
               )
             )
@@ -339,7 +335,7 @@ RSpec.describe FacilityAccountsController, feature_setting: { "accounts.edit_acc
       context "with CSV format and search term" do
         it "enqueues CsvReportEmailJob with search term and filtered scope" do
           expect do
-            get :search_results, params: { facility_id: facility.url_name, search_term: "ACTIVE", account_status: "active", format: :csv }
+            get :index, params: { facility_id: facility.url_name, search_term: "ACTIVE", account_status: "active", format: :csv }
           end.to(
             have_enqueued_job(CsvReportEmailJob).with(
               Reports::AccountSearchReport.to_s,

--- a/spec/controllers/facility_accounts_controller_spec.rb
+++ b/spec/controllers/facility_accounts_controller_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe FacilityAccountsController, feature_setting: { "accounts.edit_acc
               anything,
               hash_including(
                 search_term: nil,
-                filter_params: {},
+                filter_params: { suspended: "false" },
               )
             )
           )

--- a/spec/services/account_searcher_spec.rb
+++ b/spec/services/account_searcher_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe AccountSearcher do
         { suspended: "false" }
       end
 
-      it "includes suspended account" do
+      it "excludes suspended account" do
         expect(searcher.results).to contain_exactly(active_account, expired_account)
       end
     end

--- a/spec/services/account_searcher_spec.rb
+++ b/spec/services/account_searcher_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe AccountSearcher do
     end
   end
 
-  describe "filter_params", :use_test_account, feature_setting: { "accounts.account_tabs" => true } do
+  describe "filter_params", :use_test_account do
     let(:user) { create(:user) }
     let(:facility) { Facility.cross_facility }
     let!(:suspended_account) do
@@ -126,27 +126,58 @@ RSpec.describe AccountSearcher do
         suspended_at: Time.current,
       )
     end
+    let!(:expired_account) do
+      create(
+        :test_account,
+        :with_account_owner,
+        created_by: user.id,
+        expires_at: 1.week.ago,
+      )
+    end
     let!(:active_account) do
       create(:test_account, :with_account_owner, created_by: user.id)
     end
+    let(:searcher) do
+      described_class.new("", scope: Account.all, filter_params:)
+    end
 
-    context "with suspended filter" do
-      let(:searcher) do
-        described_class.new("", scope: Account.all, filter_params: { suspended: "true" })
+    context "with suspended false filter" do
+      let(:filter_params) do
+        { suspended: "false" }
       end
 
-      it "includes suspende account" do
-        expect(searcher.results).to match([suspended_account])
+      it "includes suspended account" do
+        expect(searcher.results).to contain_exactly(active_account, expired_account)
+      end
+    end
+
+    context "with suspended true filter" do
+      let(:filter_params) do
+        { suspended: "true" }
+      end
+
+      it "includes suspended account" do
+        expect(searcher.results).to contain_exactly(suspended_account)
       end
     end
 
     context "with account_status active filter" do
-      let(:searcher) do
-        described_class.new("", scope: Account.all, filter_params: { account_status: "active" })
+      let(:filter_params) do
+        { account_status: "active" }
       end
 
-      it "only includes active accounts" do
-        expect(searcher.results).to match([active_account])
+      it "only includes non expired accounts" do
+        expect(searcher.results).to contain_exactly(active_account, suspended_account)
+      end
+    end
+
+    context "with account_status expired filter" do
+      let(:filter_params) do
+        { account_status: "expired" }
+      end
+
+      it "only includes expired accounts" do
+        expect(searcher.results).to contain_exactly(expired_account)
       end
     end
   end

--- a/spec/system/admin/facility_accounts_tab_spec.rb
+++ b/spec/system/admin/facility_accounts_tab_spec.rb
@@ -103,9 +103,9 @@ RSpec.describe "Facility Accounts Tab" do
       expect(page).to have_no_select("Account Type")
     end
 
-    it "should show the Hide Expired Accounts button" do
+    it "displays the Show Expired Accounts button" do
       visit facility_accounts_path(facility)
-      expect(page).to have_content("Hide Expired Accounts")
+      expect(page).to have_content("Show Expired Accounts")
     end
   end
 end

--- a/spec/system/admin/facility_accounts_tab_spec.rb
+++ b/spec/system/admin/facility_accounts_tab_spec.rb
@@ -57,9 +57,8 @@ RSpec.describe "Facility Accounts Tab" do
     context "when in the active tab" do
       it "should filter by account status" do
         select I18n.t("account.statuses.active"), from: I18n.t("facility_accounts.index.label.account_status")
-        find('[data-test-id="account_search_button"]').click
-        # Wait for the loader to not be found, which is when the search results are shown
-        expect(page).to have_no_css('[data-test-id="account_search_button"]', text: "Please Wait...")
+        find(".account-search-form input[type='submit']").click
+
         expect(page).to have_content(active_account.to_s)
         expect(page).to have_no_content(expired_account.to_s)
         expect(page).to have_no_content(suspended_account.to_s)
@@ -67,9 +66,8 @@ RSpec.describe "Facility Accounts Tab" do
 
       it "should filter by account type" do
         select active_account.model_name.human, from: I18n.t("facility_accounts.index.label.account_type")
-        find('[data-test-id="account_search_button"]').click
-        # Wait for the loader to not be found, which is when the search results are shown
-        expect(page).to have_no_css('[data-test-id="account_search_button"]', text: "Please Wait...")
+        find(".account-search-form input[type='submit']").click
+
         expect(page).to have_content(active_account.to_s)
         expect(page).to have_no_content(expired_account.to_s)
         expect(page).to have_no_content(suspended_account.to_s)
@@ -92,9 +90,7 @@ RSpec.describe "Facility Accounts Tab" do
       it "should filter suspended accounts by account type" do
         click_link I18n.t("views.facility_accounts.accounts_tab_nav.suspended")
         select suspended_account.model_name.human, from: I18n.t("facility_accounts.index.label.account_type")
-        find('[data-test-id="account_search_button"]').click
-        # Wait for the loader to not be found, which is when the search results are shown
-        expect(page).to have_no_css('[data-test-id="account_search_button"]', text: "Please Wait...")
+        page.find(".account-search-form input[type='submit']").click
         expect(page).to have_content(suspended_account.to_s)
       end
     end


### PR DESCRIPTION
# Notes

In the facility accounts index page, the bug was that "hide expired accounts" button was not preserved when open search box changed.
I refactored the search to be entirely server side and unified `index` and `search_result` actions.

This change also fixes pagination when account_tabs is on.

[NU-491 | Default to hide expired payment sources](https://universe-of-universities.atlassian.net/browse/NU-491)
