### PR TITLE
[Fix] Use statement status locale on global search

### DIFF
--- a/app/views/global_search/_statements.html.haml
+++ b/app/views/global_search/_statements.html.haml
@@ -34,4 +34,4 @@
         %td.currency
           = number_to_currency(statement.total_cost)
         %td
-          = statement.status
+          = Statement.human_attribute_name("status.#{statement.status}")

--- a/spec/requests/global_search_spec.rb
+++ b/spec/requests/global_search_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "global search" do
+  describe "statement search" do
+    let(:facility) { create(:facility) }
+    let(:statement) { create(:statement, facility:) }
+    let(:status_label) do
+      Statement.human_attribute_name("status.#{statement.status}")
+    end
+
+    before { login_as create(:user, :administrator) }
+
+    it "shows statement correctly" do
+      post global_search_path, params: { search: statement.invoice_number }
+
+      expect(page).to have_text("Statements")
+      expect(page).to have_text(statement.invoice_number)
+      expect(page).to have_text(status_label)
+    end
+  end
+end


### PR DESCRIPTION
# Notes

Use locale on global statement search result status.

## Screenshot

<img width="980" height="510" alt="Captura desde 2026-08-12 10-51-24" src="https://github.com/user-attachments/assets/266466c8-c7ce-4d95-ac96-2b1b3ef3b23f" />

