### PR TITLE
[Fix] Some specs warnings

### DIFF
--- a/spec/services/reservation_window_spec.rb
+++ b/spec/services/reservation_window_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe ReservationWindow do
   describe "max_window" do
     let(:instrument) { create(:setup_instrument) }
-    let(:reservation) { create(:reservation, product: instrument) }
+    let(:reservation) { create(:setup_reservation, product: instrument) }
     let(:instance) do
       described_class.new(reservation, create(:user))
     end

--- a/spec/system/admin/adding_to_a_cross_core_order_spec.rb
+++ b/spec/system/admin/adding_to_a_cross_core_order_spec.rb
@@ -251,8 +251,8 @@ RSpec.describe "Adding to an existing order for cross core", :js do
         click_button "Add to Cross-Core Order"
 
         expect(page).to have_content("#{cross_core_product_facility2.name} was successfully added to this order.")
-        expect(page).to have_content(facility2.to_s), count: 2
-        expect(page).to have_content(user.full_name), count: 2
+        expect(page).to have_content(facility2.to_s)
+        expect(page).to have_content(user.full_name)
 
         order.reload
 
@@ -296,8 +296,8 @@ RSpec.describe "Adding to an existing order for cross core", :js do
         click_button "Add to Cross-Core Order"
 
         expect(page).to have_content("#{cross_core_product_facility2.name} was successfully added to this order.")
-        expect(page).to have_content(facility2.to_s), count: 2
-        expect(page).to have_content(user.full_name), count: 2
+        expect(page).to have_content(facility2.to_s)
+        expect(page).to have_content(user.full_name)
 
         order.reload
 


### PR DESCRIPTION
# Notes

Fix warnings on two specs:

- Reservation window specs: expect message on nil object
- Cross core spec: `count: 2` argument unused 