### PR TITLE
[Chore] Add activesupport to dependabot rails group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,7 @@ updates:
         - activemodel
         - activerecord
         - activestorage
+        - activesupport
     aws:
       update-types:
         - patch


### PR DESCRIPTION
# Notes

`activesupport` is missing from the rails gems group.
