### PR TITLE
[Chore] Make permissions extensible

### DIFF
--- a/app/controllers/facility_user_permissions_controller.rb
+++ b/app/controllers/facility_user_permissions_controller.rb
@@ -55,7 +55,7 @@ class FacilityUserPermissionsController < ApplicationController
 
   def permission_params
     allowed = FacilityUserPermission.all_permissions
-    allowed -= FacilityUserPermission::ADMIN_ONLY_PERMISSIONS unless current_user.administrator?
+    allowed -= FacilityUserPermission.admin_only_permissions unless current_user.administrator?
     allowed -= [:quoting] if SettingsHelper.feature_off?(:show_estimates_option)
 
     permitted = params.require(:facility_user_permission).permit(*allowed)

--- a/app/models/facility_user_permission.rb
+++ b/app/models/facility_user_permission.rb
@@ -42,6 +42,10 @@ class FacilityUserPermission < ApplicationRecord
     end
   end
 
+  def self.admin_only_permissions
+    ADMIN_ONLY_PERMISSIONS
+  end
+
   def no_permissions?
     active_permissions.blank?
   end
@@ -51,14 +55,14 @@ class FacilityUserPermission < ApplicationRecord
   end
 
   def active_permissions
-    PERMISSIONS.select { |perm| send(perm) }
+    self.class.all_permissions.select { |perm| send(perm) }
   end
 
   private
 
   def read_access_required_with_other_permissions
     return if read_access?
-    return if (PERMISSIONS - [:read_access]).none? { |perm| send(perm) }
+    return if (self.class.all_permissions - [:read_access]).none? { |perm| send(perm) }
 
     errors.add(:read_access, "must be granted when other permissions are active")
   end

--- a/app/views/facility_user_permissions/edit.html.haml
+++ b/app/views/facility_user_permissions/edit.html.haml
@@ -24,7 +24,7 @@
     %fieldset.js--permissionsFieldset
       %legend= text(".permissions")
       - sorted_permissions_with_labels.each do |perm, label|
-        - next if FacilityUserPermission::ADMIN_ONLY_PERMISSIONS.include?(perm) && !current_user.administrator?
+        - next if FacilityUserPermission.admin_only_permissions.include?(perm) && !current_user.administrator?
         - next if perm == :quoting && SettingsHelper.feature_off?(:show_estimates_option)
         .checkbox
           %label


### PR DESCRIPTION
# Notes

Allow permissions to be extended (without redefining the `PERMISSIONS` constant).
