### PR TITLE
[OSU-243] Estimates: download as PDF

### DIFF
--- a/app/controllers/facility_accounts_controller.rb
+++ b/app/controllers/facility_accounts_controller.rb
@@ -105,7 +105,7 @@ class FacilityAccountsController < ApplicationController
 
     respond_to do |format|
       format.pdf do
-        @statement_pdf = StatementPdfFactory.instance(@statement, download: true)
+        @statement_pdf = StatementPdfFactory.instance(@statement)
         render "statements/show"
       end
     end

--- a/app/controllers/facility_estimates_controller.rb
+++ b/app/controllers/facility_estimates_controller.rb
@@ -38,6 +38,11 @@ class FacilityEstimatesController < ApplicationController
                   type: "text/csv",
                   disposition: "attachment"
       end
+
+      if EstimatePdfFactory.defined?
+        @estimate_pdf = EstimatePdfFactory.build(@estimate)
+        format.pdf
+      end
     end
   end
 

--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -26,7 +26,7 @@ class StatementsController < ApplicationController
 
     respond_to do |format|
       format.pdf do
-        @statement_pdf = StatementPdfFactory.instance(@statement, download: true)
+        @statement_pdf = StatementPdfFactory.instance(@statement)
         render action: "show"
       end
     end

--- a/app/lib/estimate_pdf_factory.rb
+++ b/app/lib/estimate_pdf_factory.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class EstimatePdfFactory
+  def self.build(...)
+    klass.new(...)
+  end
+
+  def self.defined?
+    klass.present?
+  end
+
+  private_class_method def self.klass
+    Settings.dig(:estimate_pdf, :class_name)&.constantize
+  end
+end

--- a/app/presenters/estimate_detail_presenter.rb
+++ b/app/presenters/estimate_detail_presenter.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class EstimateDetailPresenter < SimpleDelegator
+  include ActionView::Helpers::NumberHelper
+
+  def product_display
+    parts = [product.name]
+
+    if product.facility != estimate.facility
+      parts << "(#{product.facility.name})"
+    end
+
+    parts.join(" ")
+  end
+
+  def duration_display
+    if duration_mins?
+      duration
+    elsif duration_days?
+      [
+        duration,
+        EstimateDetail.human_attribute_name(
+          "duration_unit.days",
+          count: duration,
+        ),
+      ].join(" ")
+    end
+  end
+
+  def unit_cost_disaply
+    number_to_currency(price_policy&.unit_net_cost)
+  end
+
+  def cost_display
+    number_to_currency(cost)
+  end
+
+  def duration_mins?
+    duration_unit == "mins"
+  end
+
+  def duration_days?
+    duration_unit == "days"
+  end
+end

--- a/app/presenters/estimate_detail_presenter.rb
+++ b/app/presenters/estimate_detail_presenter.rb
@@ -27,7 +27,7 @@ class EstimateDetailPresenter < SimpleDelegator
     end
   end
 
-  def unit_cost_disaply
+  def unit_cost_display
     number_to_currency(price_policy&.unit_net_cost)
   end
 

--- a/app/support/concerns/orders_pdf.rb
+++ b/app/support/concerns/orders_pdf.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module OrdersPdf
+  include ActionView::Helpers::NumberHelper
+  include DateHelper
+
+  LABEL_ROW_STYLE = {
+    font_style: :bold,
+    background_color: "cccccc",
+  }.freeze
+
+  def generate(_pdf)
+    raise NotImplementedError
+  end
+
+  def filename
+    raise NotImplementedError
+  end
+
+  def render
+    pdf = Prawn::Document.new(prawn_options)
+    PdfFontHelper.set_fonts(pdf)
+    generate(pdf)
+    pdf.render
+  end
+
+  def prawn_options
+    {
+      left_margin: 50,
+      right_margin: 50,
+      top_margin: 50,
+      bottom_margin: 75,
+      page_size: "LETTER",
+    }
+  end
+
+  def normalize_whitespace(text)
+    WhitespaceNormalizer.normalize(text)
+  end
+end

--- a/app/support/concerns/orders_pdf_helper.rb
+++ b/app/support/concerns/orders_pdf_helper.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+##
+# Common sections sed for estimates and statements pdfs.
+#
+# Assumes `facility` reader method is defined.
+module OrdersPdfHelper
+  def generate_facility_header(pdf)
+    pdf.text facility.to_s, size: 20, style: :bold
+  end
+
+  def generate_document_footer(pdf)
+    pdf.number_pages "Page <page> of <total>", at: [0, -15]
+  end
+
+  def generate_contact_info(pdf)
+    pdf.text facility.address if facility.address
+    pdf.move_down(10)
+
+    %w(phone_number fax_number email).each do |contact_field|
+      field_value = facility.send(contact_field.to_sym)
+      next if field_value.blank?
+      pdf.text "<b>#{contact_field.titleize}:</b> #{field_value}", inline_format: true
+    end
+  end
+
+end

--- a/app/support/concerns/orders_pdf_helper.rb
+++ b/app/support/concerns/orders_pdf_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 ##
-# Common sections sed for estimates and statements pdfs.
+# Common sections for estimates and statements pdfs.
 #
 # Assumes `facility` reader method is defined.
 module OrdersPdfHelper
@@ -23,5 +23,4 @@ module OrdersPdfHelper
       pdf.text "<b>#{contact_field.titleize}:</b> #{field_value}", inline_format: true
     end
   end
-
 end

--- a/app/support/estimate_pdf.rb
+++ b/app/support/estimate_pdf.rb
@@ -13,7 +13,7 @@ class EstimatePdf
 
   def filename
     I18n.t(
-      "facility_estimate.pdf.filename",
+      "facility_estimates.pdf.filename",
       id: estimate.id,
       facility: facility.abbreviation.gsub(/\s+/, "_"),
     )

--- a/app/support/estimate_pdf.rb
+++ b/app/support/estimate_pdf.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class EstimatePdf
+  include OrdersPdf
+
+  attr_reader :estimate
+
+  delegate :facility, to: :estimate
+
+  def initialize(estimate)
+    @estimate = estimate
+  end
+
+  def filename
+    I18n.t(
+      "facility_estimate.pdf.filename",
+      id: estimate.id,
+      facility: facility.abbreviation.gsub(/\s+/, "_"),
+    )
+  end
+end

--- a/app/support/example_estimate_pdf.rb
+++ b/app/support/example_estimate_pdf.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+class ExampleEstimatePdf < EstimatePdf
+  include OrdersPdfHelper
+
+  def generate(pdf)
+    generate_facility_header(pdf)
+    generate_document_header(pdf)
+    generate_contact_info(pdf) if facility.has_contact_info?
+
+    generate_order_detail_rows(pdf)
+
+    generate_document_footer(pdf)
+  end
+
+  private
+
+  def generate_document_header(pdf)
+    pdf.text "Estimate ##{estimate.id}", size: 15
+    pdf.move_down 10
+
+    pdf.font_size = 10.5
+
+    [
+      "<b>Creation Date:</b> #{I18n.l(estimate.created_at)}",
+      "<b>Expire Date:</b> #{I18n.l(estimate.expires_at)}",
+      "<b>Created for:</b> #{estimate.user_display_name}",
+      "<b>Note:</b> #{estimate.note}",
+    ].each do |line|
+      pdf.text line, inline_format: true
+    end
+    pdf.move_down(10)
+  end
+
+  def generate_order_detail_rows(pdf)
+    pdf.move_down(30)
+    pdf.table([estimate_detail_headers] + estimate_detail_rows, header: true, width: 510) do
+      row(0).style(LABEL_ROW_STYLE)
+      column(0).width = 200
+      column(1).width = 70
+      column(2).width = 70
+      column(3).width = 70
+      column(3).style(align: :right)
+      column(4).style(align: :right)
+    end
+
+    pdf.move_down 10
+    pdf.text(
+      "Total: #{number_to_currency(estimate.total_cost)}",
+      align: :right,
+      style: :bold,
+    )
+  end
+
+  def estimate_detail_headers
+    [
+      Product.model_name.human,
+      EstimateDetail.human_attribute_name(:quantity),
+      EstimateDetail.human_attribute_name(:duration),
+      EstimateDetail.human_attribute_name(:unit_cost),
+      EstimateDetail.human_attribute_name(:cost),
+    ]
+  end
+
+  def estimate_detail_rows
+    estimate.estimate_details.includes(:product).map do |estimate_detail|
+      estimate_detail_presenter = EstimateDetailPresenter.new(estimate_detail)
+
+      [
+        estimate_detail_presenter.product_display,
+        estimate_detail_presenter.quantity,
+        estimate_detail_presenter.duration_display,
+        estimate_detail_presenter.unit_cost_disaply,
+        estimate_detail_presenter.cost_display,
+      ]
+    end
+  end
+end

--- a/app/support/example_estimate_pdf.rb
+++ b/app/support/example_estimate_pdf.rb
@@ -21,13 +21,17 @@ class ExampleEstimatePdf < EstimatePdf
 
     pdf.font_size = 10.5
 
-    [
-      "<b>Creation Date:</b> #{I18n.l(estimate.created_at)}",
-      "<b>Expire Date:</b> #{I18n.l(estimate.expires_at)}",
-      "<b>Created for:</b> #{estimate.user_display_name}",
-      "<b>Note:</b> #{estimate.note}",
-    ].each do |line|
-      pdf.text line, inline_format: true
+    rows = [
+      [:created_at, I18n.l(estimate.created_at)],
+      [:expires_at, I18n.l(estimate.expires_at)],
+      [:user_display_name, estimate.user_display_name],
+    ]
+
+    rows << [:note, estimate.note] if estimate.note.present?
+
+    rows.each do |key, value|
+      label = Estimate.human_attribute_name(key)
+      pdf.text "<b>#{label}:</b> #{value}", inline_format: true
     end
     pdf.move_down(10)
   end

--- a/app/support/example_estimate_pdf.rb
+++ b/app/support/example_estimate_pdf.rb
@@ -74,7 +74,7 @@ class ExampleEstimatePdf < EstimatePdf
         estimate_detail_presenter.product_display,
         estimate_detail_presenter.quantity,
         estimate_detail_presenter.duration_display,
-        estimate_detail_presenter.unit_cost_disaply,
+        estimate_detail_presenter.unit_cost_display,
         estimate_detail_presenter.cost_display,
       ]
     end

--- a/app/support/example_statement_pdf.rb
+++ b/app/support/example_statement_pdf.rb
@@ -1,38 +1,27 @@
 # frozen_string_literal: true
 
 class ExampleStatementPdf < StatementPdf
+  include OrdersPdfHelper
 
   include TextHelpers::Translation
 
   def generate(pdf)
+    generate_facility_header(pdf)
+
     generate_document_header(pdf)
-    generate_contact_info(pdf) if @facility.has_contact_info?
-    generate_remittance_information(pdf) if @account.remittance_information.present?
+    generate_contact_info(pdf) if facility.has_contact_info?
+    generate_remittance_information(pdf) if account.remittance_information.present?
+
     generate_order_detail_rows(pdf)
+
     generate_document_footer(pdf)
   end
 
   private
 
-  def generate_contact_info(pdf)
-    pdf.text @facility.address if @facility.address
-    pdf.move_down(10)
-
-    %w(phone_number fax_number email).each do |contact_field|
-      field_value = @facility.send(contact_field.to_sym)
-      next if field_value.blank?
-      pdf.text "<b>#{contact_field.titleize}:</b> #{field_value}", inline_format: true
-    end
-  end
-
-  def generate_document_footer(pdf)
-    pdf.number_pages "Page <page> of <total>", at: [0, -15]
-  end
-
   def generate_document_header(pdf)
     pdf.font_size = 10.5
 
-    pdf.text @facility.to_s, size: 20, style: :bold
     pdf.text "Invoice ##{@statement.invoice_number}"
     pdf.text "Invoice Date: #{format_usa_date(@statement.invoice_date)}"
     pdf.text "Account: #{@account}"
@@ -68,7 +57,7 @@ class ExampleStatementPdf < StatementPdf
   def order_detail_rows
     @statement.order_details.includes(:product).order(fulfilled_at: :desc).map do |order_detail|
       [
-        format_usa_datetime(order_detail.fulfilled_at),
+        I18n.l(order_detail.fulfilled_at),
         "##{order_detail}: #{order_detail.product}" + (order_detail.note.blank? ? "" : "\n#{normalize_whitespace(order_detail.note)}"),
         OrderDetailPresenter.new(order_detail).wrapped_quantity,
         number_to_currency(order_detail.actual_total),

--- a/app/support/statement_pdf.rb
+++ b/app/support/statement_pdf.rb
@@ -10,7 +10,7 @@ class StatementPdf
   def initialize(statement)
     @statement = statement
     # TODO: remove account and facility instance variables in favour
-    # of delgate methods. Requires downstream repos to be updated
+    # of delegate methods. Requires downstream repos to be updated
     @account = statement.account
     @facility = statement.facility
   end

--- a/app/support/statement_pdf.rb
+++ b/app/support/statement_pdf.rb
@@ -5,8 +5,12 @@ class StatementPdf
 
   attr_reader :statement
 
+  delegate :facility, :account, to: :statement
+
   def initialize(statement)
     @statement = statement
+    # TODO: remove account and facility instance variables in favour
+    # of delgate methods. Requires downstream repos to be updated
     @account = statement.account
     @facility = statement.facility
   end

--- a/app/support/statement_pdf.rb
+++ b/app/support/statement_pdf.rb
@@ -1,59 +1,22 @@
 # frozen_string_literal: true
 
 class StatementPdf
+  include OrdersPdf
 
-  include ActionView::Helpers::NumberHelper
-  include DateHelper
+  attr_reader :statement
 
-  LABEL_ROW_STYLE = { font_style: :bold, background_color: "cccccc" }.freeze
-
-  DEFAULT_OPTIONS = {
-    left_margin: 50,
-    right_margin: 50,
-    top_margin: 50,
-    bottom_margin: 75,
-    page_size: "LETTER", # "A4" is now the default size in prawn-rails
-  }.freeze
-
-  def initialize(statement, download: false)
+  def initialize(statement)
     @statement = statement
     @account = statement.account
     @facility = statement.facility
-    @download = download
-  end
-
-  def generate(_pdf)
-    raise NotImplementedError
-  end
-
-  def render
-    pdf = Prawn::Document.new(options)
-    PdfFontHelper.set_fonts(pdf)
-    generate(pdf)
-    pdf.render
-  end
-
-  def download?
-    @download
-  end
-
-  def normalize_whitespace(text)
-    WhitespaceNormalizer.normalize(text)
   end
 
   def filename
-    date = I18n.l(@statement.invoice_date, format: :usa_filename_safe)
-    I18n.t("statements.pdf.filename", date: date,
-                                      facility: @facility.abbreviation.gsub(/\s+/, "_"),
-                                      invoice_number: @statement.invoice_number)
+    I18n.t(
+      "statements.pdf.filename",
+      date: I18n.l(@statement.invoice_date, format: :filename_safe),
+      facility: @facility.abbreviation.gsub(/\s+/, "_"),
+      invoice_number: @statement.invoice_number,
+    )
   end
-
-  def options
-    if download?
-      DEFAULT_OPTIONS.merge(filename: filename, disposition: "attachment")
-    else
-      DEFAULT_OPTIONS.dup
-    end
-  end
-
 end

--- a/app/views/facility_estimates/show.html.haml
+++ b/app/views/facility_estimates/show.html.haml
@@ -6,11 +6,16 @@
 
 %h2= header
 
-.pull-right
-  = link_to t(".download_csv"), facility_estimate_path(current_facility, @estimate, format: :csv)
-  = link_to t(".duplicate"),
-    duplicate_facility_estimate_path(current_facility, @estimate),
-    method: :post, class: "btn btn-primary margin_x"
+.row
+  .pull-right
+    = link_to t(".download_csv"),
+      facility_estimate_path(current_facility, @estimate, format: :csv),
+      class: "btn btn-default"
+
+    - if EstimatePdfFactory.defined?
+      = link_to t(".download_pdf"),
+        facility_estimate_path(current_facility, @estimate, format: :pdf),
+        class: "btn btn-default"
 
 .container.banner-list
   .row
@@ -34,22 +39,14 @@
         %th.text-right= EstimateDetail.human_attribute_name(:cost)
     %tbody
       - @estimate.estimate_details.includes(:price_policy).each do |estimate_detail|
-        - displayTime = estimate_detail.duration_unit == "mins"
+        - estimate_detail_presenter = EstimateDetailPresenter.new(estimate_detail)
         %tr
-          %td
-            - product = estimate_detail.product
-            - product_name = product.name
-            - if product.facility != current_facility
-              - product_name = "#{product_name} (#{product.facility.name})"
-            = product_name
-          %td= estimate_detail.quantity
-          %td{ class: displayTime ? "timeinput" : "" }
-            - if displayTime
-              = estimate_detail.duration
-            - elsif estimate_detail.duration_unit.present?
-              = "#{estimate_detail.duration} #{t(".days")}"
-          %td.currency= number_to_currency(estimate_detail.price_policy&.unit_net_cost)
-          %td.currency= number_to_currency(estimate_detail.cost)
+          %td= estimate_detail_presenter.product_display
+          %td= estimate_detail_presenter.quantity
+          %td{ class: estimate_detail_presenter.duration_mins? ? "timeinput" : "" }
+            = estimate_detail_presenter.duration_display
+          %td.currency= estimate_detail_presenter.unit_cost_disaply
+          %td.currency= estimate_detail_presenter.cost_display
     %tfoot
       %tr
         %td{ colspan: 4 }
@@ -60,5 +57,8 @@
     = t(".updated_at_notice", updated_at: I18n.l(@estimate.estimate_details.maximum(:updated_at), format: :usa))
 
 .pull-right
+  = link_to t(".duplicate"),
+    duplicate_facility_estimate_path(current_facility, @estimate),
+    method: :post, class: "btn btn-primary"
   = link_to t(".recalculate"), recalculate_facility_estimate_path(current_facility, @estimate), method: :post, class: "btn btn-primary"
   = link_to t(".edit"), edit_facility_estimate_path(current_facility, @estimate), class: "btn btn-default"

--- a/app/views/facility_estimates/show.html.haml
+++ b/app/views/facility_estimates/show.html.haml
@@ -45,7 +45,7 @@
           %td= estimate_detail_presenter.quantity
           %td{ class: estimate_detail_presenter.duration_mins? ? "timeinput" : "" }
             = estimate_detail_presenter.duration_display
-          %td.currency= estimate_detail_presenter.unit_cost_disaply
+          %td.currency= estimate_detail_presenter.unit_cost_display
           %td.currency= estimate_detail_presenter.cost_display
     %tfoot
       %tr

--- a/app/views/facility_estimates/show.pdf.prawn
+++ b/app/views/facility_estimates/show.pdf.prawn
@@ -1,0 +1,6 @@
+prawn_document(**@estimate_pdf.prawn_options,
+              filename: @estimate_pdf.filename,
+              disposition: "attachment") do |pdf|
+  PdfFontHelper.set_fonts(pdf)
+  @estimate_pdf.generate(pdf)
+end

--- a/app/views/statements/show.pdf.prawn
+++ b/app/views/statements/show.pdf.prawn
@@ -1,4 +1,6 @@
-prawn_document @statement_pdf.options do |pdf|
+prawn_document(**@statement_pdf.prawn_options,
+              filename: @statement_pdf.filename,
+              disposition: :attachment) do |pdf|
   PdfFontHelper.set_fonts(pdf)
   @statement_pdf.generate(pdf)
 end

--- a/app/views/statements/show.pdf.prawn
+++ b/app/views/statements/show.pdf.prawn
@@ -1,6 +1,6 @@
 prawn_document(**@statement_pdf.prawn_options,
               filename: @statement_pdf.filename,
-              disposition: :attachment) do |pdf|
+              disposition: "attachment") do |pdf|
   PdfFontHelper.set_fonts(pdf)
   @statement_pdf.generate(pdf)
 end

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -271,6 +271,10 @@ en:
         unit_cost: Unit Price
         duration: Duration
         duration_mins: Duration (hh:mm)
+      estimate_detail/duration_unit:
+        days:
+          one: Day
+          other: Days
       schedule_rule:
         start_time: Start Time
         end_time: End Time

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,7 @@ en:
       default: "%m/%d/%Y"
       journal_line_reference: "%Y%m%d"
       timeline_navigation: "%a, %B %e, %Y"
+      filename_safe: "%m-%d-%Y"
       usa: "%m/%d/%Y"
       usa_filename_safe: "%m-%d-%Y"
       ymd: "%Y-%m-%d"
@@ -598,6 +599,8 @@ en:
     duplicate:
       success: Estimate successfully duplicated
       error: There was an error duplicating the estimate
+    pdf:
+      filename: "estimate-%{id}-%{facility}.pdf"
 
   facility_order_details:
     edit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -600,7 +600,7 @@ en:
       success: Estimate successfully duplicated
       error: There was an error duplicating the estimate
     pdf:
-      filename: "estimate-%{id}-%{facility}.pdf"
+      filename: "%{facility}_estimate_%{id}.pdf"
 
   facility_order_details:
     edit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,7 +16,6 @@ en:
       timeline_navigation: "%a, %B %e, %Y"
       filename_safe: "%m-%d-%Y"
       usa: "%m/%d/%Y"
-      usa_filename_safe: "%m-%d-%Y"
       ymd: "%Y-%m-%d"
 
   time:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -582,8 +582,8 @@ en:
       head: Add Estimate
       or: "or"
     show:
-      days: days
       download_csv: Download CSV
+      download_pdf: Download PDF
       recalculate: Recalculate
       duplicate: Duplicate Estimate
       updated_at_notice: "Prices last updated: %{updated_at}"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -48,6 +48,9 @@ statement_pdf:
   class_name: ExampleStatementPdf
   font_name: Roboto
 
+estimate_pdf:
+  class_name: ExampleEstimatePdf
+
 validator:
   class_name: "AccountValidator::ValidatorDefault"
   test:

--- a/spec/requests/facility_estimates_spec.rb
+++ b/spec/requests/facility_estimates_spec.rb
@@ -74,4 +74,39 @@ RSpec.describe "FacilityEstimatesController" do
       include_examples "products from all facilities"
     end
   end
+
+  describe "show" do
+    let(:facility) { create(:setup_facility) }
+    let(:estimate) { create(:estimate, facility:) }
+    let(:action) do
+      -> { get facility_estimate_path(facility, estimate) }
+    end
+
+    before { login_as create(:user, :administrator) }
+
+    it "includes download links" do
+      action.call
+
+      expect(response).to have_http_status(:ok)
+      expect(page).to have_text("Download CSV")
+      expect(page).to have_text("Download PDF") if EstimatePdfFactory.defined?
+    end
+
+    context "when format is pdf" do
+      let(:action) do
+        -> { get facility_estimate_path(facility, estimate, format: :pdf) }
+      end
+
+      before do
+        skip("Estimate Pdf not defined") unless EstimatePdfFactory.defined?
+      end
+
+      it "responds with a pdf" do
+        action.call
+
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to include("application/pdf")
+      end
+    end
+  end
 end

--- a/spec/services/estimate_pdf_spec.rb
+++ b/spec/services/estimate_pdf_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EstimatePdf do
+  before do
+    skip("Estimate Pdf not defined") unless EstimatePdfFactory.defined?
+  end
+
+  let(:facility) { create(:setup_facility) }
+  let(:product) { create(:setup_item, facility:) }
+  let(:price_group) { product.price_policies.first.price_group }
+  let(:estimate) { create(:estimate, facility:, price_group:) }
+  let(:estimate_pdf) { EstimatePdfFactory.build(estimate) }
+  let(:pdf_content) { estimate_pdf.render }
+
+  before do
+    create(:estimate_detail, estimate:, product:)
+  end
+
+  it "renders pdf correctly" do
+    expect(pdf_content).to be_present
+    expect(pdf_content).to match(/\A%PDF-1.\d+\b/)
+  end
+end


### PR DESCRIPTION
# Notes

Download estimates as PDF. The download link is show only if the class to generate the PDF is defined.

[OSU-243 | Download a estimate using the invoice template](https://universe-of-universities.atlassian.net/browse/OSU-243)

# Screenshot

Estimate show page:

<img width="1307" height="648" alt="Captura desde 2026-08-31 15-13-27" src="https://github.com/user-attachments/assets/81f31845-a00e-473b-a0e1-7b40eb81c7b9" />

Example PDF:

<img width="804" height="543" alt="Captura desde 2026-09-01 15-08-36" src="https://github.com/user-attachments/assets/9e5043ba-27e3-4444-923d-535a0f414471" />


