### PR TITLE
[NUOPEN-438] Use mutex on journal creation

### DIFF
--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -13,7 +13,8 @@ class FacilityJournalsController < ApplicationController
   authorize_resource class: Journal
 
   before_action :init_journals, except: :create
-  before_action :enable_sorting, only: [:new]
+  before_action :enable_sorting, only: :new
+  after_action :restrict_referrer, only: :create
 
   layout lambda {
     action_name.in?(%w(new)) ? "two_column_head" : "two_column"
@@ -97,17 +98,26 @@ class FacilityJournalsController < ApplicationController
 
     new_journal_from_params
 
-    # The referer can have a crazy long query string depending on how many checkboxes
-    # are selected. We've seen Apache not like stuff like that and give a "malformed
-    # header from script. Bad header" error which causes the page to completely bomb out.
-    # (See Task #48311). This is just preventative.
-    referer = response.headers["Referer"]
-    response.headers["Referer"] = referer[0..referrer.index("?")] if referer.present?
+    Journal.transaction do
+      current_facility.lock!
 
-    if @journal.errors.blank? && @journal.save
+      if current_facility.journals.pending.exists?
+        flash[:error] = t("controllers.facility_journals.create.duplicate")
+        return redirect_to new_facility_journal_path
+      else
+        @journal.defer_journal_row_creation = true
+        @journal.save
+      end
+    end
+
+    sleep 20
+    @journal.create_new_journal_rows! if @journal.persisted?
+
+    if @journal.persisted?
       @journal.create_spreadsheet if Journals::JournalFormat.exists?(:xls)
-      flash[:notice] = I18n.t("controllers.facility_journals.create.notice")
       LogEvent.log(@journal, :create, current_user)
+
+      flash[:notice] = I18n.t("controllers.facility_journals.create.notice")
       redirect_to facility_journals_path(current_facility)
     else
       flash_error_messages
@@ -185,7 +195,7 @@ class FacilityJournalsController < ApplicationController
     @journal = Journal.new(
       created_by: session_user.id,
       journal_date: params[:journal_date],
-      order_details_for_creation:
+      order_details_for_creation:,
     )
   end
 
@@ -227,4 +237,12 @@ class FacilityJournalsController < ApplicationController
     flash[:error] = msg.html_safe if msg.present?
   end
 
+  def restrict_referrer
+    # The referer can have a crazy long query string depending on how many checkboxes
+    # are selected. We've seen Apache not like stuff like that and give a "malformed
+    # header from script. Bad header" error which causes the page to completely bomb out.
+    # (See Task #48311). This is just preventative.
+    referer = response.headers["Referer"]
+    response.headers["Referer"] = referer[0..referrer.index("?")] if referer.present?
+  end
 end

--- a/app/controllers/facility_journals_controller.rb
+++ b/app/controllers/facility_journals_controller.rb
@@ -110,7 +110,6 @@ class FacilityJournalsController < ApplicationController
       end
     end
 
-    sleep 20
     @journal.create_new_journal_rows! if @journal.persisted?
 
     if @journal.persisted?
@@ -194,14 +193,23 @@ class FacilityJournalsController < ApplicationController
   def new_journal_from_params
     @journal = Journal.new(
       created_by: session_user.id,
-      journal_date: params[:journal_date],
+      journal_date: create_params[:journal_date],
       order_details_for_creation:,
     )
   end
 
+  def create_params
+    params.permit(:journal_date, order_detail_ids: [])
+  end
+
   def order_details_for_creation
-    return [] unless params[:order_detail_ids].present?
-    OrderDetail.for_facility(current_facility).need_journal.includes(:account, :product, order: :user).where_ids_in(params[:order_detail_ids])
+    return [] unless create_params[:order_detail_ids].present?
+
+    OrderDetail
+      .for_facility(current_facility)
+      .need_journal
+      .includes(:account, :product, order: :user)
+      .where_ids_in(create_params[:order_detail_ids])
   end
 
   def set_pending_journals

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-require "set"
-
 class Journal < ApplicationRecord
-
   class CreationError < NUCore::Error; end
 
   module Overridable
@@ -41,6 +38,8 @@ class Journal < ApplicationRecord
 
   attr_accessor :order_details_for_creation
 
+  attribute :defer_journal_row_creation, default: false
+
   belongs_to :facility, optional: true
   belongs_to :created_by_user, class_name: "User", foreign_key: :created_by
 
@@ -60,7 +59,9 @@ class Journal < ApplicationRecord
   validate :journal_date_cannot_be_before_last_fulfillment, on: :create, if: :has_order_details_for_creation?
   validates_with JournalDateMustBeAfterCutoffs, on: :create
   before_validation :set_facility_id, on: :create, if: :has_order_details_for_creation?
-  after_create :create_new_journal_rows, if: :has_order_details_for_creation?
+  after_create :create_new_journal_rows!, if: -> { has_order_details_for_creation? && !defer_journal_row_creation }
+
+  scope :pending, -> { where(is_successful: nil) }
 
   # Digs up journals pertaining to the passed in facilities
   #
@@ -174,6 +175,15 @@ class Journal < ApplicationRecord
 
   delegate :to_s, to: :id
 
+  def create_new_journal_rows!
+    row_errors = create_journal_rows!(@order_details_for_creation)
+    if row_errors.any?
+      row_errors.each { |e| errors.add(:base, e) }
+      destroy # so it's treated as a new record
+      raise ActiveRecord::RecordInvalid.new(self)
+    end
+  end
+
   private
 
   def should_check_fiscal_years?
@@ -209,14 +219,4 @@ class Journal < ApplicationRecord
                          @order_details_for_creation.first.order.facility_id
                        end
   end
-
-  def create_new_journal_rows
-    row_errors = create_journal_rows!(@order_details_for_creation)
-    if row_errors.any?
-      row_errors.each { |e| errors.add(:base, e) }
-      destroy # so it's treated as a new record
-      raise ActiveRecord::RecordInvalid.new(self)
-    end
-  end
-
 end

--- a/app/services/journal_row_builder.rb
+++ b/app/services/journal_row_builder.rb
@@ -81,7 +81,7 @@ class JournalRowBuilder
 
   # Set an array of facility_ids with pending journals
   def pending_facility_ids
-    @pending_facility_ids ||= Journal.facility_ids_with_pending_journals
+    @pending_facility_ids ||= Journal.where.not(id: journal.id).facility_ids_with_pending_journals
   end
 
   # Run all validations on an order detail

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -65,6 +65,7 @@ en:
       create:
         notice: "The journal file has been created successfully"
         more_errors: "There are more errors. Please resolve those above to see those that remain."
+        duplicate: "There's already a pending journal for this facility"
       reconcile:
         success: "%{count} payment(s) successfully reconciled"
         errors:

--- a/spec/requests/facility_journals_spec.rb
+++ b/spec/requests/facility_journals_spec.rb
@@ -14,4 +14,62 @@ RSpec.describe "facilities journals" do
       expect(page).to have_field("search[suspended_accounts]", type: :checkbox)
     end
   end
+
+  describe "create" do
+    let(:facility) { create(:setup_facility) }
+    let(:product) { create(:setup_item, facility:) }
+    let(:order) { create(:complete_order, product:) }
+    let(:params) do
+      {
+        journal_date: Date.today,
+        order_detail_ids: order.order_details.pluck(:id),
+      }
+    end
+    let(:action) do
+      lambda do
+        post facility_journals_path(facility), params:
+      end
+    end
+
+    before do
+      order.order_details.update_all(reviewed_at: 1.day.ago)
+    end
+
+    before { login_as create(:user, :administrator) }
+
+    context "on success" do
+      it "redirects to index" do
+        action.call
+
+        expect(response).to have_http_status(:found)
+        expect(response.location).to eq(facility_journals_url(facility))
+      end
+
+      it "creates a pending journal" do
+        expect { action.call }.to(
+          change { facility.journals.count }.by(1)
+        )
+      end
+    end
+
+    context "on error" do
+      context "when duplicate pending" do
+        before { create(:journal, facility:, is_successful: nil) }
+
+        it "redirects to new" do
+          action.call
+
+          expect(response).to have_http_status(:found)
+          expect(response.location).to eq(new_facility_journal_url(facility))
+        end
+
+        it "renders correct error" do
+          action.call
+          get response.location
+
+          expect(page).to have_text(I18n.t("controllers.facility_journals.create.duplicate"))
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Notes

Use facility as mutex to detect duplicate open journal. Since journal row creation can take several seconds I've splitted the journal record creation within the mutex and journal rows creation after it.

Also:
- Remove truncation of long referrer header since order ids are sent in the request body
- Add basic expires_at validation for test accounts
- Add rspec filter to use test account for internal billing

[NUOPEN-438 | Prevent duplicate journal]()