### PR TITLE
[NUOPEN-419] Fix order files download

### DIFF
--- a/app/controllers/order_detail_stored_files_controller.rb
+++ b/app/controllers/order_detail_stored_files_controller.rb
@@ -7,7 +7,9 @@ class OrderDetailStoredFilesController < ApplicationController
   customer_tab  :all
 
   before_action :init_order_detail
-  authorize_resource class: OrderDetail
+  authorize_resource class: OrderDetail, except: [:sample_results, :sample_results_zip, :template_results]
+  authorize_resource class: OrderDetail, instance_name: :order_detail, id_param: :order_detail_id,
+                     only: [:sample_results, :sample_results_zip, :template_results]
 
   def sample_results
     redirect_to @order_detail.stored_files.sample_result.find(params[:id]).download_url, allow_other_host: true

--- a/app/controllers/order_detail_stored_files_controller.rb
+++ b/app/controllers/order_detail_stored_files_controller.rb
@@ -7,9 +7,7 @@ class OrderDetailStoredFilesController < ApplicationController
   customer_tab  :all
 
   before_action :init_order_detail
-  authorize_resource class: OrderDetail, except: [:sample_results, :sample_results_zip, :template_results]
-  authorize_resource class: OrderDetail, instance_name: :order_detail, id_param: :order_detail_id,
-                     only: [:sample_results, :sample_results_zip, :template_results]
+  authorize_resource class: OrderDetail, instance_name: :order_detail, id_param: :order_detail_id
 
   def sample_results
     redirect_to @order_detail.stored_files.sample_result.find(params[:id]).download_url, allow_other_host: true

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -471,8 +471,9 @@ class Ability
     if resource.is_a?(OrderDetail)
       project = resource.order.cross_core_project
 
-      if project.present?
-        can [:add_accessories, :new, :show, :update, :cancel, :template_results], OrderDetail if can_manage_cross_core_orders_at?(user, project.facility)
+      if project.present? && can_manage_cross_core_orders_at?(user, project.facility)
+        can [:add_accessories, :new, :show, :update, :cancel, :template_results], OrderDetail
+        can [:order_file, :upload_order_file, :remove_order_file], OrderDetail, order: { cross_core_project_id: project.id }
       end
     end
 

--- a/app/lib/facility_user_permission_ability.rb
+++ b/app/lib/facility_user_permission_ability.rb
@@ -124,7 +124,7 @@ class FacilityUserPermissionAbility
   end
 
   def grant_order_management
-    can :update, OrderDetail, { order: { facility_id: facility.id } }
+    can [:update, :order_file, :upload_order_file, :remove_order_file], OrderDetail, { order: { facility_id: facility.id } }
     can :mark_unrecoverable, OrderDetail, { order: { facility_id: facility.id } }
 
     can [:administer, :assign_price_policies_to_problem_orders, :batch_update,

--- a/app/lib/facility_user_permission_ability.rb
+++ b/app/lib/facility_user_permission_ability.rb
@@ -42,6 +42,7 @@ class FacilityUserPermissionAbility
 
     can [:administer, :index, :show, :tab_counts], Order
     can :show, OrderDetail
+    can [:sample_results, :sample_results_zip, :template_results], OrderDetail, order: { facility_id: facility.id }
 
     can [:administer, :index, :show, :timeline, :tab_counts], Reservation
 

--- a/spec/controllers/order_detail_stored_files_controller_spec.rb
+++ b/spec/controllers/order_detail_stored_files_controller_spec.rb
@@ -65,6 +65,48 @@ RSpec.describe OrderDetailStoredFilesController do
     end
   end
 
+  describe "order form authorization", feature_setting: { granular_permissions: true } do
+    let(:product) { create(:setup_service, :with_order_form) }
+    let(:order_detail) { create(:setup_order, product:).order_details.first }
+    let(:user) { create(:user) }
+    let(:params) { { order_id: order_detail.order_id, order_detail_id: order_detail.id } }
+
+    before do
+      create(:facility_user_permission, user:, facility: product.facility, read_access: true)
+      sign_in user
+    end
+
+    it "denies the upload form with only read_access" do
+      expect { get :order_file, params: }.to raise_error(CanCan::AccessDenied)
+    end
+
+    it "denies uploading with only read_access" do
+      file = Rack::Test::UploadedFile.new(Rails.root.join("spec", "files", "template1.txt"))
+      expect { post :upload_order_file, params: params.merge(stored_file: { file: }) }.to raise_error(CanCan::AccessDenied)
+    end
+
+    it "denies removing files with only read_access" do
+      file = create(:stored_file, :results, order_detail:, file_type: "template_result")
+      expect { get :remove_order_file, params: }.to raise_error(CanCan::AccessDenied)
+      expect(file.reload).to be_persisted
+    end
+  end
+
+  describe "#remove_order_file" do
+    let(:product) { create(:setup_service, :with_order_form) }
+    let(:order_detail) { create(:setup_order, product:).order_details.first }
+    let!(:file) { create(:stored_file, :results, order_detail:, file_type: "template_result") }
+
+    before { sign_in user }
+
+    it "allows the owner to remove an unpurchased order file" do
+      expect do
+        get :remove_order_file, params: { order_id: order_detail.order_id, order_detail_id: order_detail.id }
+      end.to change { order_detail.stored_files.count }.from(1).to(0)
+      expect(response).to redirect_to(order_path(order_detail.order))
+    end
+  end
+
   describe "#order_file" do
     let(:product) { create(:setup_service, :with_order_form) }
     let(:order_detail) { order.order_details.first }

--- a/spec/controllers/order_detail_stored_files_controller_spec.rb
+++ b/spec/controllers/order_detail_stored_files_controller_spec.rb
@@ -5,6 +5,66 @@ require "rails_helper"
 RSpec.describe OrderDetailStoredFilesController do
   let(:user) { order_detail.user }
 
+  describe "downloading order files", feature_setting: { granular_permissions: true } do
+    let(:facility) { product.facility }
+    let(:product) { create(:setup_service) }
+    let(:order_detail) { create(:purchased_order, product:).order_details.first }
+    let(:user) { create(:user) }
+    let(:params) { { order_id: order_detail.order_id, order_detail_id: order_detail.id } }
+
+    let!(:permission) { create(:facility_user_permission, user:, facility:, read_access: true) }
+
+    before { sign_in user }
+
+    { sample_results: "sample_result", template_results: "template_result" }.each do |action, file_type|
+      describe "##{action}" do
+        subject(:download) { get action, params: params.merge(id: file.id) }
+
+        let(:file) { create(:stored_file, :results, order_detail:, file_type:) }
+
+        it "downloads with read_access" do
+          download
+          expect(response).to redirect_to(file.download_url)
+        end
+
+        it "denies access without facility permissions" do
+          permission.destroy!
+          expect { download }.to raise_error(CanCan::AccessDenied)
+        end
+      end
+    end
+
+    describe "#sample_results_zip" do
+      subject(:download) { get :sample_results_zip, params: params.merge(format: :zip) }
+
+      let!(:file) { create(:stored_file, :results, order_detail:) }
+
+      it "downloads the results as a ZIP with read_access" do
+        download
+        expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq("application/zip")
+        Zip::File.open_buffer(response.body) do |zip|
+          expect(zip.map(&:name)).to eq([file.name])
+          expect(zip.first.get_input_stream.read).to eq("c,s,v")
+        end
+      end
+
+      it "denies access without facility permissions" do
+        permission.destroy!
+        expect { download }.to raise_error(CanCan::AccessDenied)
+      end
+
+      it "denies access with read_access in another facility" do
+        permission.update!(facility: create(:facility))
+        expect { download }.to raise_error(CanCan::AccessDenied)
+      end
+
+      it "denies access with the feature disabled", feature_setting: { granular_permissions: false } do
+        expect { download }.to raise_error(CanCan::AccessDenied)
+      end
+    end
+  end
+
   describe "#order_file" do
     let(:product) { create(:setup_service, :with_order_form) }
     let(:order_detail) { order.order_details.first }

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -999,6 +999,15 @@ RSpec.describe Ability do
       it_is_allowed_to(:index, StoredFile)
       it_is_allowed_to(:product_survey, StoredFile)
 
+      context "when downloading another facility's order files" do
+        let(:subject_resource) { build_stubbed(:order_detail, order: build_stubbed(:order, facility:)) }
+        let(:other_order_detail) { build_stubbed(:order_detail, order: build_stubbed(:order, facility: create(:facility))) }
+
+        [:sample_results, :sample_results_zip, :template_results].each do |action|
+          it { is_expected.not_to be_allowed_to(action, other_order_detail) }
+        end
+      end
+
       it_is_not_allowed_to([:manage], Journal)
       it_is_not_allowed_to([:manage], Statement)
       it_is_not_allowed_to([:manage], FacilityUserPermission)

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -736,6 +736,18 @@ RSpec.describe Ability do
         it { is_expected.not_to be_allowed_to(:disputed_orders, facility) }
       end
 
+      context "order form permissions" do
+        let(:subject_resource) { build_stubbed(:order_detail, order: build_stubbed(:order, facility:)) }
+        let(:other_order_detail) { build_stubbed(:order_detail, order: build_stubbed(:order, facility: create(:facility))) }
+
+        [:order_file, :upload_order_file, :remove_order_file].each do |action|
+          it "allows #{action} only within the facility" do
+            expect(ability).to be_allowed_to(action, subject_resource)
+            expect(ability).not_to be_allowed_to(action, other_order_detail)
+          end
+        end
+      end
+
       context "cross-core order abilities" do
         let(:other_facility) { create(:setup_facility) }
         let(:other_facility_item) { create(:setup_item, facility: other_facility) }
@@ -747,6 +759,18 @@ RSpec.describe Ability do
           let(:subject_resource) { cross_core_order_detail }
 
           it_is_allowed_to([:add_accessories, :new, :show, :update, :cancel, :template_results], OrderDetail)
+
+          [:order_file, :upload_order_file, :remove_order_file].each do |action|
+            it { is_expected.to be_allowed_to(action, cross_core_order_detail) }
+          end
+
+          it "does not allow order form access outside the authorized project" do
+            unrelated_detail = build_stubbed(:order_detail, order: build_stubbed(:order, facility: other_facility))
+
+            [:order_file, :upload_order_file, :remove_order_file].each do |action|
+              expect(ability).not_to be_allowed_to(action, unrelated_detail)
+            end
+          end
         end
 
         context "when managing cross-core reservations" do
@@ -792,7 +816,7 @@ RSpec.describe Ability do
           # grants conditional abilities (order: { user_id: user.id }) that CanCanCan
           # cannot evaluate against the class.
           it "does not allow cross-core actions on the order detail" do
-            %i[add_accessories new update cancel template_results].each do |action|
+            %i[add_accessories new update cancel template_results order_file upload_order_file remove_order_file].each do |action|
               expect(ability).not_to be_allowed_to(action, unrelated_order_detail)
             end
           end
@@ -999,12 +1023,19 @@ RSpec.describe Ability do
       it_is_allowed_to(:index, StoredFile)
       it_is_allowed_to(:product_survey, StoredFile)
 
-      context "when downloading another facility's order files" do
+      context "when downloading order files" do
         let(:subject_resource) { build_stubbed(:order_detail, order: build_stubbed(:order, facility:)) }
-        let(:other_order_detail) { build_stubbed(:order_detail, order: build_stubbed(:order, facility: create(:facility))) }
 
         [:sample_results, :sample_results_zip, :template_results].each do |action|
-          it { is_expected.not_to be_allowed_to(action, other_order_detail) }
+          it { is_expected.to be_allowed_to(action, subject_resource) }
+        end
+
+        context "from another facility" do
+          let(:other_order_detail) { build_stubbed(:order_detail, order: build_stubbed(:order, facility: create(:facility))) }
+
+          [:sample_results, :sample_results_zip, :template_results].each do |action|
+            it { is_expected.not_to be_allowed_to(action, other_order_detail) }
+          end
         end
       end
 

--- a/spec/system/admin/order_file_downloads_spec.rb
+++ b/spec/system/admin/order_file_downloads_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Order file downloads", feature_setting: { granular_permissions: true } do
+  let(:product) { create(:setup_service) }
+  let(:facility) { product.facility }
+  let(:order) { create(:purchased_order, product:) }
+  let(:order_detail) { order.order_details.first }
+  let(:user) { create(:user) }
+  let!(:file) { create(:stored_file, :results, order_detail:, file_type: "template_result") }
+  let(:download_path) { template_results_facility_order_order_detail_path(facility, order, order_detail, file) }
+
+  before do
+    create(:facility_user_permission, user:, facility:, read_access: true)
+    login_as user
+    visit facility_order_path(facility, order)
+  end
+
+  it "downloads an order file with only read_access" do
+    find_link(href: download_path).click
+
+    expect(page.status_code).to eq(200)
+    expect(page.body).to eq("c,s,v")
+  end
+end


### PR DESCRIPTION
   # Notes                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                               
   Users with read access can download files attached to orders in their facility, including individual results and ZIP archives.     
                                                                                                                                                                                                                                             [NUOPEN-419 | Granular permissions: cannot download order files](https://universe-of-universities.atlassian.net/browse/NUOPEN-419)       
