### PR TITLE
[NU-489] Invoice reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,6 @@ Because we use squash and merge, you should be able to see the changes by lookin
 at the [commit log](https://github.com/tablexi/nucore-open/commits/master). However, we have begun keeping track of breaking changes
 or optional rake tasks.
 
-### Addition of `two_tier_reconciliation` feature flag ([#6415](https://github.com/tablexi/nucore-open/pull/6415))
-
-Schools with `billing.two_tier_reconciliation: false` (the default) are not affected by this change.
-
-Schools with `billing.two_tier_reconciliation: true` get a two-tiered reconciliation flow. The reconciliation page (e.g. Reconcile Purchase Orders) opens on an invoice drop-down instead of the list of order details. Selecting an invoice and submitting reconciles every unreconciled order detail on it, applying the same reconciliation note and deposit number to all of them. A "Display Individual Items" button opens the previous per-item page with the invoice applied to the Statements filter, which can still be changed.
-
-When `billing.show_reconciliation_deposit_number` is also on, the deposit number (labeled per school through the `deposit_number_prefix` translation, e.g. "Transaction ID") is required to reconcile a whole invoice. It remains optional on the per-item page. When that flag is off, the field is not rendered and is not required, matching the previous behavior.
-
-Specs that exercise the per-item reconciliation page directly should set `feature_setting: { "billing.two_tier_reconciliation" => false }`, otherwise they will render the invoice drop-down instead.
-
 ### Addition of `PriceGroupDiscount` ([#3397](https://github.com/tablexi/nucore-open/pull/3397), [#3594](https://github.com/tablexi/nucore-open/pull/3594))
 
 Rather than one discount being set on a schedule rule, each global price group has its own discount (`PriceGroupDiscount`) for each schedule rule.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Because we use squash and merge, you should be able to see the changes by lookin
 at the [commit log](https://github.com/tablexi/nucore-open/commits/master). However, we have begun keeping track of breaking changes
 or optional rake tasks.
 
+### Addition of `two_tier_reconciliation` feature flag ([#6415](https://github.com/tablexi/nucore-open/pull/6415))
+
+Schools with `billing.two_tier_reconciliation: false` (the default) are not affected by this change.
+
+Schools with `billing.two_tier_reconciliation: true` get a two-tiered reconciliation flow. The reconciliation page (e.g. Reconcile Purchase Orders) opens on an invoice drop-down instead of the list of order details. Selecting an invoice and submitting reconciles every unreconciled order detail on it, applying the same reconciliation note and deposit number to all of them. A "Display Individual Items" button opens the previous per-item page with the invoice applied to the Statements filter, which can still be changed.
+
+When `billing.show_reconciliation_deposit_number` is also on, the deposit number (labeled per school through the `deposit_number_prefix` translation, e.g. "Transaction ID") is required to reconcile a whole invoice. It remains optional on the per-item page. When that flag is off, the field is not rendered and is not required, matching the previous behavior.
+
+Specs that exercise the per-item reconciliation page directly should set `feature_setting: { "billing.two_tier_reconciliation" => false }`, otherwise they will render the invoice drop-down instead.
+
 ### Addition of `PriceGroupDiscount` ([#3397](https://github.com/tablexi/nucore-open/pull/3397), [#3594](https://github.com/tablexi/nucore-open/pull/3594))
 
 Rather than one discount being set on a schedule rule, each global price group has its own discount (`PriceGroupDiscount`) for each schedule rule.

--- a/app/controllers/facility_accounts_reconciliation_controller.rb
+++ b/app/controllers/facility_accounts_reconciliation_controller.rb
@@ -58,7 +58,7 @@ class FacilityAccountsReconciliationController < ApplicationController
       count = reconciler.count
       ReconciliationLogService.new(reconciler.order_details, current_user).log_events
       flash[:notice] = "#{count} payment#{'s' unless count == 1} successfully updated" if count > 0
-      redirect_to([account_route.to_sym, :facility_accounts])
+      redirect_to([account_route.to_sym, :facility_accounts, { show_items: params[:show_items] }])
     else
       flash[:error] = reconciler.full_errors.join("<br />").html_safe
       redirect_to([account_route.to_sym, :facility_accounts, redirect_params])
@@ -137,7 +137,8 @@ class FacilityAccountsReconciliationController < ApplicationController
   def redirect_params
     {
       search: params[:search]&.permit!,
-      page: params[:page]
+      page: params[:page],
+      show_items: params[:show_items]
     }
   end
 end

--- a/app/controllers/facility_accounts_reconciliation_controller.rb
+++ b/app/controllers/facility_accounts_reconciliation_controller.rb
@@ -19,6 +19,11 @@ class FacilityAccountsReconciliationController < ApplicationController
                     .where(accounts: { type: account_class.to_s })
                     .includes(:order, :product, :statement)
 
+    if reconcile_by_statement?
+      @statements = TransactionSearch::StatementSearcher.new(order_details).options
+      return render :index_by_statement
+    end
+
     @search_form = TransactionSearch::SearchForm.new(params[:search])
 
     @search = TransactionSearch::Searcher.new(
@@ -31,10 +36,17 @@ class FacilityAccountsReconciliationController < ApplicationController
   end
 
   def update
+    return redirect_to([account_route.to_sym, :facility_accounts, redirect_params.merge(show_items: true)]) if params[:display_items]
+
+    if reconcile_whole_statement? && (error = whole_statement_error)
+      flash[:error] = error
+      return redirect_to([account_route.to_sym, :facility_accounts, redirect_params])
+    end
+
     reconciled_at = parse_iso_date(params[:reconciled_at])&.beginning_of_day
     reconciler = OrderDetails::Reconciler.new(
       unreconciled_details,
-      params[:order_detail],
+      order_detail_params,
       reconciled_at,
       update_params[:order_status],
       bulk_reconcile: update_params[:bulk_note_checkbox] == "1",
@@ -82,6 +94,38 @@ class FacilityAccountsReconciliationController < ApplicationController
       :bulk_note,
       :bulk_deposit_number,
     )
+  end
+
+  def reconcile_by_statement?
+    SettingsHelper.feature_on?("billing.two_tier_reconciliation") && params[:show_items].blank?
+  end
+
+  def reconcile_whole_statement?
+    params[:reconcile_statement].present?
+  end
+
+  def whole_statement_error
+    return text("facility_accounts_reconciliation.index_by_statement.statement_blank") if selected_statement_ids.blank?
+
+    if SettingsHelper.feature_on?("billing.show_reconciliation_deposit_number") && update_params[:bulk_deposit_number].blank?
+      text("facility_accounts_reconciliation.index_by_statement.deposit_number_blank")
+    end
+  end
+
+  def selected_statement_ids
+    Array(params.dig(:search, :statements)).compact_blank
+  end
+
+  def order_detail_params
+    return params[:order_detail] unless reconcile_whole_statement?
+
+    ids = unreconciled_details
+          .joins(:account)
+          .where(accounts: { type: account_class.to_s })
+          .where(statement_id: selected_statement_ids)
+          .ids
+
+    ActionController::Parameters.new(ids.index_with { { selected: "1" } }.transform_keys(&:to_s))
   end
 
   def authorize_mark_unrecoverable

--- a/app/views/facility_accounts_reconciliation/index.html.haml
+++ b/app/views/facility_accounts_reconciliation/index.html.haml
@@ -27,6 +27,7 @@
           = hidden_field_tag "search[#{key}]", value
     - if params[:page].present?
       = hidden_field_tag :page, params[:page]
+    = hidden_field_tag :show_items, params[:show_items] if params[:show_items].present?
     = render "action_row", date: true,
       unreconciled_order_details: @unreconciled_details,
       show_reconciliation_deposit_number: show_reconciliation_deposit_number,

--- a/app/views/facility_accounts_reconciliation/index_by_statement.html.haml
+++ b/app/views/facility_accounts_reconciliation/index_by_statement.html.haml
@@ -1,0 +1,45 @@
+- content_for :h1 do
+  = current_facility
+
+- content_for :sidebar do
+  = render partial: "admin/shared/sidenav_billing", locals: { sidenav_tab: account_route }
+
+%h2= t(".head", model: account_class.model_name.human(count: 2))
+
+.col-md-12
+  = form_tag([:update, account_route.to_sym, FacilityAccount], method: :post) do
+    = hidden_field_tag :bulk_note_checkbox, "1"
+
+    .row.table-actions.form-horizontal
+      .form-group
+        = label_tag :search_statements, t(".statement"), class: "control-label col-md-2"
+        .col-md-4
+          = select_tag "search[statements][]",
+            options_from_collection_for_select(@statements, :id, :invoice_number, params.dig(:search, :statements)&.first),
+            include_blank: true,
+            id: :search_statements,
+            class: "form-control"
+
+    .row.table-actions.form-horizontal
+      .form-group
+        = label_tag :reconciled_at, OrderDetail.human_attribute_name(:reconciled_at), class: "control-label col-md-2"
+        .col-md-4
+          = date_field_tag :reconciled_at, Date.current, class: "form-control", max: Date.current
+
+    .row.table-actions.form-horizontal
+      .form-group
+        = label_tag :bulk_note, t("facility_accounts_reconciliation.index.bulk_note"), class: "control-label col-md-2"
+        .col-md-4
+          = text_field_tag :bulk_note, params[:bulk_note], class: "form-control", maxlength: 250
+
+    - if SettingsHelper.feature_on?("billing.show_reconciliation_deposit_number")
+      .row.table-actions.form-horizontal
+        .form-group
+          = label_tag :bulk_deposit_number, text("facility_accounts_reconciliation.index.bulk_deposit_number"), class: "control-label col-md-2"
+          .col-md-4
+            = text_field_tag :bulk_deposit_number, params[:bulk_deposit_number], class: "form-control"
+
+    .row.table-actions.form-horizontal
+      .col-md-12.text-right
+        = submit_tag t(".submit"), name: "reconcile_statement", class: "btn btn-primary", data: { disable_with: t(".submit") }
+        = submit_tag t(".display_items"), name: "display_items", class: "btn btn-default"

--- a/app/views/facility_accounts_reconciliation/index_by_statement.html.haml
+++ b/app/views/facility_accounts_reconciliation/index_by_statement.html.haml
@@ -7,39 +7,42 @@
 %h2= t(".head", model: account_class.model_name.human(count: 2))
 
 .col-md-12
-  = form_tag([:update, account_route.to_sym, FacilityAccount], method: :post) do
-    = hidden_field_tag :bulk_note_checkbox, "1"
+  - if @statements.none?
+    %p.notice= t("facility_accounts_reconciliation.index.none", model: account_class.model_name.human(count: 2).downcase)
+  - else
+    = form_tag([:update, account_route.to_sym, FacilityAccount], method: :post) do
+      = hidden_field_tag :bulk_note_checkbox, "1"
 
-    .row.table-actions.form-horizontal
-      .form-group
-        = label_tag :search_statements, t(".statement"), class: "control-label col-md-2"
-        .col-md-4
-          = select_tag "search[statements][]",
-            options_from_collection_for_select(@statements, :id, :invoice_number, params.dig(:search, :statements)&.first),
-            include_blank: true,
-            id: :search_statements,
-            class: "form-control"
-
-    .row.table-actions.form-horizontal
-      .form-group
-        = label_tag :reconciled_at, OrderDetail.human_attribute_name(:reconciled_at), class: "control-label col-md-2"
-        .col-md-4
-          = date_field_tag :reconciled_at, Date.current, class: "form-control", max: Date.current
-
-    .row.table-actions.form-horizontal
-      .form-group
-        = label_tag :bulk_note, t("facility_accounts_reconciliation.index.bulk_note"), class: "control-label col-md-2"
-        .col-md-4
-          = text_field_tag :bulk_note, params[:bulk_note], class: "form-control", maxlength: 250
-
-    - if SettingsHelper.feature_on?("billing.show_reconciliation_deposit_number")
       .row.table-actions.form-horizontal
         .form-group
-          = label_tag :bulk_deposit_number, text("facility_accounts_reconciliation.index.bulk_deposit_number"), class: "control-label col-md-2"
+          = label_tag :search_statements, t(".statement"), class: "control-label col-md-2"
           .col-md-4
-            = text_field_tag :bulk_deposit_number, params[:bulk_deposit_number], class: "form-control"
+            = select_tag "search[statements][]",
+              options_from_collection_for_select(@statements, :id, :invoice_number, params.dig(:search, :statements)&.first),
+              include_blank: true,
+              id: :search_statements,
+              class: "form-control"
 
-    .row.table-actions.form-horizontal
-      .col-md-12.text-right
-        = submit_tag t(".submit"), name: "reconcile_statement", class: "btn btn-primary", data: { disable_with: t(".submit") }
-        = submit_tag t(".display_items"), name: "display_items", class: "btn btn-default"
+      .row.table-actions.form-horizontal
+        .form-group
+          = label_tag :reconciled_at, OrderDetail.human_attribute_name(:reconciled_at), class: "control-label col-md-2"
+          .col-md-4
+            = date_field_tag :reconciled_at, Date.current, class: "form-control", max: Date.current
+
+      .row.table-actions.form-horizontal
+        .form-group
+          = label_tag :bulk_note, t("facility_accounts_reconciliation.index.bulk_note"), class: "control-label col-md-2"
+          .col-md-4
+            = text_field_tag :bulk_note, nil, class: "form-control"
+
+      - if SettingsHelper.feature_on?("billing.show_reconciliation_deposit_number")
+        .row.table-actions.form-horizontal
+          .form-group
+            = label_tag :bulk_deposit_number, text("facility_accounts_reconciliation.index.bulk_deposit_number"), class: "control-label col-md-2"
+            .col-md-4
+              = text_field_tag :bulk_deposit_number, nil, class: "form-control"
+
+      .row.table-actions.form-horizontal
+        .col-md-12.text-right
+          = submit_tag t(".submit"), name: "reconcile_statement", class: "btn btn-primary", data: { disable_with: t(".submit") }
+          = submit_tag t(".display_items"), name: "display_items", class: "btn btn-default"

--- a/app/views/facility_accounts_reconciliation/index_by_statement.html.haml
+++ b/app/views/facility_accounts_reconciliation/index_by_statement.html.haml
@@ -27,7 +27,11 @@
         .form-group
           = label_tag :reconciled_at, OrderDetail.human_attribute_name(:reconciled_at), class: "control-label col-md-2"
           .col-md-4
-            = date_field_tag :reconciled_at, Date.current, class: "form-control", max: Date.current
+            = date_field_tag :reconciled_at,
+              Date.current,
+              class: "form-control",
+              min: @statements.map(&:created_at).min&.to_date,
+              max: Date.current
 
       .row.table-actions.form-horizontal
         .form-group

--- a/app/views/facility_accounts_reconciliation/index_by_statement.html.haml
+++ b/app/views/facility_accounts_reconciliation/index_by_statement.html.haml
@@ -9,44 +9,43 @@
 .col-md-12
   - if @statements.none?
     %p.notice= t("facility_accounts_reconciliation.index.none", model: account_class.model_name.human(count: 2).downcase)
-  - else
-    = form_tag([:update, account_route.to_sym, FacilityAccount], method: :post) do
-      = hidden_field_tag :bulk_note_checkbox, "1"
+  = form_tag([:update, account_route.to_sym, FacilityAccount], method: :post) do
+    = hidden_field_tag :bulk_note_checkbox, "1"
 
+    .row.table-actions.form-horizontal
+      .form-group
+        = label_tag :search_statements, t(".statement"), class: "control-label col-md-2"
+        .col-md-4
+          = select_tag "search[statements][]",
+            options_from_collection_for_select(@statements, :id, :invoice_number, params.dig(:search, :statements)&.first),
+            include_blank: true,
+            id: :search_statements,
+            class: "form-control"
+
+    .row.table-actions.form-horizontal
+      .form-group
+        = label_tag :reconciled_at, OrderDetail.human_attribute_name(:reconciled_at), class: "control-label col-md-2"
+        .col-md-4
+          = date_field_tag :reconciled_at,
+            Date.current,
+            class: "form-control",
+            min: @statements.map(&:created_at).min&.to_date,
+            max: Date.current
+
+    .row.table-actions.form-horizontal
+      .form-group
+        = label_tag :bulk_note, t("facility_accounts_reconciliation.index.bulk_note"), class: "control-label col-md-2"
+        .col-md-4
+          = text_field_tag :bulk_note, nil, class: "form-control"
+
+    - if SettingsHelper.feature_on?("billing.show_reconciliation_deposit_number")
       .row.table-actions.form-horizontal
         .form-group
-          = label_tag :search_statements, t(".statement"), class: "control-label col-md-2"
+          = label_tag :bulk_deposit_number, text("facility_accounts_reconciliation.index.bulk_deposit_number"), class: "control-label col-md-2"
           .col-md-4
-            = select_tag "search[statements][]",
-              options_from_collection_for_select(@statements, :id, :invoice_number, params.dig(:search, :statements)&.first),
-              include_blank: true,
-              id: :search_statements,
-              class: "form-control"
+            = text_field_tag :bulk_deposit_number, nil, class: "form-control"
 
-      .row.table-actions.form-horizontal
-        .form-group
-          = label_tag :reconciled_at, OrderDetail.human_attribute_name(:reconciled_at), class: "control-label col-md-2"
-          .col-md-4
-            = date_field_tag :reconciled_at,
-              Date.current,
-              class: "form-control",
-              min: @statements.map(&:created_at).min&.to_date,
-              max: Date.current
-
-      .row.table-actions.form-horizontal
-        .form-group
-          = label_tag :bulk_note, t("facility_accounts_reconciliation.index.bulk_note"), class: "control-label col-md-2"
-          .col-md-4
-            = text_field_tag :bulk_note, nil, class: "form-control"
-
-      - if SettingsHelper.feature_on?("billing.show_reconciliation_deposit_number")
-        .row.table-actions.form-horizontal
-          .form-group
-            = label_tag :bulk_deposit_number, text("facility_accounts_reconciliation.index.bulk_deposit_number"), class: "control-label col-md-2"
-            .col-md-4
-              = text_field_tag :bulk_deposit_number, nil, class: "form-control"
-
-      .row.table-actions.form-horizontal
-        .col-md-12.text-right
-          = submit_tag t(".submit"), name: "reconcile_statement", class: "btn btn-primary", data: { disable_with: t(".submit") }
-          = submit_tag t(".display_items"), name: "display_items", class: "btn btn-default"
+    .row.table-actions.form-horizontal
+      .col-md-12.text-right
+        = submit_tag t(".submit"), name: "reconcile_statement", class: "btn btn-primary", data: { disable_with: t(".submit") }
+        = submit_tag t(".display_items"), name: "display_items", class: "btn btn-default"

--- a/app/views/facility_accounts_reconciliation/index_by_statement.html.haml
+++ b/app/views/facility_accounts_reconciliation/index_by_statement.html.haml
@@ -7,8 +7,6 @@
 %h2= t(".head", model: account_class.model_name.human(count: 2))
 
 .col-md-12
-  - if @statements.none?
-    %p.notice= t("facility_accounts_reconciliation.index.none", model: account_class.model_name.human(count: 2).downcase)
   = form_tag([:update, account_route.to_sym, FacilityAccount], method: :post) do
     = hidden_field_tag :bulk_note_checkbox, "1"
 
@@ -49,3 +47,6 @@
       .col-md-12.text-right
         = submit_tag t(".submit"), name: "reconcile_statement", class: "btn btn-primary", data: { disable_with: t(".submit") }
         = submit_tag t(".display_items"), name: "display_items", class: "btn btn-default"
+
+  - if @statements.none?
+    %p.notice= t("facility_accounts_reconciliation.index.none", model: account_class.model_name.human(count: 2).downcase)

--- a/app/views/shared/transactions/_search.html.haml
+++ b/app/views/shared/transactions/_search.html.haml
@@ -14,4 +14,5 @@
   %div
     = hidden_field_tag :email, current_user.email, disabled: true
     = hidden_field_tag :format, params[:format], disabled: true
+    = hidden_field_tag :show_items, params[:show_items], disabled: params[:show_items].blank?
     = f.submit t("shared.filter"), class: "btn"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -283,6 +283,13 @@ en:
       bulk_deposit_number: "Bulk !deposit_number_prefix! Number"
       bulk_deposit_number_prefix: "!deposit_number_prefix!"
       bulk_deposit_number_hint: "Please enter the !deposit_number_prefix! Number from your GL008"
+    index_by_statement:
+      head: Reconcile %{model}
+      statement: Invoice
+      submit: "Reconcile"
+      display_items: "Display Individual Items"
+      statement_blank: "Please select an invoice"
+      deposit_number_blank: "!deposit_number_prefix! Number may not be blank"
 
   facility_users:
     title: "!Facility! Staff"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -178,6 +178,7 @@ feature:
     set_statement_search_start_date: false
     show_reconcile_credit_cards: false
     show_reconciliation_deposit_number: <%= ENV.fetch("RECONCILIATION_DEPOSIT_NUMBER", false) %>
+    two_tier_reconciliation: false
 
   notifications:
     order_assignment_notifications: true

--- a/doc/HOWTO_feature_flags.md
+++ b/doc/HOWTO_feature_flags.md
@@ -85,6 +85,7 @@ Grouped under `feature.billing`.
 * `set_statement_search_start_date` By default, show statements from the last month on the "create Statements" tab
 * `show_reconcile_credit_cards`: Enable reconcile menu for Credit Cards.
 * `show_reconciliation_deposit_number`: Enable reconciliation deposit number field and show it in transaction listings.
+* `two_tier_reconciliation`: Open the reconciliation page on an invoice drop-down, so a whole invoice can be reconciled at once without listing its order details. The per-item page is still reachable from there. When `show_reconciliation_deposit_number` is also on, the deposit number is required to reconcile a whole invoice.
 
 ## Notifications
 

--- a/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
+++ b/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
@@ -292,6 +292,19 @@ RSpec.describe FacilityAccountsReconciliationController do
         expect(response.location).to include("show_items=true")
         expect(response.location).to include("search%5Bstatements%5D%5B%5D=#{statement.id}")
       end
+
+      context "when reconciling from the individual items page" do
+        it "stays on the individual items page on success" do
+          perform(reconcile_statement: nil, show_items: true, order_detail: { order_detail.id.to_s => { selected: "1" } })
+          expect(response.location).to include("show_items=true")
+        end
+
+        it "stays on the individual items page on error" do
+          perform(reconcile_statement: nil, show_items: true, reconciled_at: "", order_detail: { order_detail.id.to_s => { selected: "1" } })
+          expect(flash[:error]).to be_present
+          expect(response.location).to include("show_items=true")
+        end
+      end
     end
   end
 end

--- a/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
+++ b/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
@@ -226,7 +226,6 @@ RSpec.describe FacilityAccountsReconciliationController do
         expect(response).to render_template(:index)
       end
 
-
       context "when the feature is off", feature_setting: { "billing.two_tier_reconciliation" => false } do
         it "renders the individual items page" do
           perform

--- a/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
+++ b/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
@@ -226,10 +226,21 @@ RSpec.describe FacilityAccountsReconciliationController do
         expect(response).to render_template(:index)
       end
 
+
       context "when the feature is off", feature_setting: { "billing.two_tier_reconciliation" => false } do
         it "renders the individual items page" do
           perform
           expect(response).to render_template(:index)
+        end
+      end
+
+      context "when there is nothing left to reconcile" do
+        before { order_details.each { |order_detail| order_detail.update!(statement: nil) } }
+
+        it "renders the invoice selection page without any invoices" do
+          perform
+          expect(response).to render_template(:index_by_statement)
+          expect(assigns(:statements)).to be_empty
         end
       end
     end

--- a/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
+++ b/spec/controllers/facility_accounts_reconciliation_controller_spec.rb
@@ -198,4 +198,90 @@ RSpec.describe FacilityAccountsReconciliationController do
       end
     end
   end
+
+  describe "two-tier reconciliation", feature_setting: { "billing.two_tier_reconciliation" => true, "billing.show_reconciliation_deposit_number" => true } do
+    let(:other_order) { create(:purchased_order, product:, account:) }
+    let(:other_order_detail) { other_order.order_details.first }
+    let(:order_details) { [order_detail, other_order_detail] }
+
+    before do
+      other_order_detail.change_status!(OrderStatus.complete)
+      other_order_detail.update(reviewed_at: 5.minutes.ago, statement:)
+      sign_in admin
+    end
+
+    describe "index" do
+      def perform(params = {})
+        get :index, params: { facility_id: facility.url_name, account_type: "ReconciliationTestAccount" }.merge(params)
+      end
+
+      it "renders the invoice selection page" do
+        perform
+        expect(response).to render_template(:index_by_statement)
+        expect(assigns(:statements)).to include(statement)
+      end
+
+      it "renders the individual items page when show_items is set" do
+        perform(show_items: true)
+        expect(response).to render_template(:index)
+      end
+
+      context "when the feature is off", feature_setting: { "billing.two_tier_reconciliation" => false } do
+        it "renders the individual items page" do
+          perform
+          expect(response).to render_template(:index)
+        end
+      end
+    end
+
+    describe "update" do
+      def perform(params = {})
+        post :update, params: {
+          facility_id: facility.url_name,
+          account_type: "ReconciliationTestAccount",
+          reconciled_at: Date.current.iso8601,
+          reconcile_statement: "Reconcile",
+          bulk_note_checkbox: "1",
+          bulk_note: "A bulk note",
+          bulk_deposit_number: "TX-123",
+          search: { statements: [statement.id.to_s] },
+        }.merge(params)
+      end
+
+      it "reconciles every order detail on the invoice" do
+        expect { perform }.to change {
+          order_details.map { |order_detail| order_detail.reload.state }
+        }.to(%w(reconciled reconciled))
+      end
+
+      it "applies the note and transaction id to every order detail" do
+        perform
+        order_details.each(&:reload)
+        expect(order_details.map(&:reconciled_note)).to all(eq("A bulk note"))
+        expect(order_details.map(&:deposit_number)).to all(eq("TX-123"))
+      end
+
+      it "does not reconcile when the transaction id is blank" do
+        expect { perform(bulk_deposit_number: "") }.not_to change {
+          order_detail.reload.state
+        }.from("complete")
+        expect(flash[:error]).to include("may not be blank")
+      end
+
+      it "does not reconcile when no invoice is selected" do
+        expect { perform(search: { statements: [""] }) }.not_to change {
+          order_detail.reload.state
+        }.from("complete")
+        expect(flash[:error]).to include("select an invoice")
+      end
+
+      it "redirects to the individual items page with the invoice pre-selected" do
+        expect { perform(reconcile_statement: nil, display_items: "Display Individual Items") }.not_to change {
+          order_detail.reload.state
+        }.from("complete")
+        expect(response.location).to include("show_items=true")
+        expect(response.location).to include("search%5Bstatements%5D%5B%5D=#{statement.id}")
+      end
+    end
+  end
 end

--- a/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
+++ b/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Account Reconciliation", :js do
+RSpec.describe "Account Reconciliation", :js, feature_setting: { "billing.two_tier_reconciliation" => false } do
   include AccountsTestHelper
 
   let(:facility) { create(:setup_facility) }

--- a/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
+++ b/vendor/engines/c2po/spec/system/account_reconciliation_spec.rb
@@ -183,6 +183,63 @@ RSpec.describe "Account Reconciliation", :js do
       expect(orders.last.order_details.first.reload.reconciled_note).to eq("this is the bulk note")
     end
 
+    context "with two-tier reconciliation", feature_setting: { "billing.two_tier_reconciliation" => true, "billing.show_reconciliation_deposit_number" => true } do
+      let(:extra_order) { create(:purchased_order, product: item, account: accounts.first) }
+      let(:extra_order_detail) { extra_order.order_details.first }
+
+      before do
+        extra_order_detail.to_complete!
+        extra_order_detail.update!(statement: statements.first)
+
+        visit purchase_orders_facility_accounts_path(facility)
+      end
+
+      it "reconciles every order on the selected invoice without listing them" do
+        expect(page).not_to have_content(order_number)
+
+        select statements.first.invoice_number, from: "Invoice"
+        fill_in "Reconciliation Date", with: 1.day.ago.to_date
+        fill_in "Bulk Note", with: "this is the bulk note"
+        fill_in "bulk_deposit_number", with: "TX-123"
+        click_button "Reconcile"
+
+        expect(page).to have_content("2 payments successfully updated")
+
+        [order_detail, extra_order_detail].each do |od|
+          expect(od.reload).to be_reconciled
+          expect(od.reconciled_note).to eq("this is the bulk note")
+          expect(od.deposit_number).to eq("TX-123")
+        end
+      end
+
+      it "does not reconcile without a transaction id" do
+        select statements.first.invoice_number, from: "Invoice"
+        fill_in "Reconciliation Date", with: 1.day.ago.to_date
+        click_button "Reconcile"
+
+        expect(page).to have_content("may not be blank")
+        expect(order_detail.reload).not_to be_reconciled
+      end
+
+      it "displays the individual items with the invoice filter pre-populated" do
+        select statements.first.invoice_number, from: "Invoice"
+        click_button "Display Individual Items"
+
+        expect(page).to have_content(order_number)
+        expect(page).not_to have_content(other_order_number)
+        expect(page).to have_css(".chosen-container", text: statements.first.invoice_number)
+      end
+
+      it "stays on the individual items page when the filter is re-submitted" do
+        select statements.first.invoice_number, from: "Invoice"
+        click_button "Display Individual Items"
+        click_button "Filter"
+
+        expect(page).to have_content(order_number)
+        expect(page).not_to have_content(other_order_number)
+      end
+    end
+
     context "marking as unrecoverable" do
       let(:order_detail1) { order_detail }
       let(:order_detail2) { orders.last.order_details.first }


### PR DESCRIPTION
# Notes

Facility administrators can now reconcile an entire invoice at once from the Reconcile Purchase Orders page: select an invoice from a drop-down, enter a reconciliation note and Transaction ID, and every order on that invoice is reconciled without having to check them off one by one. A Transaction ID is now required when reconciling this way. A "Display Individual Items" button opens the existing per-item page with the invoice already applied to the Statements filter, which can still be changed.

Behind the `billing.two_tier_reconciliation` feature flag, off by default — no change for schools that don't enable it.

[NU-489 | Invoice Reconciliation](https://universe-of-universities.atlassian.net/browse/NU-489)

# Screenshot

<img width="1214" height="795" alt="Screenshot 2026-08-13 at 9 09 18 AM" src="https://github.com/user-attachments/assets/08bed965-4790-4348-b2ee-2da171b9d442" />

<img width="1243" height="965" alt="Screenshot 2026-08-13 at 9 01 44 AM" src="https://github.com/user-attachments/assets/f9f26dcf-ba91-4012-a38e-0c4738f7363a" />


https://github.com/user-attachments/assets/b7ebdd36-fb53-438d-a165-dc07528d2e93


