### PR TITLE
[Fix] Global search spec: use locale for label match

### DIFF
--- a/spec/requests/global_search_spec.rb
+++ b/spec/requests/global_search_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "global search" do
     it "shows statement correctly" do
       post global_search_path, params: { search: statement.invoice_number }
 
-      expect(page).to have_text("Statements")
+      expect(page).to have_text(I18n.t("Statements"))
       expect(page).to have_text(statement.invoice_number)
       expect(page).to have_text(status_label)
     end


### PR DESCRIPTION
# Notes

Use local label in matcher.
