### PR TITLE
[DART-172] General reports date input fix

### DIFF
--- a/app/inputs/date_field_input.rb
+++ b/app/inputs/date_field_input.rb
@@ -11,12 +11,14 @@
 # `date_field` renders any Date/Time/date-string value as ISO, so pass date
 # objects and let Rails format them — for value, min and max alike.
 class DateFieldInput < SimpleForm::Inputs::Base
+  DEFAULT_MAX_DATE = "2100-01-01"
+
   def input(_wrapper_options)
     html_options = input_html_options.dup
 
     html_options[:class] = [*html_options[:class], "form-control"].uniq.join(" ")
     html_options[:min] ||= options[:min_date]
-    html_options[:max] ||= options[:max_date]
+    html_options[:max] ||= options[:max_date] || DEFAULT_MAX_DATE
 
     @builder.date_field attribute_name, html_options
   end

--- a/app/javascript/app/reports.js
+++ b/app/javascript/app/reports.js
@@ -76,7 +76,6 @@ class TabbableReports {
 
       load: (_, ui) => {
         this.update_export_all_link_visibility(ui.panel);
-        this.fix_bad_dates(ui.panel);
         return this.update_export_urls();
       }
     });
@@ -97,12 +96,6 @@ class TabbableReports {
 
   update_href(tab) {
     return tab.find('a').attr('href', this.tab_url(tab));
-  }
-
-  // Make sure to update the date params in case they were empty or invalid
-  fix_bad_dates(panel) {
-    $('#date_start').val($(panel).find('.updated_values .date_start').text());
-    return $('#date_end').val($(panel).find('.updated_values .date_end').text());
   }
 
   init_pagination() {

--- a/app/javascript/app/reports.js
+++ b/app/javascript/app/reports.js
@@ -4,6 +4,7 @@
  * DS207: Consider shorter variations of null checks
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/main/docs/suggestions.md
  */
+import debounce from "debounce";
 import { Flash } from "./flash";
 
 class TabbableReports {
@@ -91,7 +92,7 @@ class TabbableReports {
 
   init_form() {
     $('.datepicker').datepicker();
-    return this.$element.find(':input').change(() => this.update_parameters());
+    return this.$element.find(':input').change(debounce(() => this.update_parameters(), 400));
   }
 
   update_href(tab) {

--- a/app/views/reports/instrument_unavailable_reports/report_table.html.haml
+++ b/app/views/reports/instrument_unavailable_reports/report_table.html.haml
@@ -1,9 +1,5 @@
 -# TODO: this is very similar to reports/report_table
 
-.updated_values{ style: "display: none" }
-  .date_start= @date_start&.to_date
-  .date_end= @date_end&.to_date
-
 .export_raw{ data: { visible: export_raw_visible?.to_s } }
 
 %table.table.table-striped.table-hover

--- a/app/views/reports/report_table.html.haml
+++ b/app/views/reports/report_table.html.haml
@@ -1,9 +1,5 @@
 -# TODO: this is very similar to instrument_unavailable_reports/report_table
 
-.updated_values{ style: "display: none" }
-  .date_start= @date_start&.to_date
-  .date_end= @date_end&.to_date
-
 .export_raw{ data: { visible: export_raw_visible?.to_s } }
 
 %table.table.table-striped.table-hover

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
-    "@hotwired/turbo-rails": "^8.0.23"
+    "@hotwired/turbo-rails": "^8.0.23",
+    "debounce": "^3.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -155,6 +155,11 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-8.1.300.tgz#bfd50813be0225a0403bddb11e8ba9a00b1fb135"
   integrity sha512-zOENQsq3NM2jyBY6Z2qtZa3V/R/6OEqA+LGKixQbBMl7kk/J3FXDRcszPe74LsHNgB01jCl/DXu/xA8sHt4I/g==
 
+debounce@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-3.0.0.tgz#7633adff3bcd92cdfe13370c2f46e87bdb946a1b"
+  integrity sha512-64byRbF0/AirwbuHqB3/ZpMG9/nckDa6ZA0yd6UnaQNwbbemCOwvz2sL5sjXLHhZHADyiwLm0M5qMhltUUx+TA==
+
 esbuild@^0.28.1:
   version "0.28.1"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.28.1.tgz#ef45b4634c9c9d97a296aea4114a5f9840f95578"


### PR DESCRIPTION
# Notes

General reports date filters are updated when the report is response is loaded. The problem is that the report is loaded every time inputs change, so manually typing a date would override the date received from the server as you type, causing the buggy behavior.

Also:
- Add debounce to date update callback
- Restrict years to four digits on all date inputs

[DART-172 | Buggy behavior on report date filter](https://universe-of-universities.atlassian.net/browse/DART-172)
