### PR TITLE
[NUOPEN-438] Disable all journal create buttons on click

### DIFF
--- a/app/javascript/app/facility_statements.js
+++ b/app/javascript/app/facility_statements.js
@@ -1,5 +1,5 @@
 document.addEventListener("DOMContentLoaded", function() {
-  const createBtn = document.getElementById('create_statement_btn');
+  const createBtn = document.querySelector('#journals_create_form input[type=submit]');
   const modal = document.getElementsByClassName('js--statementModal')[0];
   const saveBtn = document.getElementsByClassName('js--saveStatementButton')[0];
   const parentInput = document.getElementById("parent_invoice_number");
@@ -20,8 +20,6 @@ document.addEventListener("DOMContentLoaded", function() {
       if (helperText) helperText.hidden = false;
 
       $(modal).modal('hide');
-
-      createBtn.disabled = true;
 
       // This is used by the parent statement form, so `journal` doesn't seem right.
       // However, the form is using that name.

--- a/app/javascript/app/index.js
+++ b/app/javascript/app/index.js
@@ -42,4 +42,3 @@ import './tab-counts';
 import './time_formatter';
 import './user_access_list';
 import './user_select';
-import './facility_statements';

--- a/app/javascript/facility_journal.js
+++ b/app/javascript/facility_journal.js
@@ -2,16 +2,16 @@ document.addEventListener("DOMContentLoaded", function() {
   const selectAllLink = document.querySelector(".js--select_all");
   const table = document.querySelector("table.js--transactions-table");
   const submitDiv = document.querySelector(".submit");
-  const journalCreationSubmitButton = document.querySelector(".js--journal-creation__submit");
+  const journalCreationSubmitButtons = document.querySelectorAll(".js--journal-submit");
   const journalCreationHelperText = document.querySelector(".js--journal-creation__helper");
   let earliestFulfilledAtDate;
 
   table.addEventListener("click", setEarliestFulfilledAtDate);
   selectAllLink.addEventListener("click", setEarliestFulfilledAtDate);
   submitDiv.addEventListener("click", handleModals);
-  if (journalCreationSubmitButton) {
+  journalCreationSubmitButtons.forEach(function(journalCreationSubmitButton) {
     journalCreationSubmitButton.addEventListener("click", handleSubmit);
-  }
+  })
 
   function setEarliestFulfilledAtDate(event) {
     const fulfilledAtDates = [];
@@ -45,9 +45,15 @@ document.addEventListener("DOMContentLoaded", function() {
   }
 
   function handleSubmit(event) {
-    event.preventDefault();
-    event.target.disabled = true;
-    journalCreationHelperText.toggleAttribute("hidden");
+    disableSubmitBtns();
     document.getElementById("journals_create_form").submit();
   }
+
+  function disableSubmitBtns() {
+    $.rails.disableFormElement($(".js--journal-submit"));
+  }
+
+  $("#journals_create_form").submit(function(e) {
+    disableSubmitBtns();
+  });
 });

--- a/app/javascript/facility_journal.js
+++ b/app/javascript/facility_journal.js
@@ -50,6 +50,7 @@ document.addEventListener("DOMContentLoaded", function() {
 
   function disableSubmitBtns() {
     $.rails.disableFormElement($(".js--journal-submit"));
+    $.rails.disableFormElement($("#journals_create_form").find(":submit"));
   }
 
   $("#journals_create_form").submit(function(e) {

--- a/app/javascript/facility_journal.js
+++ b/app/javascript/facility_journal.js
@@ -3,7 +3,6 @@ document.addEventListener("DOMContentLoaded", function() {
   const table = document.querySelector("table.js--transactions-table");
   const submitDiv = document.querySelector(".submit");
   const journalCreationSubmitButtons = document.querySelectorAll(".js--journal-submit");
-  const journalCreationHelperText = document.querySelector(".js--journal-creation__helper");
   let earliestFulfilledAtDate;
 
   table.addEventListener("click", setEarliestFulfilledAtDate);

--- a/app/javascript/facility_statements.js
+++ b/app/javascript/facility_statements.js
@@ -15,12 +15,7 @@ document.addEventListener("DOMContentLoaded", function() {
     saveBtn.addEventListener('click', function() {
       hiddenInput.value = parentInput.value.trim();
 
-      saveBtn.disabled = true;
-      const helperText = document.getElementsByClassName('js--statementHelper')[0];
-      if (helperText) helperText.hidden = false;
-
-      $(modal).modal('hide');
-
+      $.rails.disableFormElement($(saveBtn));
       // This is used by the parent statement form, so `journal` doesn't seem right.
       // However, the form is using that name.
       document.getElementById('journals_create_form').submit();

--- a/app/views/facility_journals/_journal_90day_modal.html.haml
+++ b/app/views/facility_journals/_journal_90day_modal.html.haml
@@ -13,5 +13,5 @@
         - if @journal_creation_reminder
           = link_to text("facility_journals.journal_90day_modal.submit_button"), "#journal-creation-reminder", class: "btn btn-primary", data: { toggle: "modal", dismiss: "modal" }
         - else
-          - submit_form = "event.preventDefault();document.getElementById('journals_create_form').submit();"
-          = submit_tag text("facility_journals.journal_90day_modal.submit_button"), class: "btn btn-primary", onclick: submit_form
+          %button.btn.btn-primary.js--journal-submit{ type: "button", data: { disable_with: t("shared.loading") } }
+            = text("facility_journals.journal_90day_modal.submit_button")

--- a/app/views/facility_journals/_journal_creation_modal.html.haml
+++ b/app/views/facility_journals/_journal_creation_modal.html.haml
@@ -9,5 +9,6 @@
       .modal-footer
         %button.btn{ type: "button", data: { dismiss: "modal" } }
           = text("facility_journals.journal_creation_reminder_modal.cancel")
-        = submit_tag text("facility_journals.journal_creation_reminder_modal.proceed"), class: "btn btn-primary js--journal-creation__submit"
-        %span.js--journal-creation__helper{ hidden: true }= "Processing, please wait..."
+        %button.btn.btn-primary.js--journal-submit{ type: "button", data: { disable_with: t("shared.loading") } }
+          = text("facility_journals.journal_creation_reminder_modal.proceed")
+

--- a/app/views/facility_journals/_journal_creation_modal.html.haml
+++ b/app/views/facility_journals/_journal_creation_modal.html.haml
@@ -11,4 +11,3 @@
           = text("facility_journals.journal_creation_reminder_modal.cancel")
         %button.btn.btn-primary.js--journal-submit{ type: "button", data: { disable_with: t("shared.loading") } }
           = text("facility_journals.journal_creation_reminder_modal.proceed")
-

--- a/app/views/facility_journals/new.html.haml
+++ b/app/views/facility_journals/new.html.haml
@@ -1,12 +1,6 @@
 - if @earliest_journal_date
   = content_for :head_content do
     = javascript_include_tag "facility_journal"
-    :javascript
-      $(function(){
-        $("#journals_create_form").submit(function(e) {
-          $(e.target).find(":submit").attr("disabled", "true");
-        });
-      });
 
 - if @journal_creation_reminder
   = render "journal_creation_modal", reminder_message: @journal_creation_reminder.message

--- a/app/views/facility_statements/_statement_modal.html.haml
+++ b/app/views/facility_statements/_statement_modal.html.haml
@@ -13,5 +13,5 @@
 
       .modal-footer
         %button.btn.btn-default{ type: "button", "data-dismiss" => "modal" }= text("views.facility_statements.statement_modal.cancel")
-        %button.btn.btn-primary.js--saveStatementButton{ type: "button" }= text("views.facility_statements.statement_modal.save")
-        %span.js--statementHelper{ hidden: true } Processing, please wait...
+        %button.btn.btn-primary.js--saveStatementButton{ type: "button", data: { disable_with: t("shared.loading") } }
+          = text("views.facility_statements.statement_modal.save")

--- a/app/views/facility_statements/new.html.haml
+++ b/app/views/facility_statements/new.html.haml
@@ -1,11 +1,3 @@
-= content_for :head_content do
-  :javascript
-    $(function(){
-      $("#journals_create_form").submit(function(e) {
-        $(e.target).find(":submit").attr("disabled", "true");
-      });
-    });
-
 = render "shared/transactions/headers"
 
 - content_for :h1 do

--- a/app/views/facility_statements/new.html.haml
+++ b/app/views/facility_statements/new.html.haml
@@ -1,5 +1,8 @@
 = render "shared/transactions/headers"
 
+= content_for :head_content do
+  = javascript_include_tag "facility_statements"
+
 - content_for :h1 do
   = current_facility
 

--- a/app/views/shared/transactions/_table.html.haml
+++ b/app/views/shared/transactions/_table.html.haml
@@ -26,7 +26,9 @@
         .col-md-2
           .submit
             = hidden_field_tag :parent_invoice_number, "", id: "parent_invoice_number_hidden"
-            = submit_tag text(@order_detail_action, scope: "admin.transaction_search.actions"), class: "btn btn-primary", id: "create_statement_btn"
+            = submit_tag text(@order_detail_action, scope: "admin.transaction_search.actions"),
+              class: "btn btn-primary",
+              data: { disable_with: t("shared.loading") }
       .row
         .col-md-12= render "shared/transactions/table_inside", order_details: order_details
   - else


### PR DESCRIPTION
# Notes

The journal creation form has several submit buttons depending on some conditions. Disable all submit buttons upon submition using disable with from Rails UJS.

This was also done for the statements create page since they share the same form.

Part of [NUOPEN-438 | Double journal creation fix](https://universe-of-universities.atlassian.net/browse/NUOPEN-438)
