### PR TITLE
[NU-498] Stepped billing: consider discounts and minimum cost

### DIFF
--- a/app/models/instrument_price_policy_calculations.rb
+++ b/app/models/instrument_price_policy_calculations.rb
@@ -80,11 +80,17 @@ module InstrumentPricePolicyCalculations
   end
 
   def calculate_for_time(start_at, end_at)
-    PricePolicies::TimeBasedPriceCalculator.new(self).calculate(start_at, end_at)
+    PricePolicies::TimeBasedPriceCalculator
+      .new(self)
+      .calculate(start_at:, end_at:)
   end
 
   def calculate_for_estimated_time(duration, quantity = 1)
-    costs = PricePolicies::TimeBasedPriceCalculator.new(self).calculate(nil, nil, duration)
+    costs =
+      PricePolicies::TimeBasedPriceCalculator
+      .new(self)
+      .calculate(duration:, minimum_cost: false)
+
     net_cost_for_one = costs[:cost] - costs[:subsidy]
 
     net_cost_for_one * quantity

--- a/app/models/timed_service_price_policy.rb
+++ b/app/models/timed_service_price_policy.rb
@@ -23,7 +23,11 @@ class TimedServicePricePolicy < PricePolicy
   end
 
   def estimate_cost_from_estimate_detail(estimate_detail)
-    costs = calculate_for_time(estimate_detail.duration)
+    costs =
+      PricePolicies::TimeBasedPriceCalculator
+      .new(self)
+      .calculate(duration:, minimum_cost: false)
+
     net_cost_for_one = costs[:cost] - costs[:subsidy]
 
     net_cost_for_one * estimate_detail.quantity
@@ -34,7 +38,9 @@ class TimedServicePricePolicy < PricePolicy
   def calculate_for_time(duration)
     return if restrict_purchase?
 
-    PricePolicies::TimeBasedPriceCalculator.new(self).calculate(nil, nil, duration)
+    PricePolicies::TimeBasedPriceCalculator
+      .new(self)
+      .calculate(duration:, minimum_cost: false)
   end
 
 end

--- a/app/models/timed_service_price_policy.rb
+++ b/app/models/timed_service_price_policy.rb
@@ -26,7 +26,7 @@ class TimedServicePricePolicy < PricePolicy
     costs =
       PricePolicies::TimeBasedPriceCalculator
       .new(self)
-      .calculate(duration:, minimum_cost: false)
+      .calculate(duration: estimate_detail.duration, minimum_cost: false)
 
     net_cost_for_one = costs[:cost] - costs[:subsidy]
 
@@ -40,7 +40,7 @@ class TimedServicePricePolicy < PricePolicy
 
     PricePolicies::TimeBasedPriceCalculator
       .new(self)
-      .calculate(duration:, minimum_cost: false)
+      .calculate(duration:)
   end
 
 end

--- a/app/services/price_policies/strategy.rb
+++ b/app/services/price_policies/strategy.rb
@@ -5,21 +5,26 @@ module PricePolicies
   module Strategy
 
     class BaseStrategy
-      attr_reader :price_policy, :start_at, :end_at
+      attr_reader :price_policy, :start_at, :end_at, :handle_minimum_cost
 
       delegate :minimum_cost,
                :minimum_cost_subsidy,
                :product,
                to: :price_policy
 
-      def initialize(price_policy, start_at: nil, end_at: nil, duration: nil)
+      def initialize(price_policy, start_at: nil, end_at: nil, duration: nil, minimum_cost: true)
         @price_policy = price_policy
         @start_at = start_at
         @end_at = end_at
         @raw_duration = duration
+        @handle_minimum_cost = minimum_cost
 
         if [start_at, end_at, duration].all?(&:nil?)
           raise ArgumentError, "Must specify start_at, end_at or duration"
+        end
+
+        if [start_at, end_at].all?(&:present?) && start_at > end_at
+          raise ArgumentError, "Wrong arguments: start_at > end_at"
         end
       end
 
@@ -87,7 +92,8 @@ module PricePolicies
         }
 
         costs = with_discount(costs)
-        with_minimum_cost(costs)
+
+        handle_minimum_cost ? with_minimum_cost(costs) : costs
       end
     end
 
@@ -121,7 +127,8 @@ module PricePolicies
       def calculate
         costs = cost_and_subsidy_for(duration)
         costs = with_discount(costs)
-        with_minimum_cost(costs)
+
+        handle_minimum_cost ? with_minimum_cost(costs) : costs
       end
 
       private

--- a/app/services/price_policies/strategy.rb
+++ b/app/services/price_policies/strategy.rb
@@ -113,6 +113,8 @@ module PricePolicies
     end
 
     # Charge usage per minute with a stepped (or tiered) rate
+    #
+    # If price policy does not have rates then it's equivalen to PerMinute
     class SteppedRate < BaseStrategy
       delegate :usage_rate, :usage_subsidy, to: :price_policy
 
@@ -121,6 +123,8 @@ module PricePolicies
         costs = with_discount(costs)
         with_minimum_cost(costs)
       end
+
+      private
 
       def build_intervals
         intervals = [
@@ -148,8 +152,6 @@ module PricePolicies
       def sorted_duration_rates
         @sorted_duration_rates ||= price_policy.duration_rates.sorted
       end
-
-      private
 
       def cost_and_subsidy_for(total_mins)
         result = build_intervals.reduce({ time_left: total_mins, cost: 0, subsidy: 0 }) do |acc, interval_data|

--- a/app/services/price_policies/strategy.rb
+++ b/app/services/price_policies/strategy.rb
@@ -103,7 +103,7 @@ module PricePolicies
       def calculate
         {
           cost: duration * usage_rate_daily,
-          subsidy: duration * price_policy.usage_subsidy_daily.to_f,
+          subsidy: duration * usage_subsidy_daily.to_f,
         }
       end
 
@@ -114,7 +114,7 @@ module PricePolicies
 
     # Charge usage per minute with a stepped (or tiered) rate
     #
-    # If price policy does not have rates then it's equivalen to PerMinute
+    # If price policy does not have rates then it's equivalent to PerMinute
     class SteppedRate < BaseStrategy
       delegate :usage_rate, :usage_subsidy, to: :price_policy
 

--- a/app/services/price_policies/strategy.rb
+++ b/app/services/price_policies/strategy.rb
@@ -5,15 +5,22 @@ module PricePolicies
   module Strategy
 
     class BaseStrategy
-      attr_reader :price_policy, :start_at, :end_at, :duration
+      attr_reader :price_policy, :start_at, :end_at
 
-      delegate :product, to: :price_policy
+      delegate :minimum_cost,
+               :minimum_cost_subsidy,
+               :product,
+               to: :price_policy
 
-      def initialize(price_policy, start_at, end_at, duration: nil)
+      def initialize(price_policy, start_at: nil, end_at: nil, duration: nil)
         @price_policy = price_policy
         @start_at = start_at
         @end_at = end_at
-        @duration = duration
+        @raw_duration = duration
+
+        if [start_at, end_at, duration].all?(&:nil?)
+          raise ArgumentError, "Must specify start_at, end_at or duration"
+        end
       end
 
       # Calculate cost and subsidy based on price policy
@@ -23,10 +30,45 @@ module PricePolicies
         raise NotImplementedError
       end
 
+      def duration
+        @raw_duration || time_duration
+      end
+
+      def time_duration
+        time_range.duration_mins
+      end
+
       protected
+
+      def with_discount(costs)
+        costs.transform_values { |value| value * discount_factor }
+      end
+
+      def with_minimum_cost(costs)
+        if costs[:cost] < minimum_cost.to_f
+          { cost: minimum_cost, subsidy: minimum_cost_subsidy }
+        else
+          costs
+        end
+      end
 
       def time_range
         @time_range ||= TimeRange.new(start_at, end_at)
+      end
+
+      def discount_factor
+        1 - (discount / 100)
+      end
+
+      def discount
+        @discount ||=
+          if @raw_duration.present?
+            0.0
+          else
+            product.schedule_rules.to_a.sum do |schedule_rule|
+              schedule_rule.discount_for(start_at, end_at, price_policy.price_group)
+            end
+          end
       end
     end
 
@@ -34,37 +76,18 @@ module PricePolicies
     #
     # Applies subsidy and discounts
     class PerMinute < BaseStrategy
-      delegate :minimum_cost,
-               :minimum_cost_subsidy,
-               :usage_rate,
+      delegate :usage_rate,
                :usage_subsidy,
                to: :price_policy
 
-      delegate :duration_mins, to: :time_range
-
       def calculate
-        costs = { cost: duration_mins * usage_rate * discount_factor }
-
-        if costs[:cost] < minimum_cost.to_f
-          { cost: minimum_cost, subsidy: minimum_cost_subsidy }
-        else
-          costs.merge(subsidy: duration_mins * usage_subsidy * discount_factor)
-        end
-      end
-
-      def discount_factor
-        discount = product.schedule_rules.to_a.sum do |sr|
-          sr.discount_for(start_at, end_at, price_policy.price_group)
-        end
-
-        1 - (discount / 100)
-      end
-
-      def calculate_estimate
-        {
+        costs = {
           cost: duration * usage_rate,
-          subsidy: duration * (usage_subsidy || 0),
+          subsidy: duration * usage_subsidy,
         }
+
+        costs = with_discount(costs)
+        with_minimum_cost(costs)
       end
     end
 
@@ -78,40 +101,25 @@ module PricePolicies
       delegate :usage_rate_daily, :usage_subsidy_daily, to: :price_policy
 
       def calculate
-        subsidy = if price_policy.usage_subsidy_daily.present?
-                    duration_days * price_policy.usage_subsidy_daily
-                  end
-
-        {
-          subsidy: subsidy || 0,
-          cost: duration_days * usage_rate_daily,
-        }
-      end
-
-      def duration_days
-        time_range.duration_days.ceil
-      end
-
-      def calculate_estimate
         {
           cost: duration * usage_rate_daily,
-          subsidy: duration * (usage_subsidy_daily || 0),
+          subsidy: duration * price_policy.usage_subsidy_daily.to_f,
         }
       end
 
+      def time_duration
+        time_range.duration_days.ceil
+      end
     end
 
     # Charge usage per minute with a stepped (or tiered) rate
     class SteppedRate < BaseStrategy
       delegate :usage_rate, :usage_subsidy, to: :price_policy
-      delegate :duration_mins, to: :time_range
 
       def calculate
-        cost_and_subsidy_for(duration_mins)
-      end
-
-      def calculate_estimate
-        cost_and_subsidy_for(duration)
+        costs = cost_and_subsidy_for(duration)
+        costs = with_discount(costs)
+        with_minimum_cost(costs)
       end
 
       def build_intervals

--- a/app/services/price_policies/time_based_price_calculator.rb
+++ b/app/services/price_policies/time_based_price_calculator.rb
@@ -27,7 +27,7 @@ module PricePolicies
     def strategy_class
       if product.daily_booking?
         Strategy::PerDay
-      elsif product.duration_pricing_mode? && price_policy.duration_rates.present?
+      elsif product.duration_pricing_mode?
         Strategy::SteppedRate
       else
         Strategy::PerMinute

--- a/app/services/price_policies/time_based_price_calculator.rb
+++ b/app/services/price_policies/time_based_price_calculator.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 module PricePolicies
-
   class TimeBasedPriceCalculator
-
     attr_reader :price_policy
 
     delegate :product, to: :price_policy
@@ -12,14 +10,8 @@ module PricePolicies
       @price_policy = price_policy
     end
 
-    def calculate(start_at, end_at, duration = nil)
-      return if start_at.blank? && end_at.blank? && duration.blank?
-
-      if duration.present?
-        strategy_class.new(price_policy, duration:).calculate
-      elsif start_at <= end_at
-        strategy_class.new(price_policy, start_at:, end_at:).calculate
-      end
+    def calculate(...)
+      strategy_class.new(price_policy, ...).calculate
     end
 
     private
@@ -33,7 +25,5 @@ module PricePolicies
         Strategy::PerMinute
       end
     end
-
   end
-
 end

--- a/app/services/price_policies/time_based_price_calculator.rb
+++ b/app/services/price_policies/time_based_price_calculator.rb
@@ -16,11 +16,9 @@ module PricePolicies
       return if start_at.blank? && end_at.blank? && duration.blank?
 
       if duration.present?
-        strategy_class.new(price_policy, start_at, end_at, duration:).calculate_estimate
-      else
-        return if start_at > end_at
-
-        strategy_class.new(price_policy, start_at, end_at).calculate
+        strategy_class.new(price_policy, duration:).calculate
+      elsif start_at <= end_at
+        strategy_class.new(price_policy, start_at:, end_at:).calculate
       end
     end
 

--- a/spec/models/instrument_price_policy_calculations_spec.rb
+++ b/spec/models/instrument_price_policy_calculations_spec.rb
@@ -78,7 +78,9 @@ RSpec.describe InstrumentPricePolicyCalculations do
 
     before do
       allow(PricePolicies::TimeBasedPriceCalculator).to receive(:new).with(policy).and_return(calculator)
-      allow(calculator).to receive(:calculate).with(nil, nil, 480).and_return(cost: 852, subsidy: 85.2)
+      allow(calculator).to(
+        receive(:calculate).with(duration: 480, minimum_cost: false).and_return(cost: 852, subsidy: 85.2)
+      )
     end
 
     it "stores the net cost (cost minus subsidy) per unit, times quantity" do

--- a/spec/models/timed_service_price_policy_spec.rb
+++ b/spec/models/timed_service_price_policy_spec.rb
@@ -5,7 +5,15 @@ require "rails_helper"
 RSpec.describe TimedServicePricePolicy do
   describe "#calculate_cost_and_subsidy_from_order_detail" do
     let(:product) { build_stubbed(:timed_service) }
-    let(:price_policy) { build_stubbed(:timed_service_price_policy, product: product, usage_rate: 60, usage_subsidy: 15) }
+    let(:price_policy) do
+      build_stubbed(
+        :timed_service_price_policy,
+        product: product,
+        usage_rate: 60,
+        usage_subsidy: 15,
+        minimum_cost: 10,
+      )
+    end
     subject(:costs) { price_policy.calculate_cost_and_subsidy_from_order_detail(order_detail) }
 
     describe "with an hour of usage" do
@@ -20,7 +28,7 @@ RSpec.describe TimedServicePricePolicy do
 
     describe "with 0 minutes of usage" do
       let(:order_detail) { build_stubbed(:order_detail, product: product, quantity: 0) }
-      it { is_expected.to eq(cost: 0, subsidy: 0) }
+      it { is_expected.to eq(cost: 10, subsidy: 2.5) }
     end
   end
 

--- a/spec/services/price_policies/time_based_price_calculator_spec.rb
+++ b/spec/services/price_policies/time_based_price_calculator_spec.rb
@@ -171,10 +171,13 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
     end
 
     describe "#discount_factor" do
-      subject(:discount) do
+      let(:strategy) do
         PricePolicies::Strategy::PerMinute.new(
-          price_policy, start_at, end_at
-        ).discount_factor
+          price_policy, start_at:, end_at:
+        )
+      end
+      subject(:discount) do
+        strategy.instance_eval { discount_factor }
       end
 
       describe "when the entire time is within a zero discount" do

--- a/spec/services/price_policies/time_based_price_calculator_spec.rb
+++ b/spec/services/price_policies/time_based_price_calculator_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
     let(:usage_cost) do
       duration * usage_rate / 60.minutes
     end
+    let(:subject) { calculator.calculate(start_at:, end_at:) }
 
     before do
       price_group.price_group_discounts.update_all(discount_percent: 0)
@@ -47,9 +48,16 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
         let(:minimum_cost) { 0 }
 
         it "returns the usage cost" do
-          expect(subject[:cost]).to be_within(0.0001).of(
-            usage_cost
-          )
+          expect(subject[:cost]).to be_within(0.0001).of(usage_cost)
+        end
+      end
+
+      context "when minimum_cost is disabled" do
+        let(:minimum_cost) { 1000 }
+        subject { calculator.calculate(start_at:, end_at:, minimum_cost: false) }
+
+        it "returns the usage cost" do
+          expect(subject[:cost]).to be_within(0.0001).of(usage_cost)
         end
       end
     end
@@ -95,7 +103,7 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
     let!(:weekend_schedule) { create(:schedule_rule, :weekend, :all_day, discount_percent: 25, product:) }
 
     describe "#calculate" do
-      subject(:costs) { calculator.calculate(start_at, end_at) }
+      subject(:costs) { calculator.calculate(start_at:, end_at:) }
 
       it_behaves_like "handles minimum cost and discounts"
 
@@ -241,7 +249,9 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
         let(:start_at) { Time.zone.local(2017, 4, 27, 12, 0) } # Thursday
         let(:end_at) { start_at - 1.hour }
 
-        it { is_expected.to be_nil }
+        it "raises argument error" do
+          expect { subject }.to raise_error(ArgumentError)
+        end
       end
     end
 
@@ -287,7 +297,7 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
 
     describe "#calculate with a duration (estimate path)" do
       let(:options) { { usage_rate: 60, usage_subsidy: 15 } }
-      subject(:costs) { calculator.calculate(nil, nil, 60) }
+      subject(:costs) { calculator.calculate(duration: 60) }
 
       it "uses the per-minute strategy" do
         expect(calculator_strategy).to be PricePolicies::Strategy::PerMinute
@@ -308,7 +318,7 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
     end
 
     describe "#calculate" do
-      subject(:costs) { calculator.calculate(start_at, end_at) }
+      subject(:costs) { calculator.calculate(start_at:, end_at:) }
 
       describe "for external price group" do
         let(:price_group) { create(:price_group, is_internal: false) }
@@ -436,8 +446,8 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
           # 2 hours       @ $25   = $50      Duration rate - Minimum duration: 1 hour
           # 2 hours       @ $20   = $40      Duration rate - Minimum duration: 3 hours
           # 0.25 hours    @ $15   = $3.75    Duration rate - Minimum duration: 5 hours
-          expect(calculator.calculate(start_at, end_at)[:cost]).to eq(562.5)
-          expect(calculator.calculate(start_at, end_at)[:subsidy].round(4)).to eq(123.75)
+          expect(calculator.calculate(start_at:, end_at:)[:cost]).to eq(562.5)
+          expect(calculator.calculate(start_at:, end_at:)[:subsidy].round(4)).to eq(123.75)
         end
       end
 
@@ -456,7 +466,7 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
     end
 
     describe "#calculate with a duration (estimate path)" do
-      subject(:costs) { calculator.calculate(nil, nil, duration_mins) }
+      subject(:costs) { calculator.calculate(duration: duration_mins) }
 
       describe "for external price group" do
         let(:price_group) { create(:price_group, is_internal: false) }
@@ -497,7 +507,7 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
   end
 
   context "when instrument has daily rate pricing" do
-    let(:subject) { calculator.calculate(start_at, end_at) }
+    let(:subject) { calculator.calculate(start_at:, end_at:) }
     let(:product) do
       create(
         :setup_instrument,
@@ -549,7 +559,7 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
     end
 
     describe "#calculate with a duration (estimate path)" do
-      subject { calculator.calculate(nil, nil, duration_days) }
+      subject { calculator.calculate(duration: duration_days) }
 
       it "returns cost and subsidy for the daily rate" do
         is_expected.to eq(
@@ -568,7 +578,7 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
       create(:timed_service_price_policy, options.merge(product:, price_group:))
     end
 
-    subject(:costs) { calculator.calculate(nil, nil, 180) }
+    subject(:costs) { calculator.calculate(duration: 180) }
 
     context "with standard pricing" do
       let(:product) { create(:timed_service, facility:) }

--- a/spec/services/price_policies/time_based_price_calculator_spec.rb
+++ b/spec/services/price_policies/time_based_price_calculator_spec.rb
@@ -14,6 +14,79 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
   end
   let(:options) { {} }
 
+  shared_examples "handles minimum cost and discounts" do
+    let(:price_group) { PriceGroup.base }
+    let(:options) do
+      {
+        usage_rate:,
+        minimum_cost:,
+      }
+    end
+    let(:usage_rate) { 10.0 }
+    let(:duration) { 2.minutes }
+    let(:start_at) { 2.days.from_now.change(hour: 9) }
+    let(:end_at) { start_at + duration }
+    let(:usage_cost) do
+      duration * usage_rate / 60.minutes
+    end
+
+    before do
+      price_group.price_group_discounts.update_all(discount_percent: 0)
+    end
+
+    describe "minimum cost handling" do
+      context "when minimum cost present" do
+        let(:minimum_cost) { 200 }
+
+        it "returns the minimum cost" do
+          expect(subject[:cost]).to eq(minimum_cost)
+        end
+      end
+
+      context "when minimum cost zero" do
+        let(:minimum_cost) { 0 }
+
+        it "returns the usage cost" do
+          expect(subject[:cost]).to be_within(0.0001).of(
+            usage_cost
+          )
+        end
+      end
+    end
+
+    context "discounts handling" do
+      let(:minimum_cost) { 0 }
+      let(:schedule_rule) do
+        product.schedule_rules.destroy_all
+        create(:schedule_rule, product:)
+      end
+
+      context "when there's a discount" do
+        let(:discount_percent) { 20 }
+
+        before do
+          schedule_rule.price_group_discounts.destroy_all
+          schedule_rule.price_group_discounts.create!(
+            discount_percent:,
+            price_group:,
+          )
+        end
+
+        it "applies the discount" do
+          expect(subject[:cost]).to be < usage_cost
+        end
+      end
+
+      context "when there's no discount" do
+        it "returns the usage cost" do
+          expect(subject[:cost]).to be_within(0.0001).of(
+            usage_cost
+          )
+        end
+      end
+    end
+  end
+
   context "when product has schedule rules pricing mode" do
     let(:product) { create(:setup_instrument, skip_schedule_rules: true) }
     let(:price_group) { create(:price_group) }
@@ -23,6 +96,8 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
 
     describe "#calculate" do
       subject(:costs) { calculator.calculate(start_at, end_at) }
+
+      it_behaves_like "handles minimum cost and discounts"
 
       describe "with no subsidies" do
         let(:options) { { usage_rate: 60 } }
@@ -248,7 +323,7 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
           end
 
           it "calls the correct strategy" do
-            expect(calculator_strategy).to be PricePolicies::Strategy::PerMinute
+            expect(calculator_strategy).to be PricePolicies::Strategy::SteppedRate
           end
         end
 
@@ -364,6 +439,19 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
           expect(calculator.calculate(start_at, end_at)[:cost]).to eq(562.5)
           expect(calculator.calculate(start_at, end_at)[:subsidy].round(4)).to eq(123.75)
         end
+      end
+
+      describe "minimum_cost and discounts" do
+        before do
+          create(
+            :duration_rate,
+            price_policy:,
+            min_duration_hours: 1,
+            rate: usage_rate - 2,
+          )
+        end
+
+        it_behaves_like "handles minimum cost and discounts"
       end
     end
 
@@ -499,7 +587,7 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
 
       context "with no duration rates set" do
         it "falls back to the per-minute strategy" do
-          expect(calculator_strategy).to be PricePolicies::Strategy::PerMinute
+          expect(calculator_strategy).to be PricePolicies::Strategy::SteppedRate
         end
 
         it { is_expected.to eq(cost: 360, subsidy: 90) }

--- a/spec/services/price_policies/time_based_price_calculator_spec.rb
+++ b/spec/services/price_policies/time_based_price_calculator_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
     let(:usage_cost) do
       duration * usage_rate / 60.minutes
     end
-    let(:subject) { calculator.calculate(start_at:, end_at:) }
+    subject { calculator.calculate(start_at:, end_at:) }
 
     before do
       price_group.price_group_discounts.update_all(discount_percent: 0)
@@ -507,7 +507,7 @@ RSpec.describe PricePolicies::TimeBasedPriceCalculator do
   end
 
   context "when instrument has daily rate pricing" do
-    let(:subject) { calculator.calculate(start_at:, end_at:) }
+    subject { calculator.calculate(start_at:, end_at:) }
     let(:product) do
       create(
         :setup_instrument,

--- a/spec/system/admin/creating_an_estimate_spec.rb
+++ b/spec/system/admin/creating_an_estimate_spec.rb
@@ -126,10 +126,12 @@ RSpec.describe(
     expect(page).to have_content item.name
     expect(page).to have_content ActionController::Base.helpers.number_to_currency(item_price_policy.unit_cost * 2) # 2 items
     expect(page).to have_content instrument.name
-    expect(page).to have_content ActionController::Base.helpers.number_to_currency(2.0) # 2 * minimum_cost
+    expect(page).to have_content ActionController::Base.helpers.number_to_currency(instrument_price_policy.usage_rate * 180) # 1.5 hours * 2 = 3 hours
     expect(page).to have_content "#{other_item.name} (#{other_facility.name})"
     expect(page).to have_content ActionController::Base.helpers.number_to_currency(other_item_price_policy.unit_cost) # 1 item
-    total = other_item_price_policy.unit_cost + (item_price_policy.unit_cost * 2) + 2.0
+    total = other_item_price_policy.unit_cost +
+            (item_price_policy.unit_cost * 2) +
+            (instrument_price_policy.usage_rate * 180)
     expect(page).to have_content ActionController::Base.helpers.number_to_currency(total)
   end
 

--- a/spec/system/admin/creating_an_estimate_spec.rb
+++ b/spec/system/admin/creating_an_estimate_spec.rb
@@ -126,12 +126,10 @@ RSpec.describe(
     expect(page).to have_content item.name
     expect(page).to have_content ActionController::Base.helpers.number_to_currency(item_price_policy.unit_cost * 2) # 2 items
     expect(page).to have_content instrument.name
-    expect(page).to have_content ActionController::Base.helpers.number_to_currency(instrument_price_policy.usage_rate * 180) # 1.5 hours * 2 = 3 hours
+    expect(page).to have_content ActionController::Base.helpers.number_to_currency(2.0) # 2 * minimum_cost
     expect(page).to have_content "#{other_item.name} (#{other_facility.name})"
     expect(page).to have_content ActionController::Base.helpers.number_to_currency(other_item_price_policy.unit_cost) # 1 item
-    total = other_item_price_policy.unit_cost +
-            (item_price_policy.unit_cost * 2) +
-            (instrument_price_policy.usage_rate * 180)
+    total = other_item_price_policy.unit_cost + (item_price_policy.unit_cost * 2) + 2.0
     expect(page).to have_content ActionController::Base.helpers.number_to_currency(total)
   end
 

--- a/vendor/engines/secure_rooms/app/models/secure_room_price_policy.rb
+++ b/vendor/engines/secure_rooms/app/models/secure_room_price_policy.rb
@@ -14,7 +14,7 @@ class SecureRoomPricePolicy < PricePolicy
     exit_at = order_detail.occupancy.exit_at
     return unless entry_at && exit_at
 
-    calculator.calculate(entry_at, exit_at)
+    calculator.calculate(start_at: entry_at, end_at: exit_at)
   end
 
   def charge_for


### PR DESCRIPTION
# Notes

Consider discounts and minimum cost when calculating stepped billing.

Changes:
- Move discount and minimum cost handling to base strategy class
- Unify raw duration and (end - start) duration cases
- Unify estimate and non-estimate calculations
- `PricePolicies::Strategy::PerMinute` logic is included in `PricePolicies::Strategy::SteppedRate`, might be worth just keeping the latter down the road

[NU-498 | Stepped billing fixes](https://universe-of-universities.atlassian.net/browse/NU-498)