### PR TITLE
[OSU-242] Public estimates

### DIFF
--- a/app/controllers/public_estimates_controller.rb
+++ b/app/controllers/public_estimates_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class PublicEstimatesController < ApplicationController
+
+  skip_before_action :authenticate_user!
+
+  def show
+    @facilities = Facility.active.alphabetized
+    @facility = @facilities.find_by(id: params[:facility_id])
+    @products = @facility ? public_products : Product.none
+    @price_group = PriceGroup.for_public_estimate(
+      customer_type: params[:customer_type],
+      profit_status: params[:profit_status],
+    )
+    @estimate = build_estimate if @price_group && requested_quantities.any?
+    @total = @estimate.estimate_details.sum { |estimate_detail| estimate_detail.cost || 0 } if @estimate
+  end
+
+  private
+
+  def public_products
+    @facility.products.active.available_for_estimates.where.not(type: "Bundle").alphabetized
+  end
+
+  def requested_quantities
+    @requested_quantities ||=
+      params[:quantities].presence&.to_unsafe_h&.select { |_id, quantity| quantity.to_i.positive? } || {}
+  end
+
+  def build_estimate
+    estimate = Estimate.new(facility: @facility, price_group: @price_group)
+
+    requested_quantities.each do |product_id, quantity|
+      product = @products.find_by(id: product_id)
+      next if product.blank?
+
+      estimate.estimate_details.build(
+        product:,
+        quantity: quantity.to_i,
+        duration: params.dig(:durations, product_id).presence,
+      )
+    end
+
+    estimate.estimate_details.each(&:assign_price_policy_and_cost)
+    estimate
+  end
+
+end

--- a/app/controllers/public_estimates_controller.rb
+++ b/app/controllers/public_estimates_controller.rb
@@ -8,15 +8,32 @@ class PublicEstimatesController < ApplicationController
     @facilities = Facility.active.alphabetized
     @facility = @facilities.find_by(id: params[:facility_id])
     @products = @facility ? public_products : Product.none
-    @price_group = PriceGroup.for_public_estimate(
-      customer_type: params[:customer_type],
-      profit_status: params[:profit_status],
-    )
+    @customer_type_options = customer_type_options
+    @price_group = PriceGroup.for_public_estimate(params[:customer_type] || "internal")
+    @priced_product_ids = priced_product_ids
     @estimate = build_estimate if @price_group && requested_quantities.any?
     @total = @estimate.estimate_details.sum { |estimate_detail| estimate_detail.cost || 0 } if @estimate
   end
 
   private
+
+  def customer_type_options
+    return [[t(".internal"), "internal"], [t(".external"), "external"]] if PriceGroup.secondary_external.blank?
+
+    [
+      [t(".internal"), "internal"],
+      [t(".external_for_profit"), "external"],
+      [t(".external_non_profit"), "external_non_profit"],
+    ]
+  end
+
+  def priced_product_ids
+    return [] if @price_group.blank? || @products.empty?
+
+    PricePolicy.current_for_date(Time.current).purchaseable
+               .where(product_id: @products.map(&:id), price_group: @price_group)
+               .distinct.pluck(:product_id)
+  end
 
   def public_products
     @facility.products.active.available_for_estimates.where.not(type: "Bundle").alphabetized
@@ -38,6 +55,7 @@ class PublicEstimatesController < ApplicationController
         product:,
         quantity: quantity.to_i,
         duration: params.dig(:durations, product_id).presence,
+        duration_unit: product.time_unit,
       )
     end
 

--- a/app/controllers/public_estimates_controller.rb
+++ b/app/controllers/public_estimates_controller.rb
@@ -7,8 +7,9 @@ class PublicEstimatesController < ApplicationController
   def show
     @facilities = Facility.active.alphabetized
     @facility = @facilities.find_by(id: params[:facility_id])
+    @customer_type = customer_type
     @customer_type_options = customer_type_options
-    @price_group = PriceGroup.for_public_estimate(customer_type)
+    @price_group = PriceGroup.for_public_estimate(@customer_type)
     @products = @facility ? priced_products : Product.none
     @estimate = build_estimate if @price_group && requested_quantities.any?
     @total = @estimate.estimate_details.sum { |estimate_detail| estimate_detail.cost || 0 } if @estimate

--- a/app/controllers/public_estimates_controller.rb
+++ b/app/controllers/public_estimates_controller.rb
@@ -7,54 +7,68 @@ class PublicEstimatesController < ApplicationController
   def show
     @facilities = Facility.active.alphabetized
     @facility = @facilities.find_by(id: params[:facility_id])
-    @products = @facility ? public_products : Product.none
     @customer_type_options = customer_type_options
-    @price_group = PriceGroup.for_public_estimate(params[:customer_type] || "internal")
-    @priced_product_ids = priced_product_ids
+    @price_group = PriceGroup.for_public_estimate(customer_type)
+    @products = @facility ? priced_products : Product.none
     @estimate = build_estimate if @price_group && requested_quantities.any?
     @total = @estimate.estimate_details.sum { |estimate_detail| estimate_detail.cost || 0 } if @estimate
   end
 
   private
 
+  def customer_types
+    Settings.public_estimates.customer_types.map(&:to_s)
+  end
+
+  def customer_type
+    customer_types.include?(params[:customer_type]) ? params[:customer_type] : customer_types.first
+  end
+
   def customer_type_options
-    return [[t(".internal"), "internal"], [t(".external"), "external"]] if PriceGroup.secondary_external.blank?
-
-    [
-      [t(".internal"), "internal"],
-      [t(".external_for_profit"), "external"],
-      [t(".external_non_profit"), "external_non_profit"],
-    ]
+    customer_types.map { |key| [t(".customer_types.#{key}"), key] }
   end
 
-  def priced_product_ids
-    return [] if @price_group.blank? || @products.empty?
+  def priced_products
+    return Product.none if @price_group.blank?
 
-    PricePolicy.current_for_date(Time.current).purchaseable
-               .where(product_id: @products.map(&:id), price_group: @price_group)
-               .distinct.pluck(:product_id)
+    facility_products.where(
+      id: PricePolicy.current_for_date(Time.current).purchaseable
+                     .where(price_group: @price_group).select(:product_id),
+    )
   end
 
-  def public_products
+  def facility_products
     @facility.products.active.available_for_estimates.where.not(type: "Bundle").alphabetized
   end
 
   def requested_quantities
-    @requested_quantities ||=
-      params[:quantities].presence&.to_unsafe_h&.select { |_id, quantity| quantity.to_i.positive? } || {}
+    @requested_quantities ||= permitted_product_values(:quantities).select { |_id, quantity| quantity.to_i.positive? }
+  end
+
+  def requested_durations
+    @requested_durations ||= permitted_product_values(:durations)
+  end
+
+  def permitted_product_values(key)
+    values = params[key]
+    return {} unless values.is_a?(ActionController::Parameters)
+
+    values.permit(@products.map { |product| product.id.to_s }).to_h
   end
 
   def build_estimate
     estimate = Estimate.new(facility: @facility, price_group: @price_group)
 
+    products = @products.where(id: requested_quantities.keys).index_by { |product| product.id.to_s }
+
     requested_quantities.each do |product_id, quantity|
-      product = @products.find_by(id: product_id)
+      product = products[product_id]
       next if product.blank?
 
       estimate.estimate_details.build(
         product:,
         quantity: quantity.to_i,
-        duration: params.dig(:durations, product_id).presence,
+        duration: requested_durations[product_id].presence,
         duration_unit: product.time_unit,
       )
     end

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -38,6 +38,19 @@ class PriceGroup < ApplicationRecord
     globals.find_by(name: Settings.price_group.name.external)
   end
 
+  def self.secondary_external
+    return if Settings.price_group.name.external_2.blank?
+
+    globals.find_by(name: Settings.price_group.name.external_2)
+  end
+
+  def self.for_public_estimate(customer_type:, profit_status: nil)
+    return base if customer_type == "internal"
+    return secondary_external if profit_status == "non_profit" && secondary_external
+
+    external
+  end
+
   def self.nonbillable
     base
   end

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -44,11 +44,12 @@ class PriceGroup < ApplicationRecord
     globals.find_by(name: Settings.price_group.name.external_2)
   end
 
-  def self.for_public_estimate(customer_type:, profit_status: nil)
-    return base if customer_type == "internal"
-    return secondary_external if profit_status == "non_profit" && secondary_external
-
-    external
+  def self.for_public_estimate(customer_type)
+    case customer_type
+    when "internal" then base
+    when "external_non_profit" then secondary_external || external
+    else external
+    end
   end
 
   def self.nonbillable

--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -38,18 +38,11 @@ class PriceGroup < ApplicationRecord
     globals.find_by(name: Settings.price_group.name.external)
   end
 
-  def self.secondary_external
-    return if Settings.price_group.name.external_2.blank?
-
-    globals.find_by(name: Settings.price_group.name.external_2)
-  end
-
   def self.for_public_estimate(customer_type)
-    case customer_type
-    when "internal" then base
-    when "external_non_profit" then secondary_external || external
-    else external
-    end
+    name = Settings.price_group.name.to_h[customer_type.to_s.to_sym]
+    return if name.blank?
+
+    globals.find_by(name:)
   end
 
   def self.nonbillable

--- a/app/views/public_estimates/show.html.haml
+++ b/app/views/public_estimates/show.html.haml
@@ -4,19 +4,13 @@
 %p= t(".intro")
 
 = form_tag estimate_path, method: :get do
-  .row
-    .col-md-3
+  .inline-form-controls
+    %div
       = label_tag :customer_type, t(".customer_type")
-      = select_tag :customer_type, options_for_select([[t(".internal"), "internal"], [t(".external"), "external"]], params[:customer_type]), class: "form-control"
-    - if PriceGroup.secondary_external
-      .col-md-3
-        = label_tag :profit_status, t(".profit_status")
-        = select_tag :profit_status, options_for_select([[t(".for_profit"), "for_profit"], [t(".non_profit"), "non_profit"]], params[:profit_status]), class: "form-control"
-    .col-md-3
+      = select_tag :customer_type, options_for_select(@customer_type_options, params[:customer_type]), class: "form-control", onchange: "this.form.submit();"
+    .margin_x
       = label_tag :facility_id, Facility.model_name.human
-      = select_tag :facility_id, options_from_collection_for_select(@facilities, :id, :name, params[:facility_id]), include_blank: true, class: "form-control"
-    .col-md-3
-      = submit_tag t(".select_facility"), class: "btn btn-default", name: nil
+      = select_tag :facility_id, options_from_collection_for_select(@facilities, :id, :name, params[:facility_id]), include_blank: true, class: "form-control", onchange: "this.form.submit();"
 
   - if @facility.present?
     %h3= t(".choose_products")
@@ -30,11 +24,15 @@
         - @products.each do |product|
           %tr
             %td= product.name
-            %td= number_field_tag "quantities[#{product.id}]", params.dig(:quantities, product.id.to_s), min: 0, style: "width: 6em;"
-            %td
-              - if product.order_quantity_as_time? || product.is_a?(Instrument)
-                = number_field_tag "durations[#{product.id}]", params.dig(:durations, product.id.to_s), min: 1, style: "width: 6em;"
-    = submit_tag t(".calculate"), class: "btn btn-primary", name: nil
+            - if @priced_product_ids.include?(product.id)
+              %td= number_field_tag "quantities[#{product.id}]", params.dig(:quantities, product.id.to_s), min: 0, style: "width: 6em;"
+              %td
+                - if product.time_unit.present?
+                  = number_field_tag "durations[#{product.id}]", params.dig(:durations, product.id.to_s), min: 1, style: "width: 6em;"
+                  = EstimateDetail.human_attribute_name("duration_unit.#{product.time_unit}", count: 2)
+            - else
+              %td.text-muted{ colspan: 2 }= t(".no_public_rate")
+  = submit_tag t(".calculate"), class: "btn btn-primary", name: nil
 
 - if @estimate.present?
   %h3= t(".results")
@@ -43,13 +41,15 @@
       %tr
         %th= Product.model_name.human
         %th= EstimateDetail.human_attribute_name(:quantity)
+        %th= EstimateDetail.human_attribute_name(:duration)
         %th.text-right= EstimateDetail.human_attribute_name(:cost)
     %tbody
-      - @estimate.estimate_details.each do |estimate_detail|
+      - @estimate.estimate_details.map { |detail| EstimateDetailPresenter.new(detail) }.each do |estimate_detail|
         %tr
-          %td= estimate_detail.product.name
+          %td= estimate_detail.product_display
           %td= estimate_detail.quantity
-          %td.text-right= estimate_detail.cost ? number_to_currency(estimate_detail.cost) : t(".no_public_rate")
+          %td= estimate_detail.duration_display
+          %td.text-right= estimate_detail.cost ? estimate_detail.cost_display : t(".no_public_rate")
   .text-right
     %strong= t(".total")
     %span= number_to_currency(@total)

--- a/app/views/public_estimates/show.html.haml
+++ b/app/views/public_estimates/show.html.haml
@@ -1,0 +1,55 @@
+= content_for :h1 do
+  = t(".title")
+
+%p= t(".intro")
+
+= form_tag estimate_path, method: :get do
+  .row
+    .col-md-3
+      = label_tag :customer_type, t(".customer_type")
+      = select_tag :customer_type, options_for_select([[t(".internal"), "internal"], [t(".external"), "external"]], params[:customer_type]), class: "form-control"
+    - if PriceGroup.secondary_external
+      .col-md-3
+        = label_tag :profit_status, t(".profit_status")
+        = select_tag :profit_status, options_for_select([[t(".for_profit"), "for_profit"], [t(".non_profit"), "non_profit"]], params[:profit_status]), class: "form-control"
+    .col-md-3
+      = label_tag :facility_id, Facility.model_name.human
+      = select_tag :facility_id, options_from_collection_for_select(@facilities, :id, :name, params[:facility_id]), include_blank: true, class: "form-control"
+    .col-md-3
+      = submit_tag t(".select_facility"), class: "btn btn-default", name: nil
+
+  - if @facility.present?
+    %h3= t(".choose_products")
+    %table.table
+      %thead
+        %tr
+          %th= Product.model_name.human
+          %th= EstimateDetail.human_attribute_name(:quantity)
+          %th= EstimateDetail.human_attribute_name(:duration)
+      %tbody
+        - @products.each do |product|
+          %tr
+            %td= product.name
+            %td= number_field_tag "quantities[#{product.id}]", params.dig(:quantities, product.id.to_s), min: 0, style: "width: 6em;"
+            %td
+              - if product.order_quantity_as_time? || product.is_a?(Instrument)
+                = number_field_tag "durations[#{product.id}]", params.dig(:durations, product.id.to_s), min: 1, style: "width: 6em;"
+    = submit_tag t(".calculate"), class: "btn btn-primary", name: nil
+
+- if @estimate.present?
+  %h3= t(".results")
+  %table.table.table-striped
+    %thead
+      %tr
+        %th= Product.model_name.human
+        %th= EstimateDetail.human_attribute_name(:quantity)
+        %th.text-right= EstimateDetail.human_attribute_name(:cost)
+    %tbody
+      - @estimate.estimate_details.each do |estimate_detail|
+        %tr
+          %td= estimate_detail.product.name
+          %td= estimate_detail.quantity
+          %td.text-right= estimate_detail.cost ? number_to_currency(estimate_detail.cost) : t(".no_public_rate")
+  .text-right
+    %strong= t(".total")
+    %span= number_to_currency(@total)

--- a/app/views/public_estimates/show.html.haml
+++ b/app/views/public_estimates/show.html.haml
@@ -8,7 +8,7 @@
     .inline-form-controls
       %div
         = label_tag :customer_type, t(".customer_type")
-        = select_tag :customer_type, options_for_select(@customer_type_options, params[:customer_type]), class: "form-control", onchange: "this.form.submit();"
+        = select_tag :customer_type, options_for_select(@customer_type_options, @customer_type), class: "form-control", onchange: "this.form.submit();"
       .margin_x
         = label_tag :facility_id, Facility.model_name.human
         = select_tag :facility_id, options_from_collection_for_select(@facilities, :id, :name, params[:facility_id]), include_blank: true, class: "form-control", onchange: "this.form.submit();"
@@ -34,6 +34,13 @@
 
 - if @estimate.present?
   %h3= t(".results")
+  .show-for-print
+    %p
+      %strong= "#{t('.customer_type')}:"
+      = t(".customer_types.#{@customer_type}")
+    %p
+      %strong= "#{Facility.model_name.human}:"
+      = @facility.name
   %table.table.table-striped
     %thead
       %tr
@@ -51,3 +58,5 @@
   .text-right
     %strong= t(".total")
     %span= number_to_currency(@total)
+  .hide-from-print
+    = button_tag t(".print"), type: "button", class: "btn btn-default", onclick: "window.print();"

--- a/app/views/public_estimates/show.html.haml
+++ b/app/views/public_estimates/show.html.haml
@@ -4,35 +4,33 @@
 %p= t(".intro")
 
 = form_tag estimate_path, method: :get do
-  .inline-form-controls
-    %div
-      = label_tag :customer_type, t(".customer_type")
-      = select_tag :customer_type, options_for_select(@customer_type_options, params[:customer_type]), class: "form-control", onchange: "this.form.submit();"
-    .margin_x
-      = label_tag :facility_id, Facility.model_name.human
-      = select_tag :facility_id, options_from_collection_for_select(@facilities, :id, :name, params[:facility_id]), include_blank: true, class: "form-control", onchange: "this.form.submit();"
+  .hide-from-print
+    .inline-form-controls
+      %div
+        = label_tag :customer_type, t(".customer_type")
+        = select_tag :customer_type, options_for_select(@customer_type_options, params[:customer_type]), class: "form-control", onchange: "this.form.submit();"
+      .margin_x
+        = label_tag :facility_id, Facility.model_name.human
+        = select_tag :facility_id, options_from_collection_for_select(@facilities, :id, :name, params[:facility_id]), include_blank: true, class: "form-control", onchange: "this.form.submit();"
 
-  - if @facility.present?
-    %h3= t(".choose_products")
-    %table.table
-      %thead
-        %tr
-          %th= Product.model_name.human
-          %th= EstimateDetail.human_attribute_name(:quantity)
-          %th= EstimateDetail.human_attribute_name(:duration)
-      %tbody
-        - @products.each do |product|
+    - if @facility.present?
+      %h3= t(".choose_products")
+      %table.table
+        %thead
           %tr
-            %td= product.name
-            - if @priced_product_ids.include?(product.id)
+            %th= Product.model_name.human
+            %th= EstimateDetail.human_attribute_name(:quantity)
+            %th= EstimateDetail.human_attribute_name(:duration)
+        %tbody
+          - @products.each do |product|
+            %tr
+              %td= product.name
               %td= number_field_tag "quantities[#{product.id}]", params.dig(:quantities, product.id.to_s), min: 0, style: "width: 6em;"
               %td
                 - if product.time_unit.present?
                   = number_field_tag "durations[#{product.id}]", params.dig(:durations, product.id.to_s), min: 1, style: "width: 6em;"
                   = EstimateDetail.human_attribute_name("duration_unit.#{product.time_unit}", count: 2)
-            - else
-              %td.text-muted{ colspan: 2 }= t(".no_public_rate")
-  = submit_tag t(".calculate"), class: "btn btn-primary", name: nil
+      = submit_tag t(".calculate"), class: "btn btn-primary", name: nil
 
 - if @estimate.present?
   %h3= t(".results")

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -15,6 +15,7 @@
     - if session_user.nil?
       %ul.nav.navbar-nav.navbar-right.hide-from-print
         = render "/shared/support"
+        = render "/shared/public_estimate_link"
         %li= link_to t("pages.login"), :new_user_session
     - else
       -# collapsed at < 979px
@@ -28,6 +29,7 @@
             %li.navbar-text= "#{acting_user.full_name} (#{acting_user.username})"
             %li.divider-vertical
             = render "/shared/support"
+            = render "/shared/public_estimate_link"
             %li= link_to t("pages.cart"), :cart, class: "js--cart_count", data: { url: orders_cart_count_url }
           - else
             - if UserPreference.options_for(current_user).any?
@@ -40,6 +42,7 @@
               %li.divider-vertical
             -# .visible-with-nav is visible > 979px
             = render "/shared/support"
+            = render "/shared/public_estimate_link"
             %li.visible-with-nav= link_to t("pages.cart"), :cart, class: "js--cart_count", data: { url: orders_cart_count_url }
             %li.divider-vertical
             = render "shared/message_summary"

--- a/app/views/shared/_public_estimate_link.html.haml
+++ b/app/views/shared/_public_estimate_link.html.haml
@@ -1,0 +1,2 @@
+- if SettingsHelper.feature_on?(:public_estimates)
+  %li= link_to t("pages.public_estimate"), estimate_path

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -275,6 +275,9 @@ en:
         days:
           one: Day
           other: Days
+        mins:
+          one: Minute
+          other: Minutes
       schedule_rule:
         start_time: Start Time
         end_time: End Time

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -123,10 +123,8 @@ en:
       customer_type: I am
       internal: Internal
       external: External
-      profit_status: Organization type
-      for_profit: For-profit
-      non_profit: Non-profit
-      select_facility: Select facility
+      external_for_profit: External - for-profit
+      external_non_profit: External - non-profit
       choose_products: Choose products
       calculate: Calculate estimate
       results: Estimated cost

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,6 +106,7 @@ en:
     movable_transactions: My Movable Transactions
     notices: Notices
     support: Support
+    public_estimate: Get an Estimate
 
   affiliates:
     add: Add Affiliate
@@ -114,6 +115,23 @@ en:
     remove:
       confirm: "Really remove affiliate %{name}?"
       label: Remove
+
+  public_estimates:
+    show:
+      title: Estimate
+      intro: Estimate the cost of using our facilities. No account required.
+      customer_type: I am
+      internal: Internal
+      external: External
+      profit_status: Organization type
+      for_profit: For-profit
+      non_profit: Non-profit
+      select_facility: Select facility
+      choose_products: Choose products
+      calculate: Calculate estimate
+      results: Estimated cost
+      no_public_rate: No public rate available
+      total: 'Total:'
 
   bundle_products:
     new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,10 +121,11 @@ en:
       title: Estimate
       intro: Estimate the cost of using our facilities. No account required.
       customer_type: I am
-      internal: Internal
-      external: External
-      external_for_profit: External - for-profit
-      external_non_profit: External - non-profit
+      customer_types:
+        base: Internal
+        external: External
+        external_2: External - non-profit
+        cancer_center: Cancer Center
       choose_products: Choose products
       calculate: Calculate estimate
       results: Estimated cost

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,13 +124,13 @@ en:
       customer_types:
         base: Internal
         external: External
-        external_2: External - non-profit
         cancer_center: Cancer Center
       choose_products: Choose products
       calculate: Calculate estimate
       results: Estimated cost
       no_public_rate: No public rate available
       total: 'Total:'
+      print: Print estimate
 
   bundle_products:
     new:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,10 @@ Rails.application.routes.draw do
     match "/users/password/reset", to: "user_password#reset", as: "reset_password", via: [:get, :post]
   end
 
+  if SettingsHelper.feature_on?(:public_estimates) && SettingsHelper.feature_on?(:show_estimates_option)
+    get "estimate", to: "public_estimates#show"
+  end
+
   # root route
   root to: "public#index"
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -221,6 +221,7 @@ feature:
   granular_permissions: true
   kiosk_view: true
   show_estimates_option: true
+  public_estimates: false
   training_requests: true
 
 split_accounts:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,6 +10,12 @@ price_group:
     external: 'External Rate'
     cancer_center: 'Cancer Center Rate'
 
+public_estimates:
+  # Keys from price_group.name. Each school can override this list.
+  customer_types:
+    - base
+    - external
+
 time_zone: "Central Time (US & Canada)"
 
 accounts:

--- a/spec/models/estimate_detail_spec.rb
+++ b/spec/models/estimate_detail_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EstimateDetail do
+  let(:facility) { create(:setup_facility) }
+  let(:price_group) { facility.price_groups.first }
+  let!(:item) { create(:setup_item, facility:) }
+  let!(:item_price_policy) do
+    create(:item_price_policy, product: item, price_group:, unit_cost: 25, unit_subsidy: 5)
+  end
+
+  describe "#assign_price_policy_and_cost without a user" do
+    let(:persisted_detail) do
+      estimate = create(:estimate, facility:, price_group:)
+      estimate.estimate_details.create!(product: item, quantity: 3)
+    end
+
+    let(:anonymous_detail) do
+      estimate = Estimate.new(facility:, price_group:)
+      estimate.estimate_details.build(product: item, quantity: 3)
+    end
+
+    it "resolves the price policy on an unsaved record" do
+      expect(anonymous_detail.assign_price_policy_and_cost).to be true
+      expect(anonymous_detail.price_policy).to eq(item_price_policy)
+    end
+
+    it "computes the same cost as the persisted equivalent" do
+      anonymous_detail.assign_price_policy_and_cost
+
+      expect(anonymous_detail.cost).to eq(persisted_detail.cost)
+      expect(anonymous_detail.cost).to eq(60)
+    end
+
+    it "persists nothing" do
+      expect { anonymous_detail.assign_price_policy_and_cost }.not_to change(EstimateDetail, :count)
+      expect(anonymous_detail).not_to be_persisted
+    end
+
+    it "returns false when no price policy matches the price group" do
+      other_item = create(:setup_item, facility:)
+      detail = Estimate.new(facility:, price_group:).estimate_details.build(product: other_item, quantity: 1)
+
+      expect(detail.assign_price_policy_and_cost).to be false
+    end
+  end
+end

--- a/spec/models/price_group_spec.rb
+++ b/spec/models/price_group_spec.rb
@@ -247,11 +247,11 @@ RSpec.describe PriceGroup do
     after { Settings.price_group.name.external_2 = initial_secondary_external }
 
     it "returns the base group for internal customers" do
-      expect(described_class.for_public_estimate(customer_type: "internal")).to eq(described_class.base)
+      expect(described_class.for_public_estimate("internal")).to eq(described_class.base)
     end
 
     it "returns the external group for external customers" do
-      expect(described_class.for_public_estimate(customer_type: "external", profit_status: "for_profit"))
+      expect(described_class.for_public_estimate("external"))
         .to eq(described_class.external)
     end
 
@@ -263,7 +263,7 @@ RSpec.describe PriceGroup do
       end
 
       it "falls back to the external group for non-profit customers" do
-        expect(described_class.for_public_estimate(customer_type: "external", profit_status: "non_profit"))
+        expect(described_class.for_public_estimate("external_non_profit"))
           .to eq(described_class.external)
       end
     end
@@ -275,12 +275,12 @@ RSpec.describe PriceGroup do
       end
 
       it "returns it for non-profit customers" do
-        expect(described_class.for_public_estimate(customer_type: "external", profit_status: "non_profit"))
+        expect(described_class.for_public_estimate("external_non_profit"))
           .to eq(secondary_external)
       end
 
       it "still returns the external group for for-profit customers" do
-        expect(described_class.for_public_estimate(customer_type: "external", profit_status: "for_profit"))
+        expect(described_class.for_public_estimate("external"))
           .to eq(described_class.external)
       end
     end

--- a/spec/models/price_group_spec.rb
+++ b/spec/models/price_group_spec.rb
@@ -241,4 +241,49 @@ RSpec.describe PriceGroup do
     end
   end
 
+  describe ".for_public_estimate" do
+    let(:initial_secondary_external) { Settings.price_group.name.external_2 }
+
+    after { Settings.price_group.name.external_2 = initial_secondary_external }
+
+    it "returns the base group for internal customers" do
+      expect(described_class.for_public_estimate(customer_type: "internal")).to eq(described_class.base)
+    end
+
+    it "returns the external group for external customers" do
+      expect(described_class.for_public_estimate(customer_type: "external", profit_status: "for_profit"))
+        .to eq(described_class.external)
+    end
+
+    context "when a second external group is not configured" do
+      before { Settings.price_group.name.external_2 = nil }
+
+      it "returns nil from .secondary_external" do
+        expect(described_class.secondary_external).to be_nil
+      end
+
+      it "falls back to the external group for non-profit customers" do
+        expect(described_class.for_public_estimate(customer_type: "external", profit_status: "non_profit"))
+          .to eq(described_class.external)
+      end
+    end
+
+    context "when a second external group is configured" do
+      let!(:secondary_external) do
+        Settings.price_group.name.external_2 = "External Non-Profit Rate"
+        described_class.setup_global(name: "External Non-Profit Rate", is_internal: false, display_order: 2)
+      end
+
+      it "returns it for non-profit customers" do
+        expect(described_class.for_public_estimate(customer_type: "external", profit_status: "non_profit"))
+          .to eq(secondary_external)
+      end
+
+      it "still returns the external group for for-profit customers" do
+        expect(described_class.for_public_estimate(customer_type: "external", profit_status: "for_profit"))
+          .to eq(described_class.external)
+      end
+    end
+  end
+
 end

--- a/spec/models/price_group_spec.rb
+++ b/spec/models/price_group_spec.rb
@@ -242,46 +242,27 @@ RSpec.describe PriceGroup do
   end
 
   describe ".for_public_estimate" do
-    let(:initial_secondary_external) { Settings.price_group.name.external_2 }
-
-    after { Settings.price_group.name.external_2 = initial_secondary_external }
-
-    it "returns the base group for internal customers" do
-      expect(described_class.for_public_estimate("internal")).to eq(described_class.base)
+    it "returns the group named by the matching price_group setting" do
+      expect(described_class.for_public_estimate("base")).to eq(described_class.base)
+      expect(described_class.for_public_estimate("external")).to eq(described_class.external)
     end
 
-    it "returns the external group for external customers" do
-      expect(described_class.for_public_estimate("external"))
-        .to eq(described_class.external)
+    it "returns nil for a key with no configured name" do
+      expect(described_class.for_public_estimate("external_2")).to be_nil
+      expect(described_class.for_public_estimate("nonsense")).to be_nil
     end
 
-    context "when a second external group is not configured" do
-      before { Settings.price_group.name.external_2 = nil }
-
-      it "returns nil from .secondary_external" do
-        expect(described_class.secondary_external).to be_nil
-      end
-
-      it "falls back to the external group for non-profit customers" do
-        expect(described_class.for_public_estimate("external_non_profit"))
-          .to eq(described_class.external)
-      end
-    end
-
-    context "when a second external group is configured" do
-      let!(:secondary_external) do
+    context "when a school configures an extra key" do
+      let(:initial_name) { Settings.price_group.name.external_2 }
+      let!(:non_profit) do
         Settings.price_group.name.external_2 = "External Non-Profit Rate"
         described_class.setup_global(name: "External Non-Profit Rate", is_internal: false, display_order: 2)
       end
 
-      it "returns it for non-profit customers" do
-        expect(described_class.for_public_estimate("external_non_profit"))
-          .to eq(secondary_external)
-      end
+      after { Settings.price_group.name.external_2 = initial_name }
 
-      it "still returns the external group for for-profit customers" do
-        expect(described_class.for_public_estimate("external"))
-          .to eq(described_class.external)
+      it "resolves that key to its group" do
+        expect(described_class.for_public_estimate("external_2")).to eq(non_profit)
       end
     end
   end

--- a/spec/requests/public_estimates_spec.rb
+++ b/spec/requests/public_estimates_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Public estimates" do
+  let(:facility) { create(:setup_facility) }
+  let!(:item) { create(:setup_item, facility:) }
+  let!(:internal_price_policy) do
+    create(:item_price_policy, product: item, price_group: PriceGroup.base, unit_cost: 10, unit_subsidy: 0)
+  end
+  let!(:external_price_policy) do
+    create(:item_price_policy, product: item, price_group: PriceGroup.external, unit_cost: 40, unit_subsidy: 0)
+  end
+
+  context "when the feature is enabled", feature_setting: { public_estimates: true, reload_routes: true } do
+    it "is reachable without logging in" do
+      get "/estimate"
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "lists the products of the selected facility" do
+      get "/estimate", params: { facility_id: facility.id }
+
+      expect(response.body).to include(item.name)
+    end
+
+    it "prices the estimate for an internal customer" do
+      get "/estimate", params: {
+        customer_type: "internal", facility_id: facility.id, quantities: { item.id.to_s => "2" }
+      }
+
+      expect(response.body).to include("$20.00")
+    end
+
+    it "prices the estimate for an external customer" do
+      get "/estimate", params: {
+        customer_type: "external", facility_id: facility.id, quantities: { item.id.to_s => "2" }
+      }
+
+      expect(response.body).to include("$80.00")
+    end
+
+    it "reports products with no rate for the selected price group" do
+      unpriced = create(:setup_item, facility:)
+
+      get "/estimate", params: {
+        customer_type: "internal", facility_id: facility.id, quantities: { unpriced.id.to_s => "1" }
+      }
+
+      expect(response.body).to include("No public rate available")
+    end
+
+    it "excludes bundles, which have no price policies of their own" do
+      bundle = create(:bundle, facility:, bundle_products: [item])
+
+      get "/estimate", params: { facility_id: facility.id }
+
+      expect(response.body).to_not include(bundle.name)
+    end
+
+    it "ignores products with no quantity" do
+      get "/estimate", params: {
+        customer_type: "internal", facility_id: facility.id, quantities: { item.id.to_s => "0" }
+      }
+
+      expect(response.body).to_not include("Estimated cost")
+    end
+  end
+
+  context "when the feature is disabled", feature_setting: { public_estimates: false, reload_routes: true } do
+    it "does not route" do
+      get "/estimate"
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/public_estimates_spec.rb
+++ b/spec/requests/public_estimates_spec.rb
@@ -59,6 +59,31 @@ RSpec.describe "Public estimates" do
       expect(response.body).to_not include(bundle.name)
     end
 
+    it "prices the estimate with a second external group when one is configured" do
+      initial = Settings.price_group.name.external_2
+      Settings.price_group.name.external_2 = "External Non-Profit Rate"
+      non_profit = PriceGroup.setup_global(name: "External Non-Profit Rate", is_internal: false, display_order: 2)
+      create(:item_price_policy, product: item, price_group: non_profit, unit_cost: 25, unit_subsidy: 0)
+
+      get "/estimate", params: {
+        customer_type: "external_non_profit", facility_id: facility.id, quantities: { item.id.to_s => "2" }
+      }
+
+      expect(response.body).to include("$50.00")
+    ensure
+      Settings.price_group.name.external_2 = initial
+    end
+
+    it "offers no quantity field for a product with no rate for the selected price group" do
+      unpriced = create(:setup_item, facility:, name: "Unpriced Widget")
+
+      get "/estimate", params: { customer_type: "internal", facility_id: facility.id }
+
+      expect(response.body).to include(unpriced.name)
+      expect(response.body).to_not include(%(name="quantities[#{unpriced.id}]"))
+      expect(response.body).to include(%(name="quantities[#{item.id}]"))
+    end
+
     it "ignores products with no quantity" do
       get "/estimate", params: {
         customer_type: "internal", facility_id: facility.id, quantities: { item.id.to_s => "0" }

--- a/spec/requests/public_estimates_spec.rb
+++ b/spec/requests/public_estimates_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Public estimates" do
 
     it "prices the estimate for an internal customer" do
       get "/estimate", params: {
-        customer_type: "internal", facility_id: facility.id, quantities: { item.id.to_s => "2" }
+        customer_type: "base", facility_id: facility.id, quantities: { item.id.to_s => "2" }
       }
 
       expect(response.body).to include("$20.00")
@@ -41,16 +41,6 @@ RSpec.describe "Public estimates" do
       expect(response.body).to include("$80.00")
     end
 
-    it "reports products with no rate for the selected price group" do
-      unpriced = create(:setup_item, facility:)
-
-      get "/estimate", params: {
-        customer_type: "internal", facility_id: facility.id, quantities: { unpriced.id.to_s => "1" }
-      }
-
-      expect(response.body).to include("No public rate available")
-    end
-
     it "excludes bundles, which have no price policies of their own" do
       bundle = create(:bundle, facility:, bundle_products: [item])
 
@@ -61,32 +51,34 @@ RSpec.describe "Public estimates" do
 
     it "prices the estimate with a second external group when one is configured" do
       initial = Settings.price_group.name.external_2
+      initial_types = Settings.public_estimates.customer_types
       Settings.price_group.name.external_2 = "External Non-Profit Rate"
+      Settings.public_estimates.customer_types = %w[base external external_2]
       non_profit = PriceGroup.setup_global(name: "External Non-Profit Rate", is_internal: false, display_order: 2)
       create(:item_price_policy, product: item, price_group: non_profit, unit_cost: 25, unit_subsidy: 0)
 
       get "/estimate", params: {
-        customer_type: "external_non_profit", facility_id: facility.id, quantities: { item.id.to_s => "2" }
+        customer_type: "external_2", facility_id: facility.id, quantities: { item.id.to_s => "2" }
       }
 
       expect(response.body).to include("$50.00")
     ensure
       Settings.price_group.name.external_2 = initial
+      Settings.public_estimates.customer_types = initial_types
     end
 
-    it "offers no quantity field for a product with no rate for the selected price group" do
+    it "does not list a product with no rate for the selected price group" do
       unpriced = create(:setup_item, facility:, name: "Unpriced Widget")
 
-      get "/estimate", params: { customer_type: "internal", facility_id: facility.id }
+      get "/estimate", params: { customer_type: "base", facility_id: facility.id }
 
-      expect(response.body).to include(unpriced.name)
-      expect(response.body).to_not include(%(name="quantities[#{unpriced.id}]"))
-      expect(response.body).to include(%(name="quantities[#{item.id}]"))
+      expect(response.body).to include(item.name)
+      expect(response.body).to_not include(unpriced.name)
     end
 
     it "ignores products with no quantity" do
       get "/estimate", params: {
-        customer_type: "internal", facility_id: facility.id, quantities: { item.id.to_s => "0" }
+        customer_type: "base", facility_id: facility.id, quantities: { item.id.to_s => "0" }
       }
 
       expect(response.body).to_not include("Estimated cost")

--- a/spec/requests/public_estimates_spec.rb
+++ b/spec/requests/public_estimates_spec.rb
@@ -49,22 +49,30 @@ RSpec.describe "Public estimates" do
       expect(response.body).to_not include(bundle.name)
     end
 
-    it "prices the estimate with a second external group when one is configured" do
-      initial = Settings.price_group.name.external_2
+    it "prices the estimate with an extra configured customer type" do
       initial_types = Settings.public_estimates.customer_types
-      Settings.price_group.name.external_2 = "External Non-Profit Rate"
-      Settings.public_estimates.customer_types = %w[base external external_2]
-      non_profit = PriceGroup.setup_global(name: "External Non-Profit Rate", is_internal: false, display_order: 2)
-      create(:item_price_policy, product: item, price_group: non_profit, unit_cost: 25, unit_subsidy: 0)
+      Settings.public_estimates.customer_types = %w[base external cancer_center]
+      cancer_center = PriceGroup.setup_global(name: Settings.price_group.name.cancer_center, is_internal: false, display_order: 2)
+      create(:item_price_policy, product: item, price_group: cancer_center, unit_cost: 25, unit_subsidy: 0)
 
       get "/estimate", params: {
-        customer_type: "external_2", facility_id: facility.id, quantities: { item.id.to_s => "2" }
+        customer_type: "cancer_center", facility_id: facility.id, quantities: { item.id.to_s => "2" }
       }
 
       expect(response.body).to include("$50.00")
     ensure
-      Settings.price_group.name.external_2 = initial
       Settings.public_estimates.customer_types = initial_types
+    end
+
+    it "shows a print shortcut and the selected facility and customer type with the results" do
+      get "/estimate", params: {
+        customer_type: "external", facility_id: facility.id, quantities: { item.id.to_s => "1" }
+      }
+
+      printed = response.parsed_body.at_css(".show-for-print").text
+
+      expect(response.body).to include("window.print()")
+      expect(printed).to include(facility.name, "External")
     end
 
     it "does not list a product with no rate for the selected price group" do

--- a/spec/system/public_estimate_spec.rb
+++ b/spec/system/public_estimate_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Building a public estimate", feature_setting: { public_estimates
 
     select "Internal", from: "customer_type"
     select facility.name, from: "facility_id"
-    click_button "Select facility"
+    click_button "Calculate estimate"
 
     fill_in "quantities[#{item.id}]", with: 4
     click_button "Calculate estimate"

--- a/spec/system/public_estimate_spec.rb
+++ b/spec/system/public_estimate_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Building a public estimate", feature_setting: { public_estimates: true, reload_routes: true } do
+  let(:facility) { create(:setup_facility) }
+  let!(:item) { create(:setup_item, facility:) }
+  let!(:price_policy) do
+    create(:item_price_policy, product: item, price_group: PriceGroup.base, unit_cost: 15, unit_subsidy: 0)
+  end
+
+  it "prices products without logging in" do
+    visit root_path
+
+    click_link "Get an Estimate"
+
+    select "Internal", from: "customer_type"
+    select facility.name, from: "facility_id"
+    click_button "Select facility"
+
+    fill_in "quantities[#{item.id}]", with: 4
+    click_button "Calculate estimate"
+
+    expect(page).to have_content("Estimated cost")
+    expect(page).to have_content("$60.00")
+  end
+end

--- a/spec/system/public_estimate_spec.rb
+++ b/spec/system/public_estimate_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Building a public estimate", feature_setting: { public_estimates: true, reload_routes: true } do
+RSpec.describe "Building a public estimate", :js, feature_setting: { public_estimates: true, reload_routes: true } do
   let(:facility) { create(:setup_facility) }
   let!(:item) { create(:setup_item, facility:) }
   let!(:price_policy) do
@@ -14,9 +14,10 @@ RSpec.describe "Building a public estimate", feature_setting: { public_estimates
 
     click_link "Get an Estimate"
 
+    expect(page).to have_no_button("Calculate estimate")
+
     select "Internal", from: "customer_type"
     select facility.name, from: "facility_id"
-    click_button "Calculate estimate"
 
     fill_in "quantities[#{item.id}]", with: 4
     click_button "Calculate estimate"


### PR DESCRIPTION
# Notes

Visitors can now get a cost estimate without logging in. A "Get an Estimate" link next to Support opens a page where they pick whether they are internal or external, choose a facility, and enter quantities for the products they are interested in, then see the estimated cost. Off by default behind the `public_estimates` feature flag.

[OSU-242 | Public estimates](https://universe-of-universities.atlassian.net/browse/OSU-242)

# Additional Context

**Nothing is persisted.** Phase 1 calculates and displays only. `PublicEstimatesController#show` builds an in-memory `Estimate` with `estimate_details.build` and calls `assign_price_policy_and_cost` on each detail — no new models and no migration. That method was already able to run on unsaved records; the specs pin that it resolves the policy, computes the same cost as a persisted equivalent, and writes nothing.

**Price group selection.** `PriceGroup.for_public_estimate` maps the visitor's answer to a global price group: internal → `base`, external non-profit → `secondary_external` falling back to `external`, everything else → `external`. `PriceGroup.secondary_external` is new and returns `nil` when `price_group.name.external_2` is unset, so schools without a second external group only see two options instead of three.

**Cost does not depend on the user.** Verified through `PricePolicySelector` and all three `estimate_cost_from_estimate_detail` implementations — they read only price group, quantity and duration, which is what makes an accountless estimate possible.

**Existing admin views were not reused.** `facility_estimates/show.html.haml` calls `includes` and `maximum` on the association, which hit the database and therefore return nothing for an unsaved estimate.

Products are listed from `available_for_estimates`, excluding bundles. A product with no purchaseable, in-date policy on the selected price group is shown as "No public rate available" rather than hidden, so visitors can tell the difference between a product that is unavailable and one that simply has no public rate.

# Screenshot

https://github.com/user-attachments/assets/fe832aa5-3fdd-4301-b8fd-77b9a44d0762


