### PR TITLE
[OSU-231] Hide subsidy to final users

### DIFF
--- a/app/controllers/concerns/order_details_csv_export.rb
+++ b/app/controllers/concerns/order_details_csv_export.rb
@@ -14,7 +14,14 @@ module OrderDetailsCsvExport
       order_detail_ids:,
       date_range_field: @date_range_field,
       label_key_prefix: @label_key_prefix,
+      show_price_breakdown: show_price_breakdown_in_csv?,
     )
+  end
+
+  private
+
+  def show_price_breakdown_in_csv?
+    true
   end
 
 end

--- a/app/controllers/concerns/order_details_csv_export.rb
+++ b/app/controllers/concerns/order_details_csv_export.rb
@@ -21,7 +21,8 @@ module OrderDetailsCsvExport
   private
 
   def show_price_breakdown_in_csv?
-    true
+    SettingsHelper.feature_off?("pricing.hide_subsidy_from_customers") ||
+      can?(:manage_billing, current_facility)
   end
 
 end

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -124,4 +124,8 @@ class TransactionsController < ApplicationController
   def redirect_to_movable_transactions
     redirect_to movable_transactions_transactions_path
   end
+
+  def show_price_breakdown_in_csv?
+    SettingsHelper.feature_off?("pricing.hide_subsidy_from_customers")
+  end
 end

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -125,7 +125,4 @@ class TransactionsController < ApplicationController
     redirect_to movable_transactions_transactions_path
   end
 
-  def show_price_breakdown_in_csv?
-    SettingsHelper.feature_off?("pricing.hide_subsidy_from_customers")
-  end
 end

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -24,6 +24,10 @@ module OrdersHelper
     end
   end
 
+  def show_price_breakdown?
+    SettingsHelper.feature_off?("pricing.hide_subsidy_from_customers")
+  end
+
   def show_note_input_to_user?(order_detail)
     acting_as? || order_detail.product.user_notes_field_mode.visible?
   end

--- a/app/mailers/purchase_notifier.rb
+++ b/app/mailers/purchase_notifier.rb
@@ -22,6 +22,7 @@ class PurchaseNotifier < ApplicationMailer
   # Notifies the specified facility staff member if any order is placed within a facility
   def order_notification(order, recipient)
     @order = order
+    @show_price_breakdown = true
     attach_all_icals_from_order(@order)
     product_count = order.products.count
 
@@ -40,6 +41,7 @@ class PurchaseNotifier < ApplicationMailer
     @user = args[:user]
     @order = args[:order]
     @greeting = text("views.purchase_notifier.order_receipt.intro")
+    @show_price_breakdown = SettingsHelper.feature_off?("pricing.hide_subsidy_from_customers")
     attach_all_icals_from_order(@order)
     send_nucore_mail to: args[:user].email, subject: text("views.purchase_notifier.order_receipt.subject")
   end

--- a/app/models/reports/account_transactions_report.rb
+++ b/app/models/reports/account_transactions_report.rb
@@ -12,6 +12,7 @@ class Reports::AccountTransactionsReport
     @order_detail_ids = order_detail_ids
     @date_range_field = options[:date_range_field] || "fulfilled_at"
     @label_key_prefix = options[:label_key_prefix] || :actual
+    @show_price_breakdown = options.fetch(:show_price_breakdown, true)
   end
 
   def to_csv
@@ -74,8 +75,7 @@ class Reports::AccountTransactionsReport
       Reservation.human_attribute_name(:actual_end_at),
       OrderDetail.human_attribute_name(:quantity),
       OrderDetail.human_attribute_name(:user),
-      OrderDetail.human_attribute_name("#{@label_key_prefix}_cost"),
-      OrderDetail.human_attribute_name("#{@label_key_prefix}_subsidy"),
+      *price_breakdown_headers,
       OrderDetail.human_attribute_name("#{@label_key_prefix}_total"),
       "#{Account.model_name.human} #{Account.human_attribute_name(:description)}",
       Account.model_name.human,
@@ -119,8 +119,7 @@ class Reports::AccountTransactionsReport
       format_usa_datetime(order_detail.time_data.try(:actual_end_at)),
       order_detail_duration(order_detail),
       order_detail.order.user.full_name,
-      order_detail.display_cost,
-      order_detail.display_subsidy,
+      *price_breakdown_values(order_detail),
       order_detail.display_total,
       order_detail.account.description,
       order_detail.account.account_number,
@@ -145,6 +144,21 @@ class Reports::AccountTransactionsReport
       row
     end
 
+  end
+
+  def price_breakdown_headers
+    return [] unless @show_price_breakdown
+
+    [
+      OrderDetail.human_attribute_name("#{@label_key_prefix}_cost"),
+      OrderDetail.human_attribute_name("#{@label_key_prefix}_subsidy"),
+    ]
+  end
+
+  def price_breakdown_values(order_detail)
+    return [] unless @show_price_breakdown
+
+    [order_detail.display_cost, order_detail.display_subsidy]
   end
 
   def notices_for(order_detail)

--- a/app/views/order_details/show.html.haml
+++ b/app/views/order_details/show.html.haml
@@ -69,9 +69,10 @@
           %th= OrderDetail.human_attribute_name(:quantity)
           %th= OrderDetail.human_attribute_name(:product)
           %th= OrderDetail.human_attribute_name(:status)
-          %th.currency= t(".th.cost")
-          - if @order_detail.has_subsidies?
-            %th.currency= t(".th.adjust")
+          - if show_price_breakdown?
+            %th.currency= t(".th.cost")
+            - if @order_detail.has_subsidies?
+              %th.currency= t(".th.adjust")
           %th.currency= t(".th.total")
       %tbody
         %tr
@@ -92,18 +93,21 @@
           %td
             = order_detail_presenter.order_status_display_name
             = order_detail_status_badges(@order_detail)
+          - currency_columns = show_price_breakdown? ? (@order_detail.has_subsidies? ? 3 : 2) : 1
           - if @order_detail.cost_estimated?
-            %td.estimated_cost.currency= show_estimated_cost(@order_detail)
-            - if @order_detail.has_subsidies?
-              %td.estimated_cost.currency= show_estimated_subsidy(@order_detail)
+            - if show_price_breakdown?
+              %td.estimated_cost.currency= show_estimated_cost(@order_detail)
+              - if @order_detail.has_subsidies?
+                %td.estimated_cost.currency= show_estimated_subsidy(@order_detail)
             %td.estimated_cost.currency= show_estimated_total(@order_detail)
           - elsif @order_detail.price_policy.nil?
-            %td{ colspan: 2 }= t(".unassigned")
+            %td{ colspan: currency_columns }= t(".unassigned")
 
           - else
-            %td.actual_cost.currency= show_actual_cost(@order_detail)
-            - if @order_detail.has_subsidies?
-              %td.actual_cost.currency= show_actual_subsidy(@order_detail)
+            - if show_price_breakdown?
+              %td.actual_cost.currency= show_actual_cost(@order_detail)
+              - if @order_detail.has_subsidies?
+                %td.actual_cost.currency= show_actual_subsidy(@order_detail)
             %td.actual_cost.currency= show_actual_total(@order_detail)
 
 = render partial: "/price_display_footnote"

--- a/app/views/orders/_cart_row.html.haml
+++ b/app/views/orders/_cart_row.html.haml
@@ -39,12 +39,14 @@
             label: false
 
     - if order_detail.cost_estimated?
-      %td.currency= show_estimated_cost(order_detail)
-      - if @order.has_subsidies?
-        %td.currency= show_estimated_subsidy(order_detail)
+      - if show_price_breakdown?
+        %td.currency= show_estimated_cost(order_detail)
+        - if @order.has_subsidies?
+          %td.currency= show_estimated_subsidy(order_detail)
       %td.currency= show_estimated_total(order_detail)
     - else
-      %td.currency= text("shared.unassigned")
-      - if @order.has_subsidies?
+      - if show_price_breakdown?
         %td.currency= text("shared.unassigned")
+        - if @order.has_subsidies?
+          %td.currency= text("shared.unassigned")
       %td.currency= text("shared.unassigned")

--- a/app/views/orders/_form.html.haml
+++ b/app/views/orders/_form.html.haml
@@ -5,9 +5,10 @@
         %th &nbsp;
         %th= OrderDetail.human_attribute_name(:product)
         %th.centered= OrderDetail.human_attribute_name(:quantity)
-        %th.currency= OrderDetail.human_attribute_name(:estimated_cost)
-        - if @order.has_subsidies?
-          %th.currency= OrderDetail.human_attribute_name(:estimated_subsidy)
+        - if show_price_breakdown?
+          %th.currency= OrderDetail.human_attribute_name(:estimated_cost)
+          - if @order.has_subsidies?
+            %th.currency= OrderDetail.human_attribute_name(:estimated_subsidy)
         %th.currency= OrderDetail.human_attribute_name(:estimated_total)
 
     %tbody
@@ -18,13 +19,14 @@
       %tr
         %td.currency{ colspan: "3" }
           %b= t(".td.total")
-        %td.currency
-          .responsive-header= OrderDetail.human_attribute_name(:estimated_cost)
-          %b= number_to_currency order.estimated_cost
-        - if order.has_subsidies?
+        - if show_price_breakdown?
           %td.currency
-            .responsive-header= OrderDetail.human_attribute_name(:estimated_subsidy)
-            %b= number_to_currency order.estimated_subsidy
+            .responsive-header= OrderDetail.human_attribute_name(:estimated_cost)
+            %b= number_to_currency order.estimated_cost
+          - if order.has_subsidies?
+            %td.currency
+              .responsive-header= OrderDetail.human_attribute_name(:estimated_subsidy)
+              %b= number_to_currency order.estimated_subsidy
         %td.currency
           .responsive-header= OrderDetail.human_attribute_name(:estimated_total)
           %b= number_to_currency order.estimated_total

--- a/app/views/orders/receipt.html.haml
+++ b/app/views/orders/receipt.html.haml
@@ -26,9 +26,10 @@
       %th.centered= OrderDetail.human_attribute_name(:id)
       %th= OrderDetail.human_attribute_name(:quantity)
       %th= OrderDetail.human_attribute_name(:product)
-      %th.currency= t('.th.cost')
-      - if @order.has_subsidies?
-        %th.currency= t('.th.adjust')
+      - if show_price_breakdown?
+        %th.currency= t('.th.cost')
+        - if @order.has_subsidies?
+          %th.currency= t('.th.adjust')
       %th.currency= t('.th.total')
   %tbody
     - OrderDetailPresenter.wrap(@order_details).each do |order_detail|
@@ -50,13 +51,14 @@
           - if order_detail.note.present?
             .order-detail-extra.order-detail-note= "Note: #{order_detail.note}"
           = render_view_hook "after_note", order_detail: order_detail
-        %td.currency= order_detail.wrapped_cost
-        - if @order.has_subsidies?
-          %td.currency= order_detail.wrapped_subsidy
+        - if show_price_breakdown?
+          %td.currency= order_detail.wrapped_cost
+          - if @order.has_subsidies?
+            %td.currency= order_detail.wrapped_subsidy
         %td.currency= order_detail.wrapped_total
   %tfoot
     %tr
-      - colspan = @order.has_subsidies? ? 5 : 4
+      - colspan = show_price_breakdown? ? (@order.has_subsidies? ? 5 : 4) : 3
       %td.hide-on-mobile{ colspan: colspan }
         %strong= t('.total')
       %td.currency

--- a/app/views/purchase_notifier/order_receipt.html.haml
+++ b/app/views/purchase_notifier/order_receipt.html.haml
@@ -35,8 +35,9 @@
       %th= OrderDetail.human_attribute_name(:quantity)
       %th= OrderDetail.human_attribute_name(:status)
       - label_key_prefix = display_cost_prefix_for_order(@order)
-      %th= OrderDetail.human_attribute_name("#{label_key_prefix}_cost")
-      %th= OrderDetail.human_attribute_name("#{label_key_prefix}_subsidy")
+      - if @show_price_breakdown
+        %th= OrderDetail.human_attribute_name("#{label_key_prefix}_cost")
+        %th= OrderDetail.human_attribute_name("#{label_key_prefix}_subsidy")
       %th= OrderDetail.human_attribute_name("#{label_key_prefix}_total")
       %th= OrderDetail.human_attribute_name(:note).pluralize
   %tbody
@@ -50,15 +51,16 @@
             = order_detail.reservation
         %td= order_detail.wrapped_quantity
         %td= order_detail.order_status_display_name
-        %td= order_detail.display_cost unless order_detail.canceled?
-        %td= order_detail.display_subsidy unless order_detail.canceled?
+        - if @show_price_breakdown
+          %td= order_detail.display_cost unless order_detail.canceled?
+          %td= order_detail.display_subsidy unless order_detail.canceled?
         %td= order_detail.display_total unless order_detail.canceled?
         %td
           - if order_detail.note.present?
             = order_detail.note
           = render_view_hook "after_note", order_detail: order_detail
     %tr
-      %td{colspan: 6}
+      %td{colspan: @show_price_breakdown ? 6 : 4}
         %strong= text(".total")
       %td.currency
         = number_to_currency(@order.total)

--- a/app/views/purchase_notifier/order_receipt.text.haml
+++ b/app/views/purchase_notifier/order_receipt.text.haml
@@ -19,8 +19,9 @@
   #{OrderDetail.human_attribute_name(:quantity)}: #{OrderDetailPresenter.new(order_detail).wrapped_quantity}
   #{OrderDetail.human_attribute_name(:status)}: #{OrderDetailPresenter.new(order_detail).order_status_display_name}
   - label_key_prefix = display_cost_prefix_for_order_detail(order_detail)
-  #{OrderDetail.human_attribute_name("#{label_key_prefix}_cost")}: #{OrderDetailPresenter.new(order_detail).display_cost unless order_detail.canceled?}
-  #{OrderDetail.human_attribute_name("#{label_key_prefix}_subsidy")}: #{OrderDetailPresenter.new(order_detail).display_subsidy unless order_detail.canceled?}
+  - if @show_price_breakdown
+    #{OrderDetail.human_attribute_name("#{label_key_prefix}_cost")}: #{OrderDetailPresenter.new(order_detail).display_cost unless order_detail.canceled?}
+    #{OrderDetail.human_attribute_name("#{label_key_prefix}_subsidy")}: #{OrderDetailPresenter.new(order_detail).display_subsidy unless order_detail.canceled?}
   #{OrderDetail.human_attribute_name("#{label_key_prefix}_total")}: #{OrderDetailPresenter.new(order_detail).display_total unless order_detail.canceled?}
   - if order_detail.note.present?
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -162,6 +162,7 @@ feature:
     can_manage_global_price_groups: true
     external_price_group_subsidies: false
     facility_directors_can_manage_price_groups: true
+    hide_subsidy_from_customers: false
     price_policy_requires_note: true
     user_based_price_groups: true
     user_based_price_groups_exclude_purchaser: false

--- a/doc/HOWTO_feature_flags.md
+++ b/doc/HOWTO_feature_flags.md
@@ -62,7 +62,7 @@ Grouped under `feature.pricing`.
 * `can_manage_global_price_groups`: Enable global price groups management.
 * `external_price_group_subsidies`: Allow facility admins to mark external price groups as subsidies of global external groups. When enabled, external price groups can have a parent group, and they will show an "Adjustment" field instead of "Rate" in price policies (similar to internal price groups).
 * `facility_directors_can_manage_price_groups` Can facility directors manage price groups
-* `hide_subsidy_from_customers`: Hide the price/adjustment breakdown on customer-facing order pages (cart, order receipt, order detail) and on the customer copy of the order receipt email, so customers only see the total they owe. Administrative views and the facility staff order notification email are unaffected.
+* `hide_subsidy_from_customers`: Hide the price/adjustment breakdown on customer-facing order pages (cart, order receipt, order detail), on the customer copy of the order receipt email, and in the transaction history CSV export account owners and business administrators run for their own accounts, so customers only see the total they owe. Administrative views, administrative CSV exports, and the facility staff order notification email are unaffected.
 * `price_policy_requires_note`: Require note when adding price policies.
 * `user_based_price_groups_exclude_purchaser`: Exclude purchaser's price groups when picking the price group of an order detail.
 * `user_based_price_groups` Allow assigning users to specific price groups (Internal Base Rate, External, etc).  This would allow some users to potentially get cheaper (internal) rates even if they don't have access to internal accounts.

--- a/doc/HOWTO_feature_flags.md
+++ b/doc/HOWTO_feature_flags.md
@@ -62,6 +62,7 @@ Grouped under `feature.pricing`.
 * `can_manage_global_price_groups`: Enable global price groups management.
 * `external_price_group_subsidies`: Allow facility admins to mark external price groups as subsidies of global external groups. When enabled, external price groups can have a parent group, and they will show an "Adjustment" field instead of "Rate" in price policies (similar to internal price groups).
 * `facility_directors_can_manage_price_groups` Can facility directors manage price groups
+* `hide_subsidy_from_customers`: Hide the price/adjustment breakdown on customer-facing order pages (cart, order receipt, order detail) and on the customer copy of the order receipt email, so customers only see the total they owe. Administrative views and the facility staff order notification email are unaffected.
 * `price_policy_requires_note`: Require note when adding price policies.
 * `user_based_price_groups_exclude_purchaser`: Exclude purchaser's price groups when picking the price group of an order detail.
 * `user_based_price_groups` Allow assigning users to specific price groups (Internal Base Rate, External, etc).  This would allow some users to potentially get cheaper (internal) rates even if they don't have access to internal accounts.

--- a/spec/controllers/facilities_controller_spec.rb
+++ b/spec/controllers/facilities_controller_spec.rb
@@ -375,6 +375,20 @@ RSpec.describe FacilitiesController do
         expect(response).to be_successful
         expect(response.body).to include("menu_billing")
       end
+
+      context "exporting as CSV", feature_setting: { granular_permissions: true, "pricing.hide_subsidy_from_customers" => true } do
+        it "keeps the price breakdown" do
+          sign_in permitted_user
+
+          expect do
+            get :transactions, params: { facility_id: facility.url_name, format: :csv }
+          end.to have_enqueued_job(CsvReportEmailJob).with(
+            Reports::AccountTransactionsReport.to_s,
+            anything,
+            hash_including(show_price_breakdown: true)
+          )
+        end
+      end
     end
 
     describe "GET #disputed_orders" do

--- a/spec/controllers/transactions_controller_spec.rb
+++ b/spec/controllers/transactions_controller_spec.rb
@@ -92,6 +92,37 @@ RSpec.describe TransactionsController do
     end
   end
 
+  describe "CSV export" do
+    let!(:account) { create(:setup_account, :with_account_owner, owner: user) }
+    let!(:order_detail) { create(:complete_order, product:, account:).order_details.first }
+
+    before { sign_in user }
+
+    def export
+      get :index, params: { format: :csv }
+    end
+
+    context "when subsidies are hidden from customers", feature_setting: { "pricing.hide_subsidy_from_customers" => true } do
+      it "queues a report without the price breakdown" do
+        expect { export }.to have_enqueued_job(CsvReportEmailJob).with(
+          Reports::AccountTransactionsReport.to_s,
+          anything,
+          hash_including(show_price_breakdown: false)
+        )
+      end
+    end
+
+    context "when subsidies are visible to customers", feature_setting: { "pricing.hide_subsidy_from_customers" => false } do
+      it "queues a report with the price breakdown" do
+        expect { export }.to have_enqueued_job(CsvReportEmailJob).with(
+          Reports::AccountTransactionsReport.to_s,
+          anything,
+          hash_including(show_price_breakdown: true)
+        )
+      end
+    end
+  end
+
   context "MovableTransactions concern", feature_setting: { "roles.move_transactions_account_roles" => true } do
     let(:user_a) { create(:user) }
     let(:user_b) { create(:user) }

--- a/spec/mailers/purchase_notifier_spec.rb
+++ b/spec/mailers/purchase_notifier_spec.rb
@@ -149,4 +149,25 @@ RSpec.describe PurchaseNotifier do
       end
     end
   end
+
+  describe "hiding the price breakdown from customers", feature_setting: { "pricing.hide_subsidy_from_customers" => true } do
+    describe ".order_receipt" do
+      before { described_class.order_receipt(order:, user:).deliver_now }
+
+      it "shows the customer only the total", :aggregate_failures do
+        expect(email.html_part.to_s).to include("Total")
+        expect(email.html_part.to_s).not_to include("Adjustment")
+        expect(email.text_part.to_s).not_to include("Adjustment")
+      end
+    end
+
+    describe ".order_notification" do
+      before { described_class.order_notification(order, "orders@example.net").deliver_now }
+
+      it "keeps the full breakdown for facility staff", :aggregate_failures do
+        expect(email.html_part.to_s).to include("Adjustment")
+        expect(email.text_part.to_s).to include("Adjustment")
+      end
+    end
+  end
 end

--- a/spec/models/reports/account_transactions_report_spec.rb
+++ b/spec/models/reports/account_transactions_report_spec.rb
@@ -55,6 +55,30 @@ RSpec.describe Reports::AccountTransactionsReport do
         end
       end
 
+      describe "with show_price_breakdown false" do
+        let(:report_options) { { show_price_breakdown: false } }
+        let(:rows) { CSV.parse(report.to_csv) }
+
+        it "omits the price and adjustment columns, keeping the total", :aggregate_failures do
+          expect(rows.first).to include(OrderDetail.human_attribute_name(:actual_total))
+          expect(rows.first).not_to include(OrderDetail.human_attribute_name(:actual_cost))
+          expect(rows.first).not_to include(OrderDetail.human_attribute_name(:actual_subsidy))
+        end
+
+        it "keeps every row the same width as the headers" do
+          expect(rows.map(&:size).uniq).to eq([rows.first.size])
+        end
+      end
+
+      describe "with show_price_breakdown defaulted" do
+        it "includes the price and adjustment columns", :aggregate_failures do
+          headers = CSV.parse_line(report.to_csv)
+
+          expect(headers).to include(OrderDetail.human_attribute_name(:actual_cost))
+          expect(headers).to include(OrderDetail.human_attribute_name(:actual_subsidy))
+        end
+      end
+
       describe "price group column" do
         let(:order_details) { OrderDetail.limit(1) }
         let(:order_detail) { order_details.first }

--- a/spec/system/hiding_subsidies_from_customers_spec.rb
+++ b/spec/system/hiding_subsidies_from_customers_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Hiding subsidies from customers", feature_setting: { "pricing.hide_subsidy_from_customers" => true } do
+  let!(:product) { create(:setup_item) }
+  let!(:account) { create(:nufs_account, :with_account_owner, owner: user) }
+  let(:facility) { product.facility }
+  let!(:price_policy) do
+    create(:item_price_policy,
+           price_group: PriceGroup.base,
+           product:,
+           unit_cost: 100,
+           unit_subsidy: 20)
+  end
+  let!(:account_price_group_member) do
+    create(:account_price_group_member, account:, price_group: price_policy.price_group)
+  end
+  let(:user) { create(:user) }
+
+  # The setup_item factory adds its own policy for the facility's price group, which
+  # the order factories enroll accounts in. Give it the same amounts so the totals
+  # are the same whichever of the two policies ends up applying.
+  before do
+    product.price_policies.where.not(id: price_policy.id).update_all(unit_cost: 100, unit_subsidy: 20)
+  end
+
+  describe "as the customer" do
+    before { login_as user }
+
+    def add_to_cart
+      visit facility_path(facility)
+      click_link product.name
+      click_link "Add to cart"
+      choose account.to_s
+      click_button "Continue"
+    end
+
+    it "shows only the total in the cart, on the receipt and on the order detail", :aggregate_failures do
+      add_to_cart
+
+      expect(page).to have_content("$80.00")
+      expect(page).not_to have_content("$100.00")
+      expect(page).not_to have_content("Adjustment")
+
+      click_button "Purchase"
+
+      expect(page).to have_content("Order Receipt")
+      expect(page).to have_content("$80.00")
+      expect(page).not_to have_content("$100.00")
+      expect(page).not_to have_content("Adjustment")
+
+      order_detail = OrderDetail.last
+      visit order_order_detail_path(order_detail.order, order_detail)
+
+      expect(page).to have_content("$80.00")
+      expect(page).not_to have_content("$100.00")
+      expect(page).not_to have_content("Adjustment")
+    end
+  end
+
+  describe "as facility staff" do
+    let!(:order) { create(:purchased_order, product:, account:) }
+    let(:facility_admin) { create(:user, :facility_administrator, facility:) }
+
+    before { login_as facility_admin }
+
+    it "still shows the full breakdown on the facility order page", :aggregate_failures do
+      visit facility_order_path(facility, order)
+
+      expect(page).to have_content("Subsidy")
+      expect(page).to have_content("$100.00")
+      expect(page).to have_content("$80.00")
+    end
+  end
+end

--- a/spec/system/placing_an_order_on_behalf_of_spec.rb
+++ b/spec/system/placing_an_order_on_behalf_of_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Placing an order on behalf of" do
       end
     end
 
-    it "can backdate an order", :js do # js needed for More options expansion
+    it "can backdate an order", :js, feature_setting: { "pricing.hide_subsidy_from_customers" => false } do # js needed for More options expansion
       two_days_ago = I18n.l(2.days.ago.to_date, format: :usa)
       three_days_ago = I18n.l(3.days.ago.to_date, format: :usa)
       visit facility_path(facility)

--- a/spec/system/purchasing_a_reservation_on_behalf_of_spec.rb
+++ b/spec/system/purchasing_a_reservation_on_behalf_of_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "Purchasing a reservation on behalf of another user" do
   end
 
   describe "creating multiple reservations" do
-    it "can create reservations in the future" do
+    it "can create reservations in the future", feature_setting: { "pricing.hide_subsidy_from_customers" => false } do
       fill_in "order[order_details][][quantity]", with: "2"
       click_button "Create Order", match: :first
       choose account.to_s
@@ -126,7 +126,7 @@ RSpec.describe "Purchasing a reservation on behalf of another user" do
       expect(page).to have_css(".currency .actual_cost", count: 0)
     end
 
-    it "can create reservations in the past" do
+    it "can create reservations in the past", feature_setting: { "pricing.hide_subsidy_from_customers" => false } do
       fill_in "order[order_details][][quantity]", with: "2"
       click_button "Create Order", match: :first
       choose account.to_s


### PR DESCRIPTION
# Notes
* Hide subsidy to final users

[OSU-231 | Hide Subsidy Adjustments from Customer-Facing RELMS Views ](https://universe-of-universities.atlassian.net/browse/OSU-231)

# Additional Context
It was easier to implement here and turn on the feature flag than to implement in the school's repo avoiding the main app.

# Screenshot
## Admin side
<img width="1197" height="344" alt="image" src="https://github.com/user-attachments/assets/58514cf4-c761-4556-aa52-1f134bd75028" />

## User side
<img width="1172" height="98" alt="image" src="https://github.com/user-attachments/assets/15e32e77-eb89-4f27-884a-7416d695a1dd" />

## User's receipt
<img width="511" height="282" alt="image" src="https://github.com/user-attachments/assets/6b551b60-3625-404d-95cc-004e700510f1" />
